### PR TITLE
SANAD-12: record protected publication rejection evidence

### DIFF
--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -119,7 +119,9 @@ The protected validation-only run at public `main` commit `c2bd6b3b` passed the
 complete hosted Agent and Client matrix. It exercised the protected signing
 Environments, generated the assembled manifest, checksums, Appcast, SBOM, and
 attestations as private retained artifacts, and created no tag, Draft, or
-Release.
+Release. Read-only guard probe `30730348167` was then rejected by the repository
+owner at `release-publication`; the protected step did not run and post-run
+inventory remained at zero `v1` tags and zero Releases or Drafts.
 
 The following remain live-release gates:
 

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -57,6 +57,14 @@ run must end without executing the guarded step, and a separate read-only API
 inventory must prove the `v1` tag and Release counts remain unchanged. Approval
 of this probe is not approval to publish an RC or Stable Release.
 
+Live probe run `30730348167` pinned public `main` commit `ff22d991` and recorded
+zero `v1` tags and zero `v1` Releases before entering the Environment. The
+repository owner rejected `release-publication`; the guarded job ended as
+rejected without executing its read-only step. A separate post-run API
+inventory again found zero `v1` tags and zero `v1` Releases or Drafts. This
+closes the rejection/no-partial-publication evidence only; it grants no
+approval for RC1 or any later publication.
+
 ## Update failure coverage
 
 Automated tests cover contract parsing, invalid tag rejection, deterministic


### PR DESCRIPTION
## Problem / Goal
Record the live Gate 1 evidence that owner rejection at `release-publication` leaves no partial public state.

## Evidence
- guard probe run `30730348167` pinned `ff22d991`
- preflight recorded zero `v1` tags and zero `v1` Releases
- `AhmedAttia3` rejected the protected Environment deployment
- guarded job did not execute its read-only step
- post-run inventory remained zero `v1` tags and zero Releases/Drafts
- this evidence grants no RC1 or later publication approval

## Verification
- `git diff --check`
- GitHub deployment approval API reports `state=rejected`
- read-only tags and Releases APIs report zero after completion
