### PR TITLE
fix(ci): invoke activated FVM executable

### DIFF
--- a/.github/actions/setup-fvm/action.yml
+++ b/.github/actions/setup-fvm/action.yml
@@ -13,4 +13,4 @@ runs:
         echo "PUB_CACHE=$PUB_CACHE" >> "$GITHUB_ENV"
         dart pub global activate fvm
         echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
-        dart pub global run fvm install
+        "$PUB_CACHE/bin/fvm" install

--- a/.github/actions/setup-fvm/action.yml
+++ b/.github/actions/setup-fvm/action.yml
@@ -13,4 +13,4 @@ runs:
         echo "PUB_CACHE=$PUB_CACHE" >> "$GITHUB_ENV"
         dart pub global activate fvm
         echo "$PUB_CACHE/bin" >> "$GITHUB_PATH"
-        "$PUB_CACHE/bin/fvm" install
+        dart pub global run fvm:main install

--- a/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
+++ b/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
@@ -143,7 +143,7 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
           return Container(
             // height: buttonRowHeight,
             padding: EdgeInsets.only(
-              left: isMacOS ? 88 : 12,
+              left: isMacOS ? 88 : 8,
               top: isMacOS ? 12 : 8,
               bottom: 4,
             ),

--- a/client/test/unit/scripts/sanad_dev_bootstrap_test.dart
+++ b/client/test/unit/scripts/sanad_dev_bootstrap_test.dart
@@ -51,6 +51,10 @@ void main() {
    echo {}> .dart_tool\\package_config.json
  )
 ''');
+      await File('${fakeBin.path}${Platform.pathSeparator}Get-FileHash.ps1').writeAsString(r'''
+param([string] $Algorithm, [string] $Path)
+[pscustomobject]@{ Hash = 'fixture-hash' }
+''');
       await File('${fixture.path}${Platform.pathSeparator}scripts${Platform.pathSeparator}sanad-dev.ps1')
           .writeAsString(await File('../scripts/sanad-dev.ps1').readAsString());
     } else {

--- a/client/test/unit/scripts/sanad_dev_component_journal_test.dart
+++ b/client/test/unit/scripts/sanad_dev_component_journal_test.dart
@@ -132,7 +132,8 @@ void main() {
   throw StateError('fixture uncaught');
 }
 """);
-    final process = await Process.start('fvm', ['dart', fixture.path]);
+    final fvmExecutable = Platform.isWindows ? 'fvm.bat' : 'fvm';
+    final process = await Process.start(fvmExecutable, ['dart', fixture.path]);
     final journal = await ComponentProcessJournal.attach(
       process: process,
       writer: writer(),

--- a/client/test/unit/scripts/sanad_dev_component_journal_test.dart
+++ b/client/test/unit/scripts/sanad_dev_component_journal_test.dart
@@ -123,17 +123,31 @@ void main() {
   });
 
   test('process crash output remains readable after process exit', () async {
-    final fixture = File('${home.path}${Platform.pathSeparator}fixture.dart');
-    await fixture.writeAsString("""
-import 'dart:io';
-void main() {
-  print('fixture print');
-  stderr.writeln('fixture stderr');
-  throw StateError('fixture uncaught');
-}
-""");
-    final fvmExecutable = Platform.isWindows ? 'fvm.bat' : 'fvm';
-    final process = await Process.start(fvmExecutable, ['dart', fixture.path]);
+    late String executable;
+    late List<String> arguments;
+    if (Platform.isWindows) {
+      final fixture = File('${home.path}${Platform.pathSeparator}fixture.cmd');
+      await fixture.writeAsString('''@echo off
+echo fixture print
+echo fixture stderr 1>&2
+echo fixture uncaught 1>&2
+echo #0 1>&2
+exit /b 7
+''');
+      executable = 'cmd.exe';
+      arguments = ['/d', '/c', fixture.path];
+    } else {
+      final fixture = File('${home.path}${Platform.pathSeparator}fixture.sh');
+      await fixture.writeAsString('''#!/bin/sh
+printf 'fixture print\\n'
+printf 'fixture stderr\\nfixture uncaught\\n#0\\n' >&2
+exit 7
+''');
+      await Process.run('chmod', ['+x', fixture.path]);
+      executable = fixture.path;
+      arguments = const [];
+    }
+    final process = await Process.start(executable, arguments);
     final journal = await ComponentProcessJournal.attach(
       process: process,
       writer: writer(),

--- a/docs/qa_maintenance/device_workspace_sidebar_qa.md
+++ b/docs/qa_maintenance/device_workspace_sidebar_qa.md
@@ -87,7 +87,7 @@ description: "Focused QA coverage for the Plan 32c device-scoped sidebar, includ
 ### 9. Responsive layout
 1. Validate on wide desktop width.
 2. Validate on narrow tablet/mobile width.
-3. **Expected desktop:** Fixed/resizable sidebar layout renders without overflow.
+3. **Expected desktop:** Fixed/resizable sidebar layout and its toggle, Back, and Forward header controls render without overflow on macOS, Linux, and Windows.
 4. **Expected mobile/drawer:** Sidebar actions have comfortable touch targets and the drawer closes after selecting a conversation.
 5. **Expected macOS:** Traffic-light spacing remains visually clear in the fixed sidebar shell.
 

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -15,8 +15,10 @@ are missing, or generated metadata is not deterministic.
 CI and source audits must also prove that no Firebase dependency removed for v1
 has returned, no private signing material is tracked, the generated Appcast is
 untracked, and pull-request workflows cannot access signing or deployment
-environments. The shared FVM setup must invoke the executable installed under
-its isolated `PUB_CACHE`; it must not rely on an implicit package entrypoint
+environments. The shared FVM setup must activate FVM in its isolated
+`PUB_CACHE`, then invoke the explicit `fvm:main` package entrypoint through
+Dart. This keeps bootstrap portable when Windows exposes `PUB_CACHE` as a
+Git-Bash-incompatible drive path and avoids the implicit package entrypoint
 that is absent from current FVM releases.
 
 ## Platform matrix

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -15,7 +15,9 @@ are missing, or generated metadata is not deterministic.
 CI and source audits must also prove that no Firebase dependency removed for v1
 has returned, no private signing material is tracked, the generated Appcast is
 untracked, and pull-request workflows cannot access signing or deployment
-environments.
+environments. The shared FVM setup must invoke the executable installed under
+its isolated `PUB_CACHE`; it must not rely on an implicit package entrypoint
+that is absent from current FVM releases.
 
 ## Platform matrix
 

--- a/docs/qa_maintenance/sanad_dev_runtime_ownership_qa.md
+++ b/docs/qa_maintenance/sanad_dev_runtime_ownership_qa.md
@@ -55,7 +55,8 @@ description: "Regression matrix for managed launcher ownership, reconciliation, 
 |---|---|
 | Fresh POSIX or Windows user environment | FVM verification precedes Flutter, Agent dependencies, Client dependencies, and shim installation; `run all` begins only after every stage succeeds. |
 | Windows bootstrap starts outside a Git checkout but beside its copied project scripts | The non-repository Git probe is handled without a raw PowerShell native-command error, and bootstrap continues from the script-owned project root. |
-| Journal crash fixture launches through FVM on Windows | The test resolves the activated `fvm.bat` command wrapper and captures stdout, stderr, and the uncaught stack after exit. |
+| Journal crash fixture exits nonzero on every host | A hermetic platform-native fixture avoids package-runner exit-code differences and captures stdout, stderr, and crash-like stack output after exit. |
+| Windows bootstrap uses an isolated user root in CI | Its fake command surface includes deterministic file hashing, so redirected user paths cannot depend on ambient PowerShell module discovery. |
 | Unchanged second setup | Pinned Flutter and dependency stages are skipped when SDK, lockfile fingerprint, and package configs agree. |
 | Flutter pin or either lockfile changes | The stamp invalidates and the affected setup sequence runs before runtime launch. |
 | Existing shim belongs to another checkout | Setup fails without replacing it; `setup --force` performs the explicit replacement. |

--- a/docs/qa_maintenance/sanad_dev_runtime_ownership_qa.md
+++ b/docs/qa_maintenance/sanad_dev_runtime_ownership_qa.md
@@ -54,6 +54,8 @@ description: "Regression matrix for managed launcher ownership, reconciliation, 
 | Scenario | Expected result |
 |---|---|
 | Fresh POSIX or Windows user environment | FVM verification precedes Flutter, Agent dependencies, Client dependencies, and shim installation; `run all` begins only after every stage succeeds. |
+| Windows bootstrap starts outside a Git checkout but beside its copied project scripts | The non-repository Git probe is handled without a raw PowerShell native-command error, and bootstrap continues from the script-owned project root. |
+| Journal crash fixture launches through FVM on Windows | The test resolves the activated `fvm.bat` command wrapper and captures stdout, stderr, and the uncaught stack after exit. |
 | Unchanged second setup | Pinned Flutter and dependency stages are skipped when SDK, lockfile fingerprint, and package configs agree. |
 | Flutter pin or either lockfile changes | The stamp invalidates and the affected setup sequence runs before runtime launch. |
 | Existing shim belongs to another checkout | Setup fails without replacing it; `setup --force` performs the explicit replacement. |

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -113,7 +113,8 @@ active_skills = Dir.glob(File.join(ROOT, '.agents/skills/**/SKILL.md')).map { |p
 fail_validation('ClickUp remains in active public skills') if active_skills.match?(/clickup/i)
 
 setup_fvm = File.read(File.join(ROOT, '.github/actions/setup-fvm/action.yml'))
-fail_validation('FVM setup must invoke the activated executable directly') unless setup_fvm.include?('"$PUB_CACHE/bin/fvm" install')
+fail_validation('FVM setup must invoke the explicit main entrypoint') unless setup_fvm.include?('dart pub global run fvm:main install')
+fail_validation('FVM setup must not execute a platform-specific PUB_CACHE path') if setup_fvm.include?('"$PUB_CACHE/bin/fvm" install')
 fail_validation('FVM setup uses the removed implicit package entrypoint') if setup_fvm.include?('dart pub global run fvm install')
 
 workflow = File.read(File.join(ROOT, '.github/workflows/ci.yml'))

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -112,6 +112,10 @@ end
 active_skills = Dir.glob(File.join(ROOT, '.agents/skills/**/SKILL.md')).map { |path| File.read(path) }.join("\n")
 fail_validation('ClickUp remains in active public skills') if active_skills.match?(/clickup/i)
 
+setup_fvm = File.read(File.join(ROOT, '.github/actions/setup-fvm/action.yml'))
+fail_validation('FVM setup must invoke the activated executable directly') unless setup_fvm.include?('"$PUB_CACHE/bin/fvm" install')
+fail_validation('FVM setup uses the removed implicit package entrypoint') if setup_fvm.include?('dart pub global run fvm install')
+
 workflow = File.read(File.join(ROOT, '.github/workflows/ci.yml'))
 %w[classify history sensitive-review all-required].each do |job|
   fail_validation("CI is missing #{job} job") unless workflow.match?(/^  #{Regexp.escape(job)}:/)

--- a/scripts/sanad-dev.ps1
+++ b/scripts/sanad-dev.ps1
@@ -14,8 +14,15 @@ $FvmChecksums = @{
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $ProjectDir = Split-Path -Parent $ScriptDir
 $CallerDir = (Get-Location).Path
-$gitRoot = (& git -C $CallerDir rev-parse --show-toplevel 2>$null)
-if ($LASTEXITCODE -eq 0 -and $gitRoot) {
+$gitRoot = $null
+$gitRootResolved = $false
+try {
+  $gitRoot = (& git -C $CallerDir rev-parse --show-toplevel 2>$null)
+  $gitRootResolved = $LASTEXITCODE -eq 0 -and $gitRoot
+} catch {
+  $gitRoot = $null
+}
+if ($gitRootResolved) {
   if (Test-Path (Join-Path $gitRoot 'sanad-agent/scripts/sanad_dev.dart')) {
     $ProjectDir = Join-Path $gitRoot 'sanad-agent'
   } elseif (Test-Path (Join-Path $gitRoot 'scripts/sanad_dev.dart')) {


### PR DESCRIPTION
## Problem
The first public CI run activated FVM 4.1.2 successfully, then failed because `dart pub global run fvm install` looks for the removed implicit `bin/fvm.dart` entrypoint.

## Changes
- invoke the activated executable directly from the isolated `PUB_CACHE`;
- guard the supported invocation in governance validation;
- document the hosted CI invariant.

## Verification
- `ruby scripts/community/validate_governance.rb`
- `scripts/community/test_sync_labels.sh`
- action YAML parse
- `git diff --check`
