### PR TITLE
SANAD-12: add private full-matrix release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,15 @@ jobs:
           ! grep -E 'WINDOWS_SIGNING_PFX|Prepared Authenticode|Authenticode verification' \
             .github/workflows/release.yml scripts/install.ps1 client/release/windows/release.ps1
           grep -F 'environment: release-publication' .github/workflows/release.yml
-          grep -F 'Create immutable Draft release candidate' .github/workflows/release.yml
+          grep -F 'validation_only:' .github/workflows/release.yml
+          grep -F "if: needs.validate.outputs.validation_only != 'true'" .github/workflows/release.yml
+          grep -F 'name: Create immutable Draft candidate' .github/workflows/release.yml
+          grep -F 'name: Build and verify signed private IPA' .github/workflows/release.yml
           grep -F -- '--draft' .github/workflows/release.yml
           grep -F 'release-manifest-rc.json' release/release-contract.json
           grep -F 'appcast-rc.xml' release/release-contract.json
+          jq -e '.artifacts[] | select(.platform == "ios" and .public == false)' \
+            release/release-contract.json >/dev/null
       - name: Scan committed content for credentials
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,8 @@ jobs:
           cat "$RUNNER_TEMP/changed"
           agent=false; client=false; docs=false; release=false; security=false
           while IFS= read -r path; do
-            case "$path" in agent/*|release/contract/*) agent=true ;; esac
-            case "$path" in client/*|release/contract/*) client=true ;; esac
+            case "$path" in agent/*|release/contract/*|release/release-contract.json) agent=true ;; esac
+            case "$path" in client/*|release/contract/*|release/release-contract.json) client=true ;; esac
             case "$path" in *.md|docs/*|.vscode/*|.agents/*|.github/ISSUE_TEMPLATE/*|.github/DISCUSSION_TEMPLATE/*|.github/labels.yml|.github/CODEOWNERS|.github/PULL_REQUEST_TEMPLATE.md|scripts/community/*) docs=true ;; esac
             case "$path" in .github/workflows/*|release/*|client/release/*|agent/tool/release_tool.dart|scripts/install.sh|scripts/install.ps1) release=true ;; esac
             case "$path" in SECURITY.md|docs/operations/code_signing_policy.md|agent/lib/core/auth/*|agent/lib/core/auth/**/*|agent/lib/capabilities/permissions/*|agent/lib/capabilities/permissions/**/*) security=true ;; esac

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       release_tag:
-        description: Existing v1.0.0 or v1.0.0-rc.N tag to build
+        description: Intended v1.0.0 or v1.0.0-rc.N identity
         type: string
         required: true
+      validation_only:
+        description: Build the complete private matrix without requiring a tag or creating a Draft
+        type: boolean
+        default: true
       request_publication:
         description: Queue protected publication after the Draft is ready
         type: boolean
@@ -38,6 +42,7 @@ jobs:
       manifest: ${{ steps.contract.outputs.manifest }}
       appcast: ${{ steps.contract.outputs.appcast }}
       prerelease: ${{ steps.contract.outputs.prerelease }}
+      validation_only: ${{ steps.contract.outputs.validation_only }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -52,8 +57,14 @@ jobs:
           version="$(jq -r '.version' ../release/release-contract.json)"
           build="$(jq -r '.build_number' ../release/release-contract.json)"
           tag="${GITHUB_REF_NAME}"
-          if [[ "$GITHUB_REF_TYPE" != "tag" ]]; then
+          validation_only=false
+          if [[ "$GITHUB_EVENT_NAME" == workflow_dispatch ]]; then
             tag="${{ inputs.release_tag }}"
+            if [[ "${{ inputs.validation_only }}" == true ]]; then
+              test "$GITHUB_REF" = refs/heads/main
+              test "${{ inputs.request_publication }}" != true
+              validation_only=true
+            fi
           fi
           if [[ "$tag" == "v$version" ]]; then
             channel=stable
@@ -68,7 +79,9 @@ jobs:
           fi
           fvm dart run tool/release_tool.dart validate-contract \
             --repo-root .. --tag "$tag" --channel "$channel"
-          test "$(git rev-parse "$tag^{commit}")" = "$GITHUB_SHA"
+          if [[ "$validation_only" != true ]]; then
+            test "$(git rev-parse "$tag^{commit}")" = "$GITHUB_SHA"
+          fi
           {
             echo "version=$version"
             echo "artifact_version=${tag#v}"
@@ -78,8 +91,10 @@ jobs:
             echo "manifest=$manifest"
             echo "appcast=$appcast"
             echo "prerelease=$prerelease"
+            echo "validation_only=$validation_only"
           } >> "$GITHUB_OUTPUT"
       - name: Refuse an existing immutable or Draft release
+        if: steps.contract.outputs.validation_only != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -363,12 +378,73 @@ jobs:
           retention-days: ${{ env.RELEASE_ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
 
+  client-ios:
+    needs: validate
+    runs-on: macos-15
+    timeout-minutes: 60
+    environment: apple-testflight
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-fvm
+      - name: Restore Apple Distribution identity and profile
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_P12_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_P12_PASSWORD }}
+          PROFILE_BASE64: ${{ secrets.IOS_APP_STORE_PROFILE_BASE64 }}
+        run: |
+          set -euo pipefail
+          test -n "$CERTIFICATE_BASE64"
+          test -n "$PROFILE_BASE64"
+          keychain="$RUNNER_TEMP/sanad-ios.keychain-db"
+          keychain_password="$(openssl rand -base64 32)"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 -D > "$RUNNER_TEMP/distribution.p12"
+          printf '%s' "$PROFILE_BASE64" | base64 -D > "$RUNNER_TEMP/sanad.mobileprovision"
+          chmod 600 "$RUNNER_TEMP/distribution.p12" "$RUNNER_TEMP/sanad.mobileprovision"
+          security create-keychain -p "$keychain_password" "$keychain"
+          security default-keychain -s "$keychain"
+          security unlock-keychain -p "$keychain_password" "$keychain"
+          security import "$RUNNER_TEMP/distribution.p12" -k "$keychain" \
+            -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security list-keychains -d user -s "$keychain"
+          security set-key-partition-list -S apple-tool:,apple: \
+            -s -k "$keychain_password" "$keychain"
+          uuid="$(security cms -D -i "$RUNNER_TEMP/sanad.mobileprovision" | \
+            plutil -extract UUID raw -o - -)"
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          cp "$RUNNER_TEMP/sanad.mobileprovision" \
+            "$HOME/Library/MobileDevice/Provisioning Profiles/$uuid.mobileprovision"
+      - name: Build and verify signed private IPA
+        working-directory: client
+        run: |
+          set -euo pipefail
+          fvm flutter pub get
+          fvm flutter build ipa --release \
+            --build-name="${{ needs.validate.outputs.version }}" \
+            --build-number="${{ needs.validate.outputs.build }}" \
+            --dart-define-from-file=config/prod.json \
+            --export-options-plist=release/ios/ExportOptions.plist
+          ipa="$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)"
+          test -n "$ipa"
+          unzip -q "$ipa" -d "$RUNNER_TEMP/ipa-check"
+          app="$(find "$RUNNER_TEMP/ipa-check/Payload" -maxdepth 1 -type d -name '*.app' -print -quit)"
+          test -n "$app"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          mkdir -p ../dist
+          cp "$ipa" \
+            "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-ios-universal.ipa"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: client-ios-private
+          path: dist/*
+          retention-days: ${{ env.RELEASE_ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+
   assemble:
-    needs: [validate, agent, client-linux-web, client-android, client-macos, client-windows]
+    needs: [validate, agent, client-linux-web, client-android, client-macos, client-windows, client-ios]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
-      contents: write
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -417,7 +493,22 @@ jobs:
           path: dist/*
           retention-days: ${{ env.RELEASE_ARTIFACT_RETENTION_DAYS }}
           if-no-files-found: error
-      - name: Create immutable Draft release candidate
+
+  draft:
+    name: Create immutable Draft candidate
+    needs: [validate, assemble]
+    if: needs.validate.outputs.validation_only != 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.validate.outputs.channel }}-release-candidate
+          path: dist
+      - name: Create private Draft
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -446,8 +537,8 @@ jobs:
 
   publish:
     name: Publish approved immutable release
-    needs: [validate, assemble]
-    if: github.ref_type == 'tag' || inputs.request_publication == true
+    needs: [validate, draft]
+    if: needs.validate.outputs.validation_only != 'true' && (github.ref_type == 'tag' || inputs.request_publication == true)
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     environment: release-publication

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -11,10 +11,7 @@ The public `EastStarAI/sanad-agent` repository owns CI, artifact construction,
 signing orchestration, the release manifest, update-feed generation, and the
 canonical installer sources. The first release line uses marketing version `1.0.0` for both Sanad Agent and Sanad Client. RC tags use `v1.0.0-rc.N`; Stable uses `v1.0.0`. Each candidate records its increasing build number in the checked-in contract.
 
-Pull-request CI is read-only and never receives signing or deployment
-credentials. Signing and deployment jobs use protected GitHub Environments,
-least-privilege permissions, immutable release assets, and explicit manual
-deployment inputs.
+Pull-request CI is read-only and never receives signing or deployment credentials. A protected validation-only dispatch from `main` can build the complete signed Agent/Client matrix, including a private IPA, as retained private artifacts without a tag, Draft, Release, TestFlight upload, or deployment. Signing jobs use protected GitHub Environments. Assembly remains contents-read; only the separate Draft and publication jobs receive contents-write.
 
 ## Artifact channels
 
@@ -54,7 +51,7 @@ unsigned APK or AAB can be produced.
 | `updates-production` | Atomic Appcast deployment |
 | `installers-production` | Publishing canonical installer sources |
 
-Signing environments and `release-publication` require the repository owner as reviewer and accept deployments only from protected refs. `release-build` has no signing responsibility. Repository secret scanning and push protection are enabled. No signing or deployment secret was added while establishing these boundaries; fork, pull-request, and Dependabot workflows remain read-only and cannot trigger the tag/manual release workflow or enter protected environments.
+Signing environments and `release-publication` require the repository owner as reviewer and accept deployments only from protected refs. `release-build` has no signing responsibility. Repository secret scanning and push protection are enabled. Signing secrets were transferred directly from the validated local signing store to their owning Environments without exposing values in Git, logs, or durable temporary files. Publication and production-deployment Environments contain no deployment secret. Fork, pull-request, and Dependabot workflows remain read-only and cannot trigger the tag/manual release workflow or enter protected environments.
 
 ## Secret inventory
 

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -49,10 +49,7 @@ Automated tests cover contract parsing, invalid tag rejection, deterministic
 Appcast output, source-managed no-mutation behavior, checksum rejection, client
 bootstrap selection, and existing daemon-controller behavior.
 
-Hosted validation additionally exercises interrupted downloads, wrong
-architecture, corrupted size and checksum, replacement failure, service restart,
-retained Sanad Home, repeated update requests, and rollback to the prior signed
-version.
+Hosted validation begins with a `validation_only` full-matrix run from protected `main`. It requires no tag and must leave zero Drafts and Releases while retaining private Agent/Client artifacts, the signed IPA, manifest, checksums, SBOM, Appcast, and attestations. Later lifecycle validation additionally exercises interrupted downloads, wrong architecture, corrupted size and checksum, replacement failure, service restart, retained Sanad Home, repeated update requests, and rollback to the prior signed version.
 
 ## Installer coverage
 

--- a/docs/technical/update_architecture.md
+++ b/docs/technical/update_architecture.md
@@ -10,8 +10,7 @@ description: "The shared release manifest and the update ownership of the Sanad 
 `release/release-contract.json` defines the marketing version, build, Stable tag, accepted RC channel files, repository, canonical filename templates, platform, architecture, and expected signature type. RC artifact filenames include the full `-rc.N` release identity while pubspec marketing versions remain `1.0.0`. Tags are either `v<version>` or `v<version>-rc.N`; every other prerelease form is rejected. The shared Dart package under `release/contract/` parses and
 validates that contract and the generated release manifest.
 
-The public release manifest is generated only after every public and private
-handoff artifact required by the contract exists. Its public entries include
+The candidate manifest is generated only after every public and private handoff artifact required by the contract exists, including the signed private iOS IPA. Validation-only manifests describe the intended immutable release identity but remain private workflow artifacts and never imply that the tag or Release exists. Its public entries include
 the immutable download URL, byte size, SHA-256 digest, platform, architecture,
 component, version, and signature metadata. Private AAB and Web handoffs remain
 protected workflow artifacts and are verified by their build attestations. The

--- a/release/README.md
+++ b/release/README.md
@@ -8,7 +8,7 @@ The shared Dart models and validators live beside the data contract in `release/
 
 The accepted tags are exactly the stable tag `v<marketing-version>` or an RC tag `v<marketing-version>-rc.<positive-number>`. Stable uses `release-manifest.json` and `appcast.xml`. RC uses the separate `release-manifest-rc.json` and `appcast-rc.xml`; stable clients never consume the RC feed.
 
-A tag or manual candidate dispatch validates the tag, channel, build, and tagged commit, builds the matrix, creates attestations, uploads a retained workflow artifact, and creates a GitHub **Draft**. It cannot publish from the build/assembly path. Publication is a separate least-privilege job guarded by the `release-publication` Environment and its required owner approval. Rejection or cancellation leaves only the private Draft.
+A protected `validation_only` dispatch from `main` validates an intended RC or Stable identity and builds the complete Agent and Client matrix—including a private signed IPA—without requiring a tag and without creating any Draft or Release. It produces only retained private workflow artifacts and attestations. A tag or non-validation candidate dispatch additionally requires the tagged commit and creates a GitHub **Draft** only in a separate contents-write job. The build/assembly path remains contents-read. Publication is a separate least-privilege job guarded by the `release-publication` Environment and its required owner approval. Rejection or cancellation leaves only the private Draft.
 
 The workflow refuses any existing Draft or published Release for the tag. Once created, a candidate is not replaced in place. A correction uses a new RC or patch tag and a fresh protected run.
 

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -95,6 +95,15 @@
     },
     {
       "component": "client",
+      "platform": "ios",
+      "architecture": "universal",
+      "format": "ipa",
+      "filename": "sanad-client-1.0.0-ios-universal.ipa",
+      "public": false,
+      "signature_type": "apple-distribution"
+    },
+    {
+      "component": "client",
       "platform": "web",
       "architecture": "universal",
       "format": "tar.gz",


### PR DESCRIPTION
## Goal

Build and verify the complete Agent and Client release matrix from protected `main` before any tag or public release exists.

## Changes

- add a default-safe `validation_only` manual mode that accepts an intended RC/Stable identity but requires protected `main` rather than a Git tag;
- build Agent macOS arm64/x64, Linux x64, and unsigned Windows x64;
- build Client macOS universal, Linux x64, unsigned Windows x64 with WinSparkle DSA, signed Android APK/AAB, signed private iOS IPA, and immutable Web archive;
- add the private signed IPA to the release contract;
- generate private manifest, checksums, Appcast, SBOM, attestations, and retained workflow artifacts;
- move Draft creation into a separate contents-write job and skip both Draft and publication jobs entirely during validation-only runs;
- keep TestFlight upload, Web deployment, tags, Drafts, Releases, and publication out of validation mode.

## Security

Signing materials are scoped to protected GitHub Environments with required owner review. Values were transferred directly from the validated local signing store and are not present in Git, PR jobs, logs, or durable temporary files. `release-publication` and deployment environments contain no deployment secret.

## Local Verification

- JSON and workflow YAML parsing passed;
- Stable/RC release-contract validation passed;
- an RC1 fixture required all contracted private outputs including IPA, while the public manifest excluded private iOS/Web/AAB artifacts;
- focused Agent release/update tests passed (9 tests);
- Agent analyzer and governance validation passed;
- workflow trust-boundary assertions and `git diff --check` passed.

## No Publication

This PR creates no tag, Draft, Release, RC, Stable publication, TestFlight upload, or Web deployment. The full-matrix workflow will be dispatched only after this PR passes protected CI and merges.
