### PR TITLE
fix(community): hydrate Discord merge actors

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -27,14 +27,15 @@ jobs:
             url="$(jq -r '.release.html_url' "$GITHUB_EVENT_PATH")"
             description="Published by @$(jq -r '.release.author.login' "$GITHUB_EVENT_PATH")."
           else
-            pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            associated_pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               --jq 'map(select(.merged_at != null and .base.ref == "main")) | first')"
-            if [[ "$pull_request" == "null" ]]; then
+            if [[ "$associated_pull_request" == "null" ]]; then
               echo "No merged pull request is associated with this main push."
               echo "send=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            number="$(jq -r '.number' <<<"$pull_request")"
+            number="$(jq -r '.number' <<<"$associated_pull_request")"
+            pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
             title="Merged PR #${number}: $(jq -r '.title' <<<"$pull_request")"
             url="$(jq -r '.html_url' <<<"$pull_request")"
             description="Merged by @$(jq -r '.merged_by.login' <<<"$pull_request") from @$(jq -r '.user.login' <<<"$pull_request")."

--- a/docs/operations/community_governance.md
+++ b/docs/operations/community_governance.md
@@ -54,7 +54,7 @@ limits, grant bots least
 privilege, test the project-owned permanent invite in a logged-out
 browser session, and keep moderation/audit channels private.
 
-The GitHub feed in `#github` is read-only. Its channel-scoped webhook is stored only as the `DISCORD_WEBHOOK_URL` repository secret and is exposed only to the final send step. The tracked notification workflow runs on pushes to protected `main` and published Releases: a main push is posted only when GitHub associates it with a merged pull request, while a published Release is posted directly. Payloads disable mentions and contain only the public title, link, and public actor identities. Raw Issues, CI runs, security events, fork activity, and direct or emergency pushes are intentionally excluded. Contributor opportunities may be selected manually for `#contributors`.
+The GitHub feed in `#github` is read-only. Its channel-scoped webhook is stored only as the `DISCORD_WEBHOOK_URL` repository secret and is exposed only to the final send step. The tracked notification workflow runs on pushes to protected `main` and published Releases: a main push is posted only when GitHub associates it with a merged pull request, while a published Release is posted directly. Payloads disable mentions and contain only the public title, link, and actor identities hydrated from the complete public pull-request or Release record. Raw Issues, CI runs, security events, fork activity, and direct or emergency pushes are intentionally excluded. Contributor opportunities may be selected manually for `#contributors`.
 
 ## Deferred Maintainer Skills
 

--- a/docs/qa_maintenance/community_governance_qa.md
+++ b/docs/qa_maintenance/community_governance_qa.md
@@ -48,7 +48,7 @@ A vulnerability diverges at step 1 to Private Vulnerability Reporting and must n
 ## Discord Live Matrix
 
 - Confirm `DISCORD_WEBHOOK_URL` exists as a repository secret while its value is absent from source, logs, and evidence.
-- Merge one approved pull request and confirm exactly one public-title/link notification appears in `#github`; a direct push without an associated merged pull request produces no message.
+- Merge one approved pull request and confirm exactly one public-title/link notification appears in `#github` with non-null contributor and merger identities; a direct push without an associated merged pull request produces no message.
 - Publish a controlled Release only under SANAD-12 and confirm exactly one release notification; workflow dispatches, Issues, CI runs, security events, and fork activity produce none.
 - Confirm notification payloads suppress all mentions even when a public title contains mention syntax.
 - Verify role permissions with a non-owner test account. Owner-account 2FA

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -149,6 +149,7 @@ fail_validation('Discord webhook secret must not be exposed to the payload build
 fail_validation('Discord webhook secret must be scoped to the final send step') unless send_notification.fetch('env', {})['DISCORD_WEBHOOK_URL'].to_s.include?('secrets.DISCORD_WEBHOOK_URL')
 fail_validation('Discord notifications must use the repository webhook secret') unless discord_workflow.include?('secrets.DISCORD_WEBHOOK_URL')
 fail_validation('Discord notifications must resolve merged pull requests from protected main pushes') unless discord_workflow.include?('commits/${GITHUB_SHA}/pulls') && discord_workflow.include?('.merged_at != null') && discord_workflow.include?('.base.ref == "main"')
+fail_validation('Discord notifications must hydrate complete pull-request actor data') unless discord_workflow.include?('pulls/${number}') && discord_workflow.include?('.merged_by.login')
 fail_validation('Discord notifications must include published Releases') unless discord_workflow.include?('types: [published]')
 fail_validation('Discord notifications must suppress mentions') unless discord_workflow.include?('allowed_mentions: {parse: []}')
 %w[pull_request pull_request_target issues workflow_run workflow_dispatch].each do |event|


### PR DESCRIPTION
## Problem / Goal
The first live Discord notification for PR #4 proved delivery and link routing, but the commit-to-PR association endpoint omits `merged_by`, producing `Merged by @null`.

## Technical Changes
- retain the associated-PR lookup that suppresses direct pushes;
- hydrate the selected PR through the complete pull-request endpoint before building public actor text;
- extend governance validation and QA evidence to require non-null merger/contributor identities.

## Verification
- confirmed the association endpoint returns `merged_by: null` while `pulls/4` returns `AhmedAttia3`;
- complete actor hydration simulation passed and rejected `@null`;
- governance validator and workflow YAML parsing passed;
- `git diff --check` passed.

After merge, the resulting notification is the final live actor-identity verification.
