### PR TITLE
feat(governance): add repository maintainer skill

### DIFF
--- a/.agents/skills/sanad-repository-maintainer/SKILL.md
+++ b/.agents/skills/sanad-repository-maintainer/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: Sanad Repository Maintainer
+description: Maintain the public Sanad Agent repository through its tracked governance, review labels, protected checks, fork-safety rules, and verified GitHub workflows.
+---
+
+# Sanad Repository Maintainer
+
+Use this skill when maintaining `EastStarAI/sanad-agent`. It is written for human maintainers and for development agents acting on their behalf. Read-only inspection is safe by default. An agent must obtain explicit authorization from the responsible human before any GitHub mutation.
+
+## Start With Repository State
+
+1. Confirm the target repository, authenticated GitHub account, available repository role, default branch, and current commit.
+2. Read `.github/GOVERNANCE.md` and the nearest tracked manifest or documentation page for the surface being maintained.
+3. Compare tracked desired state with the live repository before proposing a mutation.
+4. Report drift, missing permission, and rollback impact before changing live state.
+5. Query the postcondition after every mutation; an accepted API request is not evidence that the intended state is live.
+
+Never hardcode mutable rule, category, run, branch, webhook, or secret identifiers. Discover them from the target repository when needed.
+
+## Permission Boundary
+
+GitHub roles and organization policies may change. Verify the live permission instead of assuming it from a username.
+
+- Public/read access may inspect metadata, Issues, Discussions, pull requests, checks, workflows, and other public repository state.
+- Triage-capable maintainers may classify work and manage ordinary labels or Issue/Discussion state within project governance.
+- Write or maintain access may update review branches and merge an eligible pull request when project policy and human authorization allow it.
+- Administrative repository settings, branch protection or rulesets, Actions permissions, secrets, webhooks, security features, and organization-owned surfaces require the corresponding live administrative permission and separate action-specific authorization.
+
+If the authenticated role cannot perform an operation, stop. Do not seek a bypass, weaker setting, alternate token, or unrelated organization permission.
+
+## Pull Requests and Protected Review
+
+1. Require a Conventional Commits title, common ancestry with current `main`, resolved conversations, and the latest successful `All required checks pass` result.
+2. Map changed paths to `maintainer-reviewed`, `security-reviewed`, and `release-reviewed` using `.github/GOVERNANCE.md` and `.github/workflows/ci.yml`.
+3. Apply a protected review label only after an authorized maintainer confirms the corresponding review. A label is review evidence, not a mechanism for hiding a failure.
+4. Preserve read-only, secret-free execution for fork pull requests.
+5. Merge only through the repository's enabled squash flow and only after the responsible maintainer authorizes the merge.
+6. Verify the resulting default-branch commit, CI result, branch cleanup, and any bounded downstream notification.
+
+Use short status queries. Do not leave indefinite watch or follow commands running.
+
+## Managed Repository Surfaces
+
+- Treat `.github/labels.yml`, `.github/discussion-categories.yml`, and `.github/branch-protection.yml` as desired-state manifests.
+- Dry-run or compare first, apply only the intended drift correction, then verify idempotency.
+- Preserve the stable aggregate check, current protected-review model, resolved-conversation requirement, force-push and deletion blocks, and documented merge policy unless an approved governance change explicitly replaces them.
+- Keep Issue Forms, Discussion categories, support routes, CODEOWNERS, and public documentation consistent with their tracked sources.
+- Keep the Discord feed limited to merged pull requests and published Releases. Do not add raw Issues, CI runs, security events, fork activity, or direct-push notifications.
+
+## Secret and Security Handling
+
+- Never read, print, copy, log, comment, or commit a secret value. Inspect only secret names and update metadata when necessary.
+- Never place credentials in workflow inputs, artifacts, pull-request comments, or evidence files.
+- Do not use `pull_request_target` to obtain secrets for fork code.
+- Route undisclosed vulnerabilities through Private Vulnerability Reporting; do not recreate their contents in public Issues or Discussions.
+- Security, webhook, or secret rotation requires explicit authorization and a bounded verification and rollback plan.
+
+## Excluded Procedures
+
+This repository-maintenance skill does not define release publication, signing, installer or update publication, Appcast management, TestFlight delivery, Web deployment, production deployment, DNS, or TLS procedures. Use the separately reviewed release or operations procedure that owns those actions.
+
+When target identity, permission, review evidence, authorization, or rollback is ambiguous, stop before mutation and request the missing decision.

--- a/docs/operations/community_governance.md
+++ b/docs/operations/community_governance.md
@@ -56,6 +56,8 @@ browser session, and keep moderation/audit channels private.
 
 The GitHub feed in `#github` is read-only. Its channel-scoped webhook is stored only as the `DISCORD_WEBHOOK_URL` repository secret and is exposed only to the final send step. The tracked notification workflow runs on pushes to protected `main` and published Releases: a main push is posted only when GitHub associates it with a merged pull request, while a published Release is posted directly. Payloads disable mentions and contain only the public title, link, and actor identities hydrated from the complete public pull-request or Release record. Raw Issues, CI runs, security events, fork activity, and direct or emergency pushes are intentionally excluded. Contributor opportunities may be selected manually for `#contributors`.
 
-## Deferred Maintainer Skills
+## Repository Maintainer Skill Boundary
 
-`sanad-repository-maintainer` belongs to SANAD-11 after live GitHub APIs, category IDs, rule behavior, and permission boundaries are proven. `sanad-release-maintainer` belongs to SANAD-12 after releases, checksums, Appcast publication, and protected environments work on the public repository. Neither deferral blocks the three local contribution and pull-request skills.
+`sanad-repository-maintainer` is a public procedure for human maintainers and development agents working on this repository. It describes role-based access rather than assuming authority from a username: public/read access supports inspection, triage access supports ordinary work classification, write or maintain access supports review-branch and eligible merge operations, and administrative surfaces require the corresponding live repository permission.
+
+Read-only inspection is the default. An agent requires explicit action-specific human authorization before every mutation, and every maintainer must preserve tracked governance, protected checks, fork safety, and secret boundaries. Mutable IDs are discovered from GitHub rather than stored. Release publication, signing, distribution, and production operations use separately reviewed procedures and are not defined by this skill.

--- a/docs/qa_maintenance/community_governance_qa.md
+++ b/docs/qa_maintenance/community_governance_qa.md
@@ -14,7 +14,7 @@ description: "Static and live verification matrix for labels, templates, contrib
 | Forms | All YAML parses; blank Issues are disabled; forms route security privately and warn users to redact secrets or diagnostics |
 | Discussions | Categories and templates distinguish Ideas & RFCs, Q&A, Show and Tell, and maintainer-only announcements |
 | PR template | Linked Issue, bounded verification, platforms, security/privacy, docs, screenshots, rollback, duplicates, and optional AI disclosure are covered |
-| Skills | Frontmatter is valid, repository paths resolve, no active skill mentions the retired project manager, and every sensitive mutation requires explicit authorization |
+| Skills | Three contribution skills and `sanad-repository-maintainer` have valid frontmatter, repository paths resolve, no active skill mentions the retired project manager, and every sensitive mutation requires explicit authorization |
 | CI | Path classifier, common-ancestor check, protected labels, label-event reruns, fork-safe permissions, stable aggregate job, and checksum-verified secret scanning without organization-license secrets are present; only exact reviewed synthetic credential-test paths are allowlisted |
 | VS Code | The three tracked JSON files parse, remain allowlisted, contain no machine paths, and expose no shortcuts for ownership-sensitive runtime mutations |
 | Governance text | No CLA/DCO/sign-off requirement remains in active public guidance; single-maintainer and independent-maintainer protection modes are explicit |
@@ -44,6 +44,7 @@ A vulnerability diverges at step 1 to Private Vulnerability Reporting and must n
 - Add each protected review label from an authorized account and verify the failed gate reruns.
 - Open a fork pull request and verify no signing, deployment, or environment secret is exposed.
 - Apply branch protection and confirm direct push, force push, deletion, merge commit, rebase merge, and unresolved-conversation merge are blocked.
+- Confirm the repository-maintainer skill describes public/read, triage, write/maintain, and administrative boundaries without embedding a current account identity or token permission, and requires explicit human authorization before an agent performs any mutation.
 
 ## Discord Live Matrix
 

--- a/scripts/community/validate_governance.rb
+++ b/scripts/community/validate_governance.rb
@@ -109,6 +109,17 @@ skills.each do |skill|
   fail_validation("#{skill} lacks an explicit no-unauthorized-mutation boundary") unless text.downcase.include?('explicit authorization')
 end
 
+repository_maintainer_path = File.join(ROOT, '.agents/skills/sanad-repository-maintainer/SKILL.md')
+fail_validation('missing sanad-repository-maintainer skill') unless File.file?(repository_maintainer_path)
+repository_maintainer = File.read(repository_maintainer_path)
+fail_validation('invalid frontmatter for sanad-repository-maintainer') unless repository_maintainer.match?(/\A---\nname: .+\ndescription: .+\n---\n/)
+%w[EastStarAI/sanad-agent explicit\ authorization All\ required\ checks\ pass release\ publication production\ deployment].each do |boundary|
+  fail_validation("sanad-repository-maintainer is missing boundary #{boundary}") unless repository_maintainer.include?(boundary)
+end
+%w[AhmedAttia3 viewerPermission SANAD-11 SANAD-12 SANAD-13].each do |private_detail|
+  fail_validation("sanad-repository-maintainer exposes non-public operational detail #{private_detail}") if repository_maintainer.include?(private_detail)
+end
+
 active_skills = Dir.glob(File.join(ROOT, '.agents/skills/**/SKILL.md')).map { |path| File.read(path) }.join("\n")
 fail_validation('ClickUp remains in active public skills') if active_skills.match?(/clickup/i)
 
@@ -156,4 +167,4 @@ fail_validation('Discord notifications must suppress mentions') unless discord_w
   fail_validation("Discord notifications must not subscribe to #{event}") if discord_workflow.match?(/^  #{Regexp.escape(event)}:/)
 end
 
-puts "Governance artifacts valid: #{labels.length} labels, #{yaml_paths.length} YAML files, #{skills.length} contribution skills."
+puts "Governance artifacts valid: #{labels.length} labels, #{yaml_paths.length} YAML files, #{skills.length} contribution skills, 1 repository maintainer skill."


### PR DESCRIPTION
## Problem / Goal
Provide a reusable public repository-maintenance procedure for human maintainers and development agents contributing to Sanad Agent.

## Technical Changes
- describe role-based read, triage, write/maintain, and administrative boundaries without assuming authority from a username;
- require explicit human authorization before an agent performs a GitHub mutation;
- document protected checks, review labels, fork safety, desired-state manifests, secret handling, and postcondition verification;
- keep release publication and production operations in separate owning procedures;
- extend governance validation to reject account-specific or internal planning details in the public skill.

## Verification
- governance validator passed with three contribution skills plus one repository maintainer skill;
- community workflow simulation passed;
- Gitleaks scanned the public branch history with no leaks found;
- targeted scan found no account identity, live permission field, or internal task identifier in the skill;
- `git diff --check` passed.
