### PR TITLE
SANAD-12: add read-only publication rejection probe

### DIFF
--- a/.github/workflows/release-publication-guard-probe.yml
+++ b/.github/workflows/release-publication-guard-probe.yml
@@ -1,0 +1,80 @@
+name: Probe release publication guard
+
+on:
+  workflow_dispatch:
+    inputs:
+      expected_commit:
+        description: Full public main commit expected to enter the protected gate
+        type: string
+        required: true
+      expected_v1_tag_count:
+        description: Expected count of v1 tags before and after the probe
+        type: number
+        required: true
+        default: 0
+      expected_v1_release_count:
+        description: Expected count of v1 Releases and Drafts before and after the probe
+        type: number
+        required: true
+        default: 0
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  preflight:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      tag_count: ${{ steps.inventory.outputs.tag_count }}
+      release_count: ${{ steps.inventory.outputs.release_count }}
+    steps:
+      - name: Verify immutable probe identity
+        env:
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = refs/heads/main
+          test "$GITHUB_SHA" = "$EXPECTED_COMMIT"
+          test "${#EXPECTED_COMMIT}" = 40
+      - id: inventory
+        name: Record the read-only publication baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_TAG_COUNT: ${{ inputs.expected_v1_tag_count }}
+          EXPECTED_RELEASE_COUNT: ${{ inputs.expected_v1_release_count }}
+        run: |
+          set -euo pipefail
+          tags="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v1" --jq 'length' | awk '{sum += $1} END {print sum + 0}')"
+          releases="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq '[.[] | select(.tag_name | startswith("v1"))] | length' | awk '{sum += $1} END {print sum + 0}')"
+          test "$tags" = "$EXPECTED_TAG_COUNT"
+          test "$releases" = "$EXPECTED_RELEASE_COUNT"
+          {
+            echo "tag_count=$tags"
+            echo "release_count=$releases"
+          } >> "$GITHUB_OUTPUT"
+
+  publication-guard:
+    name: Enter release-publication without write permission
+    needs: preflight
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    environment: release-publication
+    permissions:
+      contents: read
+    steps:
+      - name: Prove approval cannot publish or mutate a Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASELINE_TAG_COUNT: ${{ needs.preflight.outputs.tag_count }}
+          BASELINE_RELEASE_COUNT: ${{ needs.preflight.outputs.release_count }}
+        run: |
+          set -euo pipefail
+          tags="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/git/matching-refs/tags/v1" --jq 'length' | awk '{sum += $1} END {print sum + 0}')"
+          releases="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq '[.[] | select(.tag_name | startswith("v1"))] | length' | awk '{sum += $1} END {print sum + 0}')"
+          test "$tags" = "$BASELINE_TAG_COUNT"
+          test "$releases" = "$BASELINE_RELEASE_COUNT"
+          echo "Protected publication gate entered with contents:read; no release mutation is possible."

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -91,6 +91,12 @@ separate future decision.
 
 ## Atomic publication and rollback
 
+A separate read-only publication-guard probe may enter the protected
+`release-publication` Environment only to verify approval or rejection behavior.
+It requires an exact public `main` commit, inventories existing `v1` tags and
+Releases before the gate, has no write permission, and never creates a candidate.
+Probe approval is not Release publication approval.
+
 The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. The private Web handoff
 is downloaded from the explicitly selected successful release-workflow run and
 verified against its GitHub build attestation. Server deployment then writes a

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -43,6 +43,20 @@ rules remain fail-closed.
 | Client iOS | signed IPA export for NanoSoft LY LLC; App Store Connect record and API key ready | Internal TestFlight upload |
 | Client Web | release build and version marker | protected atomic deployment, cache/SPA checks, rollback |
 
+## Protected publication rejection probe
+
+The dedicated `Probe release publication guard` workflow validates the
+`release-publication` Environment without creating a tag, Draft, candidate, or
+Release. Its preflight job is restricted to `contents: read`, requires an exact
+40-character public `main` commit, and records the expected counts of `v1` tags
+and Releases. The only dependent job enters `release-publication` with the same
+read-only permission and can only compare those counts.
+
+For the rejection case, an owner rejects the pending protected deployment. The
+run must end without executing the guarded step, and a separate read-only API
+inventory must prove the `v1` tag and Release counts remain unchanged. Approval
+of this probe is not approval to publish an RC or Stable Release.
+
 ## Update failure coverage
 
 Automated tests cover contract parsing, invalid tag rejection, deterministic


### PR DESCRIPTION
## Problem / Goal
Gate 1 still requires live evidence that rejecting or cancelling `release-publication` cannot leave a public Release. Testing that boundary through the real release workflow would require a tag and Draft, which are forbidden before the gate closes.

## Technical Changes
- add a workflow-dispatch probe pinned to an exact public `main` commit
- inventory expected `v1` tag and Release counts before entering the protected Environment
- enter `release-publication` using `contents: read` only
- create no tag, candidate, Draft, or Release under either approval or rejection
- document the rejection evidence procedure and clarify that probe approval is not publication approval

## Verification
- YAML parse passed
- `git diff --check`
- live read-only baseline: 0 `v1` tags and 0 `v1` Releases/Drafts
- `graphify update .`
