### PR TITLE
SANAD-12: repair hosted full-matrix builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,6 +136,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-fvm
       - name: Install dependencies and test
+        if: matrix.platform != 'windows'
         working-directory: agent
         shell: bash
         run: |
@@ -143,12 +144,29 @@ jobs:
           fvm dart analyze
           fvm dart test
       - name: Compile agent
+        if: matrix.platform != 'windows'
         working-directory: agent
         shell: bash
         run: |
           mkdir -p ../dist
           fvm dart compile exe bin/sanad_agent.dart \
             -o "../dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-${{ matrix.platform }}-${{ matrix.architecture }}${{ matrix.extension }}"
+      - name: Install dependencies and test on Windows
+        if: matrix.platform == 'windows'
+        working-directory: agent
+        shell: pwsh
+        run: |
+          fvm dart pub get
+          fvm dart analyze
+          fvm dart test
+      - name: Compile Windows agent
+        if: matrix.platform == 'windows'
+        working-directory: agent
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path ../dist -Force | Out-Null
+          fvm dart compile exe bin/sanad_agent.dart `
+            -o "../dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-windows-x64.exe"
       - name: Import Apple Developer ID
         if: matrix.platform == 'macos'
         shell: bash
@@ -195,7 +213,6 @@ jobs:
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
             --wait
-          spctl --assess --type execute --verbose=2 "$agent"
       - uses: actions/upload-artifact@v4
         with:
           name: agent-${{ matrix.platform }}-${{ matrix.architecture }}
@@ -301,7 +318,10 @@ jobs:
           printf '%s' "$CERTIFICATE_BASE64" | base64 -D > "$RUNNER_TEMP/developer-id.p12"
           printf '%s' "$SPARKLE_KEY_BASE64" | base64 -D > "$RUNNER_TEMP/sparkle-private-key"
           printf '%s' "$APPLE_KEY_BASE64" | base64 -D > "$RUNNER_TEMP/AuthKey.p8"
-          chmod 600 "$RUNNER_TEMP"/*
+          chmod 600 \
+            "$RUNNER_TEMP/developer-id.p12" \
+            "$RUNNER_TEMP/sparkle-private-key" \
+            "$RUNNER_TEMP/AuthKey.p8"
           security create-keychain -p "$keychain_password" "$keychain"
           security default-keychain -s "$keychain"
           security unlock-keychain -p "$keychain_password" "$keychain"
@@ -344,9 +364,19 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-fvm
-      - name: Install NSIS
+      - name: Install NSIS with bounded retries
         shell: pwsh
-        run: choco install nsis -y --no-progress
+        run: |
+          $installed = $false
+          foreach ($attempt in 1..3) {
+            choco install nsis -y --no-progress
+            $installed = (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe") -or
+              (Test-Path "C:\Program Files\NSIS\makensis.exe") -or
+              [bool](Get-Command makensis -ErrorAction SilentlyContinue)
+            if ($installed) { break }
+            if ($attempt -lt 3) { Start-Sleep -Seconds (15 * $attempt) }
+          }
+          if (-not $installed) { throw "NSIS installation failed after 3 attempts." }
       - name: Restore WinSparkle update-signing material
         shell: pwsh
         env:
@@ -418,11 +448,17 @@ jobs:
         run: |
           set -euo pipefail
           fvm flutter pub get
-          fvm flutter build ipa --release \
+          fvm flutter build ipa --release --no-codesign \
             --build-name="${{ needs.validate.outputs.version }}" \
             --build-number="${{ needs.validate.outputs.build }}" \
-            --dart-define-from-file=config/prod.json \
-            --export-options-plist=release/ios/ExportOptions.plist
+            --dart-define-from-file=config/prod.json
+          archive=build/ios/archive/Runner.xcarchive
+          test -d "$archive"
+          rm -rf build/ios/ipa
+          xcodebuild -exportArchive \
+            -archivePath "$archive" \
+            -exportPath build/ios/ipa \
+            -exportOptionsPlist release/ios/ExportOptions.plist
           ipa="$(find build/ios/ipa -maxdepth 1 -name '*.ipa' -print -quit)"
           test -n "$ipa"
           unzip -q "$ipa" -d "$RUNNER_TEMP/ipa-check"

--- a/client/release/windows/release.ps1
+++ b/client/release/windows/release.ps1
@@ -21,6 +21,10 @@ try {
 Push-Location $ClientRoot
 try {
     & "$PSScriptRoot\build_installer.ps1" -EnvConfig $EnvConfig
+    if ($LASTEXITCODE -ne 0) { throw "Windows installer build failed." }
+    if (-not (Test-Path -LiteralPath $Installer)) {
+        throw "Windows installer output is missing."
+    }
     if (-not $PrivateKeyPath -or -not (Test-Path -LiteralPath $PrivateKeyPath)) {
         throw "WINSPARKLE_PRIVATE_KEY_PATH is required."
     }

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -61,6 +61,18 @@ service. Release validation must cover clean install, pairing-token replay,
 lost-success retry, durable reconnect, reinstall, upgrade, failed verification,
 interrupted replacement, and uninstall on each supported desktop host.
 
+## First hosted validation-only probe
+
+Run `30723337563` validated the no-tag safety boundary and signing-Environment approvals. It created no tag, Draft, or Release. Agent Linux, Client Linux/Web, and signed Android APK/AAB completed successfully. The remaining jobs exposed workflow defects rather than invalid signing material:
+
+- Windows Agent invoked FVM from Git Bash, where the Windows pub-cache executable was not on PATH; Windows Agent commands now use PowerShell.
+- Both signed and notarized macOS Agent binaries reached the final check, where Gatekeeper rejected raw CLI executables as non-app bundles; raw CLIs retain codesign and notary acceptance checks without the inapplicable `spctl` app assessment.
+- Client macOS recursively changed all runner-temporary permissions, including GitHub command files; permission hardening is now limited to the three restored signing files.
+- Client iOS attempted automatic Development signing during archive; it now creates an unsigned archive and performs the manual App Store Distribution export with the installed profile.
+- Client Windows encountered a transient Chocolatey `504` for NSIS and continued into update signing without an installer; NSIS installation now has bounded retries and the packaging helper fails immediately when the build or output is missing.
+
+A rerun must close these hosted defects before the validation-only matrix is accepted.
+
 ## SANAD-08 local evidence
 
 The preparation worktree passed both analyzers, the complete Backend suite


### PR DESCRIPTION
## Failure Triage

Validation-only run `30723337563` succeeded for Agent Linux, Client Linux/Web, and signed Android APK/AAB. The failed jobs exposed workflow/packaging defects rather than invalid signing material.

## Fixes

- run Windows Agent FVM commands under PowerShell instead of Git Bash;
- retain codesign and Apple notarization acceptance for raw macOS CLI binaries while removing the inapplicable Gatekeeper app-bundle assessment;
- restrict Client macOS `chmod` to restored signing files so GitHub runner command files remain accessible;
- archive iOS without signing, then export manually with the installed App Store Distribution identity/profile;
- install NSIS with three bounded Chocolatey attempts and verify `makensis` exists;
- make Windows packaging fail immediately when NSIS/build output is missing instead of falling through to WinSparkle signing;
- document the focused error evidence and required rerun.

## Verification

- workflow YAML and release contract parse successfully;
- Flutter confirms `ipa --no-codesign` support;
- focused release/update tests pass (9 tests);
- Agent analyzer, governance validation, static workflow assertions, and `git diff --check` pass.

## Safety

No tag, Draft, Release, TestFlight upload, Web deployment, or publication is created by this PR. After protected CI and merge, only `validation_only` will be rerun.
