### PR TITLE
feat(community): notify Discord of public milestones

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -1,0 +1,75 @@
+name: Discord community notifications
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    name: Notify Discord
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Build approved community notification
+        id: message
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            title="Release $(jq -r '.release.name // .release.tag_name' "$GITHUB_EVENT_PATH")"
+            url="$(jq -r '.release.html_url' "$GITHUB_EVENT_PATH")"
+            description="Published by @$(jq -r '.release.author.login' "$GITHUB_EVENT_PATH")."
+          else
+            pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+              --jq 'map(select(.merged_at != null and .base.ref == "main")) | first')"
+            if [[ "$pull_request" == "null" ]]; then
+              echo "No merged pull request is associated with this main push."
+              echo "send=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            number="$(jq -r '.number' <<<"$pull_request")"
+            title="Merged PR #${number}: $(jq -r '.title' <<<"$pull_request")"
+            url="$(jq -r '.html_url' <<<"$pull_request")"
+            description="Merged by @$(jq -r '.merged_by.login' <<<"$pull_request") from @$(jq -r '.user.login' <<<"$pull_request")."
+          fi
+          payload="$(jq -n \
+            --arg title "${title:0:240}" \
+            --arg url "$url" \
+            --arg description "${description:0:1000}" \
+            '{
+              username: "Sanad GitHub",
+              allowed_mentions: {parse: []},
+              embeds: [{
+                title: $title,
+                url: $url,
+                description: $description,
+                color: 8141549
+              }]
+            }')"
+          {
+            echo "send=true"
+            echo "payload<<SANAD_DISCORD_PAYLOAD"
+            echo "$payload"
+            echo "SANAD_DISCORD_PAYLOAD"
+          } >> "$GITHUB_OUTPUT"
+      - name: Send approved notification
+        if: steps.message.outputs.send == 'true'
+        shell: bash
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PAYLOAD: ${{ steps.message.outputs.payload }}
+        run: |
+          set -euo pipefail
+          test -n "$DISCORD_WEBHOOK_URL"
+          curl --fail --silent --show-error --retry 3 \
+            --header 'Content-Type: application/json' \
+            --data "$PAYLOAD" \
+            --output /dev/null \
+            "$DISCORD_WEBHOOK_URL"

--- a/docs/operations/community_governance.md
+++ b/docs/operations/community_governance.md
@@ -54,7 +54,7 @@ limits, grant bots least
 privilege, test the project-owned permanent invite in a logged-out
 browser session, and keep moderation/audit channels private.
 
-The GitHub feed in `#github` is read-only and limited to merged pull requests, releases, and selected announcements. Contributor opportunities may be selected for `#contributors`; raw Issue and CI firehoses are intentionally excluded.
+The GitHub feed in `#github` is read-only. Its channel-scoped webhook is stored only as the `DISCORD_WEBHOOK_URL` repository secret and is exposed only to the final send step. The tracked notification workflow runs on pushes to protected `main` and published Releases: a main push is posted only when GitHub associates it with a merged pull request, while a published Release is posted directly. Payloads disable mentions and contain only the public title, link, and public actor identities. Raw Issues, CI runs, security events, fork activity, and direct or emergency pushes are intentionally excluded. Contributor opportunities may be selected manually for `#contributors`.
 
 ## Deferred Maintainer Skills
 

--- a/docs/qa_maintenance/community_governance_qa.md
+++ b/docs/qa_maintenance/community_governance_qa.md
@@ -47,6 +47,10 @@ A vulnerability diverges at step 1 to Private Vulnerability Reporting and must n
 
 ## Discord Live Matrix
 
+- Confirm `DISCORD_WEBHOOK_URL` exists as a repository secret while its value is absent from source, logs, and evidence.
+- Merge one approved pull request and confirm exactly one public-title/link notification appears in `#github`; a direct push without an associated merged pull request produces no message.
+- Publish a controlled Release only under SANAD-12 and confirm exactly one release notification; workflow dispatches, Issues, CI runs, security events, and fork activity produce none.
+- Confirm notification payloads suppress all mentions even when a public title contains mention syntax.
 - Verify role permissions with a non-owner test account. Owner-account 2FA
   remains enabled; future Maintainer/Moderator 2FA is not a SANAD-10 gate.
 - Confirm ordinary members cannot write to announcements, rules, or the GitHub feed.

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -139,4 +139,20 @@ fail_validation('Gitleaks fixture allowlist must be limited to generic API-key f
   fail_validation("Gitleaks config is missing reviewed fixture #{fixture}") unless gitleaks_config.include?(fixture)
 end
 
+discord_path = File.join(ROOT, '.github/workflows/discord-notifications.yml')
+discord_workflow = File.read(discord_path)
+discord_steps = load_yaml(discord_path).dig('jobs', 'notify', 'steps')
+build_notification = discord_steps&.find { |step| step['id'] == 'message' }
+send_notification = discord_steps&.find { |step| step['name'] == 'Send approved notification' }
+fail_validation('Discord workflow must keep build and send steps separate') unless build_notification && send_notification
+fail_validation('Discord webhook secret must not be exposed to the payload build step') if build_notification.fetch('env', {}).key?('DISCORD_WEBHOOK_URL')
+fail_validation('Discord webhook secret must be scoped to the final send step') unless send_notification.fetch('env', {})['DISCORD_WEBHOOK_URL'].to_s.include?('secrets.DISCORD_WEBHOOK_URL')
+fail_validation('Discord notifications must use the repository webhook secret') unless discord_workflow.include?('secrets.DISCORD_WEBHOOK_URL')
+fail_validation('Discord notifications must resolve merged pull requests from protected main pushes') unless discord_workflow.include?('commits/${GITHUB_SHA}/pulls') && discord_workflow.include?('.merged_at != null') && discord_workflow.include?('.base.ref == "main"')
+fail_validation('Discord notifications must include published Releases') unless discord_workflow.include?('types: [published]')
+fail_validation('Discord notifications must suppress mentions') unless discord_workflow.include?('allowed_mentions: {parse: []}')
+%w[pull_request pull_request_target issues workflow_run workflow_dispatch].each do |event|
+  fail_validation("Discord notifications must not subscribe to #{event}") if discord_workflow.match?(/^  #{Regexp.escape(event)}:/)
+end
+
 puts "Governance artifacts valid: #{labels.length} labels, #{yaml_paths.length} YAML files, #{skills.length} contribution skills."


### PR DESCRIPTION
## Problem / Goal
Connect the public repository to the read-only Discord `#github` feed without creating an Issue, CI, security, or fork-activity firehose.

## Technical Changes
- add a least-privilege workflow triggered only by protected `main` pushes and published Releases;
- resolve a main push to its associated merged pull request and suppress direct/emergency pushes;
- expose `DISCORD_WEBHOOK_URL` only to the final send step;
- disable Discord mentions and publish only public titles, links, and actor identities;
- add governance validation and live QA documentation for the boundary.

## Verification
- repository secret exists without exposing its value;
- governance validator passed with 16 YAML files;
- workflow YAML parsed successfully;
- merged-PR, published-Release, and direct-push suppression payload simulations passed;
- payload simulation confirmed mention suppression;
- `git diff --check` passed.

After merge, the resulting protected-main push is the controlled live webhook test. Release notification remains owned by SANAD-12.
