### PR TITLE
SANAD-12: record successful hosted release matrix

### DIFF
--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -109,15 +109,24 @@ Local verification proves the release contract, manifest/checksum generation,
 macOS universal packaging and Developer ID signatures, iOS signed export,
 Sparkle signatures, Web packaging, analyzers, and updater tests.
 
+The protected validation-only run at public `main` commit `c2bd6b3b` passed the
+complete hosted Agent and Client matrix. It exercised the protected signing
+Environments, generated the assembled manifest, checksums, Appcast, SBOM, and
+attestations as private retained artifacts, and created no tag, Draft, or
+Release.
+
 The following remain live-release gates:
 
-- the workflow and installer now implement the approved unsigned Windows `1.0.0` policy while retaining WinSparkle DSA, manifest, checksum, SBOM, provenance, and disclosure checks; hosted Windows 10/11 Defender and SmartScreen evidence remains required before publication;
+- the workflow and installer implement the approved unsigned Windows `1.0.0`
+  policy while retaining WinSparkle DSA, manifest, checksum, SBOM, provenance,
+  and disclosure checks; Windows 10/11 Defender and SmartScreen evidence remains
+  required before publication;
 - use the completed App Store Connect API key and application record for
-  Internal TestFlight upload; local notarization, staple, and Gatekeeper
-  verification have already passed;
-- protected signing and `release-publication` Environments exist with required owner review; signing material still must be transferred separately without exposing values;
-- run hosted Actions, publish the immutable release, deploy Web/Appcast/
-  installers, and exercise real upgrade and rollback paths.
+  Internal TestFlight upload; hosted notarization, staple, and Gatekeeper
+  verification have passed;
+- build and review tagged RC candidates, publish each immutable Release only
+  after its separate owner approval, stage Web/Appcast/installers, and exercise
+  clean installation, real upgrade, failure recovery, and rollback paths.
 
 Those actions are owned by the later public-release task and do not weaken the
 prepared workflows.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -84,8 +84,16 @@ imported the restored Sparkle key with `generate_keys -f` and invoked
 this Keychain path may request interactive authorization. Hosted macOS signing
 now passes the runner-temporary exported key directly to `sign_update` through
 `--ed-key-file`, while preserving the Keychain fallback for operator builds.
-A replacement validation-only run must complete the macOS Client, assembly,
-manifest, SBOM, and attestations before the hosted matrix is accepted.
+
+Replacement validation-only run `30728515333` at public `main` commit
+`c2bd6b3b` passed the complete Agent and Client matrix, including macOS Client
+Developer ID signing, notarization, stapling, Gatekeeper assessment, and direct
+Sparkle update signing. Assembly generated and attested the manifest,
+checksums, Appcast, SBOM, and candidate assets; all 11 retained artifacts remain
+private. The Draft and publication jobs were skipped, and the run left no tag,
+Draft, or Release. This closes the hosted full-matrix build probe; clean-machine
+installation, update, rollback, Windows Defender/SmartScreen, and Internal
+TestFlight upload remain separate live gates.
 
 ## SANAD-08 local evidence
 


### PR DESCRIPTION
## Problem / Goal
The release docs still described the hosted full-matrix rerun and signing-material transfer as pending after validation-only run `30728515333` passed.

## Documentation Changes
- record the cancelled Sparkle-Keychain run and successful replacement run
- record full Agent/Client matrix, assembly, private artifacts, and attestation evidence
- record that Draft/publication were skipped and no tag or Release exists
- retain clean-machine, Windows Defender/SmartScreen, TestFlight upload, RC publication, update, and rollback as open live gates

## Verification
- `git diff --check`
- GitHub run `30728515333`: success at `c2bd6b3b`
- 11 retained private artifacts
- zero tags and Releases
