### PR TITLE
fix(ci): run license-free Gitleaks scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
     if: needs.classify.outputs.release == 'true' || needs.classify.outputs.security == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    env:
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_LINUX_X64_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
     steps:
       - uses: actions/checkout@v6
         with:
@@ -186,9 +189,15 @@ jobs:
           ! git ls-files | grep -E '\.(p12|p8|jks|keystore|mobileprovision|provisionprofile)$'
           ! git ls-files | grep -E '(^|/)dsa_priv\.pem$|(^|/)appcast\.xml$'
       - name: Scan committed content for credentials
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          archive="$RUNNER_TEMP/gitleaks.tar.gz"
+          curl --fail --location --retry 3 --proto '=https' --tlsv1.2 \
+            --output "$archive" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          printf '%s  %s\n' "$GITLEAKS_LINUX_X64_SHA256" "$archive" | sha256sum --check
+          tar --extract --gzip --file "$archive" --directory "$RUNNER_TEMP" gitleaks
+          "$RUNNER_TEMP/gitleaks" detect --source . --config .gitleaks.toml --redact --no-banner
 
   sensitive-review:
     name: Verify protected review labels

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[extend]
+useDefault = true
+
+[[allowlists]]
+description = "Synthetic generic API-key fixtures used by credential and redaction tests"
+rules = ["generic-api-key"]
+paths = [
+  '''^agent/test/core/provider_runtime/provider_instance_service_test\.dart$''',
+  '''^agent/test/core/secrets_redactor_test\.dart$''',
+  '''^agent/test/interfaces/interfaces_test\.dart$''',
+]

--- a/docs/qa_maintenance/community_governance_qa.md
+++ b/docs/qa_maintenance/community_governance_qa.md
@@ -15,7 +15,7 @@ description: "Static and live verification matrix for labels, templates, contrib
 | Discussions | Categories and templates distinguish Ideas & RFCs, Q&A, Show and Tell, and maintainer-only announcements |
 | PR template | Linked Issue, bounded verification, platforms, security/privacy, docs, screenshots, rollback, duplicates, and optional AI disclosure are covered |
 | Skills | Frontmatter is valid, repository paths resolve, no active skill mentions the retired project manager, and every sensitive mutation requires explicit authorization |
-| CI | Path classifier, common-ancestor check, protected labels, label-event reruns, fork-safe permissions, and the stable aggregate job are present |
+| CI | Path classifier, common-ancestor check, protected labels, label-event reruns, fork-safe permissions, stable aggregate job, and checksum-verified secret scanning without organization-license secrets are present; only exact reviewed synthetic credential-test paths are allowlisted |
 | VS Code | The three tracked JSON files parse, remain allowlisted, contain no machine paths, and expose no shortcuts for ownership-sensitive runtime mutations |
 | Governance text | No CLA/DCO/sign-off requirement remains in active public guidance; single-maintainer and independent-maintainer protection modes are explicit |
 | Brand assets | README has no unapproved interface screenshot; unconsumed legacy logos are absent; build-required icons stay present until an approved canonical source can replace them atomically |

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -21,6 +21,15 @@ Dart. This keeps bootstrap portable when Windows exposes `PUB_CACHE` as a
 Git-Bash-incompatible drive path and avoids the implicit package entrypoint
 that is absent from current FVM releases.
 
+The credential scan runs the pinned open-source Gitleaks CLI directly rather
+than the organization-licensed GitHub Action. CI downloads the official Linux
+archive over HTTPS, verifies its pinned SHA-256 before extraction, scans the
+complete checked-out Git history with redaction enabled, and requires no
+repository secret or commercial license. The tracked configuration extends the
+default rules and narrowly allows only the reviewed `generic-api-key` fixtures
+in three exact credential/redaction test files; production paths and all other
+rules remain fail-closed.
+
 ## Platform matrix
 
 | Target | Local evidence | Hosted or clean-machine evidence still required |

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -124,5 +124,19 @@ end
 fail_validation('aggregate check name is unstable') unless workflow.include?('name: All required checks pass')
 fail_validation('CI must rerun review gates when labels change') unless workflow.include?('labeled') && workflow.include?('unlabeled')
 fail_validation('fork PRs must not use pull_request_target') if workflow.include?('pull_request_target')
+fail_validation('CI must not require the organization-licensed Gitleaks Action') if workflow.include?('gitleaks/gitleaks-action') || workflow.include?('GITLEAKS_LICENSE')
+fail_validation('Gitleaks archive must be checksum verified before execution') unless workflow.include?('sha256sum --check')
+fail_validation('Gitleaks scan must use the reviewed config, redact findings, and scan the checked-out source') unless workflow.include?('gitleaks" detect --source . --config .gitleaks.toml --redact --no-banner')
+
+gitleaks_config = File.read(File.join(ROOT, '.gitleaks.toml'))
+fail_validation('Gitleaks config must extend the default rules') unless gitleaks_config.include?('useDefault = true')
+fail_validation('Gitleaks fixture allowlist must be limited to generic API-key findings') unless gitleaks_config.include?('rules = ["generic-api-key"]')
+%w[
+  agent/test/core/provider_runtime/provider_instance_service_test\\.dart
+  agent/test/core/secrets_redactor_test\\.dart
+  agent/test/interfaces/interfaces_test\\.dart
+].each do |fixture|
+  fail_validation("Gitleaks config is missing reviewed fixture #{fixture}") unless gitleaks_config.include?(fixture)
+end
 
 puts "Governance artifacts valid: #{labels.length} labels, #{yaml_paths.length} YAML files, #{skills.length} contribution skills."


### PR DESCRIPTION
## Problem / Goal
The first protected `main` push failed because `gitleaks/gitleaks-action@v2` requires a commercial license for organization-owned repositories. The Node deprecation messages were warnings from that action; the missing `GITLEAKS_LICENSE` was the blocking error.

## Technical Changes
- replace the licensed action with the pinned open-source Gitleaks 8.30.1 CLI;
- verify the official Linux archive with its published SHA-256 before extraction;
- scan full checked-out Git history with redaction and no repository secrets;
- add a narrow default-extending allowlist for six reviewed synthetic fixtures in three exact test files;
- make governance validation reject regression to the licensed action or an unverified scanner.

## Verification
- governance validator and CI YAML parsing passed;
- official Linux x64 archive matched pinned SHA-256 and contained the expected binary;
- Gitleaks 8.30.1 scanned seven commits locally with the tracked config: no leaks found;
- `git diff --check` passed.

Fixes the failure in https://github.com/EastStarAI/sanad-agent/actions/runs/30713378526.
