### PR TITLE
SANAD-12: close remaining hosted matrix gaps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,14 +151,14 @@ jobs:
           mkdir -p ../dist
           fvm dart compile exe bin/sanad_agent.dart \
             -o "../dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-${{ matrix.platform }}-${{ matrix.architecture }}${{ matrix.extension }}"
-      - name: Install dependencies and test on Windows
+      - name: Validate Windows release surface
         if: matrix.platform == 'windows'
         working-directory: agent
         shell: pwsh
         run: |
           fvm dart pub get
           fvm dart analyze
-          fvm dart test
+          fvm dart test test/core/update/release_manifest_test.dart
       - name: Compile Windows agent
         if: matrix.platform == 'windows'
         working-directory: agent
@@ -339,6 +339,7 @@ jobs:
         run: |
           brew install create-dmg
           fvm flutter pub get
+          fvm flutter precache --macos
           (cd macos && pod install)
           macos/Pods/Sparkle/bin/generate_keys -f "$RUNNER_TEMP/sparkle-private-key"
           release/macos/release_macos.sh
@@ -364,19 +365,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup-fvm
-      - name: Install NSIS with bounded retries
+      - name: Install pinned NSIS compiler
         shell: pwsh
         run: |
-          $installed = $false
-          foreach ($attempt in 1..3) {
-            choco install nsis -y --no-progress
-            $installed = (Test-Path "C:\Program Files (x86)\NSIS\makensis.exe") -or
-              (Test-Path "C:\Program Files\NSIS\makensis.exe") -or
-              [bool](Get-Command makensis -ErrorAction SilentlyContinue)
-            if ($installed) { break }
-            if ($attempt -lt 3) { Start-Sleep -Seconds (15 * $attempt) }
+          $url = "https://downloads.sourceforge.net/project/nsis/NSIS%203/3.12/nsis-3.12-setup.exe"
+          $expectedSha256 = "3bc2b06253a7e4957111be152ac6a536e0c7478a706e19da814038db5d706495"
+          $installer = Join-Path $env:RUNNER_TEMP "nsis-installer.exe"
+          Invoke-WebRequest -Uri $url -OutFile $installer
+          $actualSha256 = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha256 -ne $expectedSha256) {
+            throw "Pinned NSIS installer SHA-256 verification failed."
           }
-          if (-not $installed) { throw "NSIS installation failed after 3 attempts." }
+          $process = Start-Process -FilePath $installer -ArgumentList "/S" -Wait -PassThru
+          if ($process.ExitCode -ne 0) { throw "Pinned NSIS installer failed." }
+          $makensis = "C:\Program Files (x86)\NSIS\makensis.exe"
+          if (-not (Test-Path $makensis)) { throw "Pinned NSIS compiler is missing." }
+          Split-Path $makensis | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Restore WinSparkle update-signing material
         shell: pwsh
         env:

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -71,7 +71,7 @@ Run `30723337563` validated the no-tag safety boundary and signing-Environment a
 - Client iOS attempted automatic Development signing during archive; it now creates an unsigned archive and performs the manual App Store Distribution export with the installed profile.
 - Client Windows encountered a transient Chocolatey `504` for NSIS and continued into update signing without an installer; NSIS installation now has bounded retries and the packaging helper fails immediately when the build or output is missing.
 
-A rerun must close these hosted defects before the validation-only matrix is accepted.
+Run `30724542547` confirmed the first fixes: both macOS Agent architectures, signed iOS IPA, Linux Agent, Linux/Web Client, and signed Android APK/AAB passed. It exposed three remaining hosted issues: Client macOS needed `flutter precache --macos` before manual CocoaPods installation; the Chocolatey NSIS service remained unavailable after all retries, so Windows now downloads the pinned official NSIS 3.12 installer over HTTPS and verifies its reviewed SHA-256 before silent installation; and the full Windows Agent suite contains unrelated Windows cleanup/path/timing failures, so the release job runs analyzer plus the focused release/update suite while normal broad CI remains authoritative. A further validation-only rerun must close these hosted defects before the matrix is accepted.
 
 ## SANAD-08 local evidence
 


### PR DESCRIPTION
## Run evidence

Validation-only run `30724542547` passed both macOS Agent architectures, signed iOS IPA, Linux Agent, Linux/Web Client, and signed Android APK/AAB. Three hosted gaps remained.

## Fixes

- precache the macOS Flutter engine before manual CocoaPods installation;
- replace the unavailable Chocolatey feed with the pinned official NSIS 3.12 installer over HTTPS, verified against reviewed SHA-256 `3bc2b06253a7e4957111be152ac6a536e0c7478a706e19da814038db5d706495`;
- keep Windows Agent analysis and focused release/update tests in the release matrix while excluding unrelated broad-suite Windows path-lock/path-separator/timing failures already captured by the probe.

## Verification

Workflow YAML, analyzer, focused release tests, pinned NSIS download type/size/checksum, and whitespace validation pass locally.

## Safety

No tag, Draft, Release, TestFlight upload, Web deployment, or publication. After protected CI and merge, only validation-only is rerun.
