### PR TITLE
SANAD-12: avoid interactive Sparkle signing in hosted release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -336,12 +336,12 @@ jobs:
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_PRIVATE_KEY_PATH: ${{ runner.temp }}/AuthKey.p8
+          SPARKLE_ED25519_PRIVATE_KEY_PATH: ${{ runner.temp }}/sparkle-private-key
         run: |
           brew install create-dmg
           fvm flutter pub get
           fvm flutter precache --macos
           (cd macos && pod install)
-          macos/Pods/Sparkle/bin/generate_keys -f "$RUNNER_TEMP/sparkle-private-key"
           release/macos/release_macos.sh
           mkdir -p ../dist
           source_prefix="build/sanad-client-${{ needs.validate.outputs.version }}-macos-universal.dmg"

--- a/client/release/macos/release_macos.sh
+++ b/client/release/macos/release_macos.sh
@@ -15,7 +15,19 @@ cd "$CLIENT_ROOT"
 "$SCRIPT_DIR/build_macos_dmg.sh"
 "$SCRIPT_DIR/notarize_macos.sh" "$DMG_PATH"
 
-SIGN_OUTPUT="$(fvm dart run auto_updater:sign_update "$DMG_PATH")"
+if [ -n "${SPARKLE_ED25519_PRIVATE_KEY_PATH:-}" ]; then
+  if [ ! -f "$SPARKLE_ED25519_PRIVATE_KEY_PATH" ]; then
+    echo "Sparkle EdDSA private key file is missing." >&2
+    exit 1
+  fi
+  SIGN_OUTPUT="$(
+    macos/Pods/Sparkle/bin/sign_update \
+      --ed-key-file "$SPARKLE_ED25519_PRIVATE_KEY_PATH" \
+      "$DMG_PATH"
+  )"
+else
+  SIGN_OUTPUT="$(fvm dart run auto_updater:sign_update "$DMG_PATH")"
+fi
 SIGNATURE="$(printf '%s\n' "$SIGN_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')"
 if [ -z "$SIGNATURE" ]; then
   echo "Sparkle EdDSA signing failed." >&2

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -37,6 +37,12 @@ requires the external `android/key.properties` file when the requested task is
 a release task; a missing file must fail release configuration before an
 unsigned APK or AAB can be produced.
 
+The hosted macOS Client job restores the exported Sparkle Ed25519 key to a
+runner-temporary file and passes that file directly to Sparkle `sign_update`.
+It does not import the key through `generate_keys` or depend on interactive
+Keychain authorization. Local operator builds may continue using the existing
+Keychain when no explicit Sparkle key-file path is supplied.
+
 ## Protected environments
 
 | Environment | Responsibility |

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -75,6 +75,18 @@ Run `30724542547` confirmed the first fixes: both macOS Agent architectures, sig
 
 Run `30725502085` then passed the complete Agent matrix plus Linux/Web, iOS, and Android Clients. Client macOS exposed a secret-encoding mismatch, corrected by storing the base64-encoded Sparkle key file as required by the workflow. Client Windows showed that PowerShell's web cmdlet received non-canonical SourceForge redirect bytes; the download now uses bounded `curl.exe` HTTPS redirects and verifies both the exact reviewed byte size and SHA-256. A further validation-only rerun must close these final two hosted defects before the matrix is accepted.
 
+Run `30726573652` confirmed every Agent target and the Linux/Web, iOS, Android,
+and Windows Clients. The macOS Client completed Developer ID signing,
+notarization, stapling, and Gatekeeper assessment, then remained inside the
+same build step before producing its Sparkle update signature. The workflow had
+imported the restored Sparkle key with `generate_keys -f` and invoked
+`sign_update` indirectly without a key-file argument; Sparkle documents that
+this Keychain path may request interactive authorization. Hosted macOS signing
+now passes the runner-temporary exported key directly to `sign_update` through
+`--ed-key-file`, while preserving the Keychain fallback for operator builds.
+A replacement validation-only run must complete the macOS Client, assembly,
+manifest, SBOM, and attestations before the hosted matrix is accepted.
+
 ## SANAD-08 local evidence
 
 The preparation worktree passed both analyzers, the complete Backend suite


### PR DESCRIPTION
## Problem / Goal
Validation-only release run `30726573652` completed notarization, stapling, and Gatekeeper assessment for the macOS Client, then hung before producing its Sparkle update signature. The workflow imported the key into Keychain and invoked signing without a key-file argument, allowing a headless runner to wait for interactive Keychain authorization.

## Technical Changes
- pass the runner-temporary exported Sparkle Ed25519 key directly to `sign_update --ed-key-file`
- remove the hosted `generate_keys -f` Keychain import
- preserve the existing Keychain fallback for local operator builds
- document the non-interactive CI boundary and the failed-run evidence

## Verification
- `bash -n client/release/macos/release_macos.sh`
- parsed `.github/workflows/release.yml` with Ruby YAML
- `git diff --check`
- direct Sparkle `sign_update --ed-key-file` probe with a temporary random Ed25519 seed
- `fvm dart test test/core/update/release_manifest_test.dart` (9 passed)
- `graphify update .`
