### PR TITLE
Keep private endpoints out of public profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,10 @@ jobs:
           grep -F "if: needs.validate.outputs.validation_only != 'true'" .github/workflows/release.yml
           grep -F 'name: Create immutable Draft candidate' .github/workflows/release.yml
           grep -F 'name: Build and verify signed private IPA' .github/workflows/release.yml
+          grep -F 'fvm flutter test test/tool/app_web_startup_contract_test.dart' .github/workflows/release.yml
+          grep -F 'build/web/sanad-public-sha.txt' .github/workflows/release.yml
+          grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
+          grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F -- '--draft' .github/workflows/release.yml
           grep -F 'release-manifest-rc.json' release/release-contract.json
           grep -F 'appcast-rc.xml' release/release-contract.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,7 @@ jobs:
   web:
     if: inputs.deploy_web == true
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     environment: web-production
     steps:
       - uses: actions/checkout@v6
@@ -49,8 +50,19 @@ jobs:
       - name: Fetch attested Web artifact
         env:
           GH_TOKEN: ${{ github.token }}
+          RELEASE_RUN_ID: ${{ inputs.release_run_id }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          gh run download "${{ inputs.release_run_id }}" \
+          set -euo pipefail
+          [[ "$RELEASE_RUN_ID" =~ ^[0-9]+$ ]]
+          [[ "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          expected_sha="$(git rev-parse HEAD)"
+          run_metadata="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID")"
+          test "$(jq -r '.conclusion' <<<"$run_metadata")" = success
+          test "$(jq -r '.path' <<<"$run_metadata")" = .github/workflows/release.yml
+          test "$(jq -r '.head_sha' <<<"$run_metadata")" = "$expected_sha"
+          gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft == false' | grep -Fxq true
+          gh run download "$RELEASE_RUN_ID" \
             --name stable-release-candidate \
             --dir download
           web_artifact="$(find download -maxdepth 1 \
@@ -60,16 +72,103 @@ jobs:
             --repo "${{ github.repository }}"
           mkdir web
           tar -xzf "$web_artifact" -C web
-      - name: Atomic Web deployment
+          test -s web/index.html
+          grep -Fq 'flutter_bootstrap.js' web/index.html
+          test -s web/flutter_bootstrap.js
+          test -s web/favicon.svg
+          test "$(cat web/sanad-public-sha.txt)" = "$expected_sha"
+          jq -e --arg version "${RELEASE_TAG#v}" \
+            '.version == $version and (.build | type == "number")' \
+            web/version.json >/dev/null
+          find web -type d -exec chmod 755 {} +
+          find web -type f -exec chmod 644 {} +
+          test -z "$(find web -type f ! -perm -004 -print -quit)"
+      - name: Publish immutable Production Web release
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
-          tag="${{ inputs.release_tag }}"
-          rsync -az --delete --delay-updates web/ \
-            "$DEPLOY_USER@$DEPLOY_HOST:/srv/sanad/web/incoming-$tag/"
+          set -euo pipefail
+          tag="$RELEASE_TAG"
+          expected_sha="$(git rev-parse HEAD)"
+          incoming="/srv/sanad/web/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          release="/srv/sanad/web/releases/$tag"
+          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'"; then
+            echo "Reusing the existing immutable Production Web release $release."
+            exit 0
+          fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; mkdir -p /srv/sanad/web/releases; mv /srv/sanad/web/incoming-$tag /srv/sanad/web/releases/$tag; ln -sfn /srv/sanad/web/releases/$tag /srv/sanad/web/current"
+            "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming' /srv/sanad/web/releases"
+          rsync -az --delete --delay-updates web/ \
+            "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; find '$incoming' -type d -exec chmod 755 {} +; find '$incoming' -type f -exec chmod 644 {} +; test -z \"\$(find '$incoming' -type f ! -perm -004 -print -quit)\"; test -s '$incoming/index.html'; grep -Fq flutter_bootstrap.js '$incoming/index.html'; test \"\$(cat '$incoming/sanad-public-sha.txt')\" = '$expected_sha'; test ! -e '$release'; mv '$incoming' '$release'"
+      - name: Activate, verify, and roll back Production Web on failure
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          release="/srv/sanad/web/releases/$RELEASE_TAG"
+          selector=/srv/sanad/web/current
+          expected_sha="$(git rev-parse HEAD)"
+          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
+          test -n "$previous"
+          previous_index_sha="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; sha256sum '$previous/index.html' | cut -d ' ' -f 1")"
+          test -n "$previous_index_sha"
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'; ln -sfn '$release' '$selector'"
+
+          verify_web() {
+            body="$(mktemp)"
+            trap 'rm -f "$body"' RETURN
+            curl --fail --silent --show-error --location --max-time 20 \
+              --output "$body" "https://app.sanad.eaststarai.com/?source=$expected_sha"
+            grep -Fq 'flutter_bootstrap.js' "$body"
+            curl --fail --silent --show-error --max-time 20 \
+              "https://app.sanad.eaststarai.com/flutter_bootstrap.js?source=$expected_sha" >/dev/null
+            curl --fail --silent --show-error --max-time 20 \
+              "https://app.sanad.eaststarai.com/favicon.svg?source=$expected_sha" >/dev/null
+            served_sha="$(curl --fail --silent --show-error --max-time 20 \
+              "https://app.sanad.eaststarai.com/sanad-public-sha.txt?source=$expected_sha")"
+            test "$served_sha" = "$expected_sha"
+          }
+
+          activated=false
+          for attempt in $(seq 1 12); do
+            if verify_web; then
+              activated=true
+              break
+            fi
+            sleep 5
+          done
+          if [[ "$activated" != true ]]; then
+            echo "Production Web verification failed; restoring the previous selector."
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; test -s '$previous/index.html'; ln -sfn '$previous' '$selector'"
+            rollback_verified=false
+            for attempt in $(seq 1 12); do
+              rolled_back_index="$(mktemp)"
+              if curl --fail --silent --show-error --location --max-time 20 \
+                --output "$rolled_back_index" \
+                "https://app.sanad.eaststarai.com/?rollback=$previous_index_sha" && \
+                [[ "$(sha256sum "$rolled_back_index" | cut -d ' ' -f 1)" == "$previous_index_sha" ]]; then
+                rollback_verified=true
+                rm -f "$rolled_back_index"
+                break
+              fi
+              rm -f "$rolled_back_index"
+              sleep 5
+            done
+            if [[ "$rollback_verified" != true ]]; then
+              echo "Production Web rollback verification failed." >&2
+            fi
+            exit 1
+          fi
 
   updates:
     if: inputs.deploy_updates == true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,11 +234,28 @@ jobs:
       - name: Build Linux and Web
         working-directory: client
         run: |
+          set -euo pipefail
           fvm flutter pub get
+          fvm flutter analyze
+          fvm flutter test test/tool/app_web_startup_contract_test.dart
           fvm flutter build linux --release --dart-define-from-file=config/prod.json
           fvm flutter build web --release --dart-define-from-file=config/prod.json
           printf '%s\n' '{"version":"${{ needs.validate.outputs.artifact_version }}","build":${{ needs.validate.outputs.build }}}' \
             > build/web/version.json
+          git rev-parse HEAD > build/web/sanad-public-sha.txt
+          test -s build/web/index.html
+          grep -Fq 'flutter_bootstrap.js' build/web/index.html
+          test -s build/web/flutter_bootstrap.js
+          test -s build/web/favicon.svg
+          jq -e \
+            --arg version '${{ needs.validate.outputs.artifact_version }}' \
+            --argjson build '${{ needs.validate.outputs.build }}' \
+            '.version == $version and .build == $build' \
+            build/web/version.json >/dev/null
+          test "$(cat build/web/sanad-public-sha.txt)" = "$GITHUB_SHA"
+          find build/web -type d -exec chmod 755 {} +
+          find build/web -type f -exec chmod 644 {} +
+          test -z "$(find build/web -type f ! -perm -004 -print -quit)"
           mkdir -p ../dist
           tar -C build/linux/x64/release -czf \
             "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-linux-x64.tar.gz" bundle

--- a/agent/test/core/config_test.dart
+++ b/agent/test/core/config_test.dart
@@ -140,12 +140,12 @@ LOG_MAX_LENGTH=1000
 
     final overridden = Config(
       environment: const {
-        'GATEWAY_URL': 'https://dev.api.sanad.eaststarai.com',
-        'PORTAL_URL': 'https://dev.portal.sanad.eaststarai.com',
+        'GATEWAY_URL': 'https://gateway.internal.example',
+        'PORTAL_URL': 'https://portal.internal.example',
       },
     );
-    expect(overridden.gatewayUrl, 'https://dev.api.sanad.eaststarai.com');
-    expect(overridden.portalUrl, 'https://dev.portal.sanad.eaststarai.com');
+    expect(overridden.gatewayUrl, 'https://gateway.internal.example');
+    expect(overridden.portalUrl, 'https://portal.internal.example');
   });
 
   test(

--- a/client/lib/core/AGENTS.md
+++ b/client/lib/core/AGENTS.md
@@ -79,5 +79,6 @@ Defined in `core/navigation/navigation_history_controller.dart`. The controller:
 
 ## Development Runtime Configuration
 
-- Public source launch profiles use Production hosted endpoints with Local+Cloud enabled by default; Dev endpoint profiles are explicit internal integration only, and automated tests must not contact Production.
+- Public source launch profiles use Production hosted endpoints with Local+Cloud enabled by default; automated tests must not contact Production.
+- Public source must not own hosted Development or Staging endpoint values. Non-local profiles default to Production, while private deployment owners inject `BACKEND_URL` and `PORTAL_URL` explicitly at build time.
 - Keep worktree identity compile-time and optional. `sanad-dev` may inject a readable linked-worktree name, branch, absolute Sanad Home, and home-derived SharedPreferences prefix through `AppConfig`; ordinary, primary-user, and packaged runs retain the default preference namespace.

--- a/client/lib/core/config/public_service_endpoints.dart
+++ b/client/lib/core/config/public_service_endpoints.dart
@@ -3,15 +3,12 @@ class PublicServiceEndpoints {
 
   static const String productionBackend = 'https://api.sanad.eaststarai.com';
   static const String productionPortal = 'https://portal.sanad.eaststarai.com';
-  static const String developmentBackend = 'https://dev.api.sanad.eaststarai.com';
-  static const String developmentPortal = 'https://dev.portal.sanad.eaststarai.com';
   static const String localBackend = 'http://127.0.0.1:8001';
   static const String localPortal = 'http://127.0.0.1:8083';
 
   static String backendFor(String environment) {
     return switch (environment.trim().toLowerCase()) {
       'local' => localBackend,
-      'dev' || 'stg' => developmentBackend,
       _ => productionBackend,
     };
   }
@@ -19,7 +16,6 @@ class PublicServiceEndpoints {
   static String portalFor(String environment) {
     return switch (environment.trim().toLowerCase()) {
       'local' => localPortal,
-      'dev' || 'stg' => developmentPortal,
       _ => productionPortal,
     };
   }

--- a/client/test/unit/config/public_service_endpoints_test.dart
+++ b/client/test/unit/config/public_service_endpoints_test.dart
@@ -2,23 +2,20 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/core/config/public_service_endpoints.dart';
 
 void main() {
-  test('resolves public endpoints from the selected environment', () {
-    expect(
-      PublicServiceEndpoints.backendFor('dev'),
-      'https://dev.api.sanad.eaststarai.com',
-    );
-    expect(
-      PublicServiceEndpoints.portalFor('dev'),
-      'https://dev.portal.sanad.eaststarai.com',
-    );
-    expect(
-      PublicServiceEndpoints.backendFor('prod'),
-      'https://api.sanad.eaststarai.com',
-    );
-    expect(
-      PublicServiceEndpoints.portalFor('prod'),
-      'https://portal.sanad.eaststarai.com',
-    );
+  test('defaults hosted profiles to public production services', () {
+    for (final environment in ['dev', 'stg', 'prod', 'unknown']) {
+      expect(
+        PublicServiceEndpoints.backendFor(environment),
+        'https://api.sanad.eaststarai.com',
+      );
+      expect(
+        PublicServiceEndpoints.portalFor(environment),
+        'https://portal.sanad.eaststarai.com',
+      );
+    }
+  });
+
+  test('keeps the explicit local profile on loopback services', () {
     expect(
       PublicServiceEndpoints.backendFor('local'),
       'http://127.0.0.1:8001',

--- a/client/test/unit/scripts/sanad_dev_cloud_endpoints_test.dart
+++ b/client/test/unit/scripts/sanad_dev_cloud_endpoints_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -5,11 +6,19 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../../scripts/sanad_dev/cloud_endpoints.dart';
 
 void main() {
+  test('tracked hosted profiles do not own private endpoint values', () {
+    for (final path in ['config/dev.json', 'config/prod.json']) {
+      final decoded = jsonDecode(File(path).readAsStringSync()) as Map<String, dynamic>;
+
+      expect(decoded, isNot(contains('BACKEND_URL')), reason: path);
+      expect(decoded, isNot(contains('PORTAL_URL')), reason: path);
+    }
+  });
+
   test('production profile maps to public production services', () async {
     final temp = await Directory.systemTemp.createTemp('sanad-cloud-config');
     addTearDown(() => temp.delete(recursive: true));
-    final config = File('${temp.path}/prod.json')
-      ..writeAsStringSync('{"ENVIRONMENT":"prod"}');
+    final config = File('${temp.path}/prod.json')..writeAsStringSync('{"ENVIRONMENT":"prod"}');
 
     expect(readSanadCloudEndpoints(config).toAgentEnvironment(), {
       'GATEWAY_URL': 'https://api.sanad.eaststarai.com',
@@ -17,14 +26,14 @@ void main() {
     });
   });
 
-  test('maps explicit development profile to internal services', () async {
+  test('development profile remains on public production services', () async {
     final temp = await Directory.systemTemp.createTemp('sanad-cloud-config');
     addTearDown(() => temp.delete(recursive: true));
     final config = File('${temp.path}/dev.json')..writeAsStringSync('''{"ENVIRONMENT":"dev"}''');
 
     expect(readSanadCloudEndpoints(config).toAgentEnvironment(), {
-      'GATEWAY_URL': 'https://dev.api.sanad.eaststarai.com',
-      'PORTAL_URL': 'https://dev.portal.sanad.eaststarai.com',
+      'GATEWAY_URL': 'https://api.sanad.eaststarai.com',
+      'PORTAL_URL': 'https://portal.sanad.eaststarai.com',
     });
   });
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -114,6 +114,7 @@ These files are mandatory execution contracts governing subdirectories. Always r
 - [مواصفات نظام التصميم والمكونات المرئية للمشاريع](docs/technical/design_system.md): توثيق شامل للألوان، الخطوط، الهيكل البنائي والواجهات التفاعلية المشتركة لمشاريع Sanad (التطبيق الرئيسي، صفحة الهبوط، ولوحة التحكم).
 - [Device Runtime Settings Protocol](docs/technical/device_runtime_settings_protocol.md): Unified local/cloud protocol commands, validation, persistence, and secret-handling rules for device settings.
 - [Hosted Services Boundary](docs/technical/hosted_services_boundary.md): Ownership and compatibility boundary between the open-source Sanad Agent clients and EastStar AI hosted services.
+- [Public Client Endpoint Configuration](docs/technical/public_client_endpoint_configuration.md): Production/local public defaults and explicit private build-time injection for hosted Development or Staging services.
 - [Message Turn Replay Protocol](docs/technical/message_turn_replay_protocol.md): Technical specification and protocols governing historical message turn replay and recovery.
 - [بروتوكول مزودي نماذج اللغة](docs/technical/provider_protocol.md): بروتوكول إعداد مزودي LLM والمصادقة والتخزين واختيار النموذج في Sanad Agent.
 - [Reasoning, Thoughts, and Final Answer Separation](docs/technical/reasoning_thoughts_separation.md): Protocol, adapter normalization, history, and state for assistant surfaces. Streaming text shares the final-answer Markdown look; provider reasoning is a transient live-only row never rebuilt from history.

--- a/docs/operations/developer_guide.md
+++ b/docs/operations/developer_guide.md
@@ -260,14 +260,6 @@ cd agent
 fvm dart run bin/sanad_agent.dart login
 ```
 
-Environment overrides can target a compatible service without changing
-tracked profiles:
-
-```env
-GATEWAY_URL=https://dev.api.sanad.eaststarai.com
-PORTAL_URL=https://dev.portal.sanad.eaststarai.com
-```
-
 Authentication and provider credentials belong to the selected Sanad Home and
 must remain outside Git and logs.
 

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -101,8 +101,12 @@ The candidate workflow creates a private Draft and fails if the tag already owns
 is downloaded from the explicitly selected successful release-workflow run and
 verified against its GitHub build attestation. Server deployment then writes a
 versioned directory and changes a `current` symlink only after the transfer
-succeeds. Rollback switches that symlink to the last known good version; it
-does not rebuild or mutate a published release.
+succeeds. The Web handoff records its exact public commit, validates the Flutter
+shell, bootstrap, favicon, version marker, and hosted readability before
+activation, then verifies the public Production URL. A failed public probe
+restores the preceding selector automatically. Rollback switches that symlink
+to the last known good version; it does not rebuild or mutate a published
+release.
 
 Web assets use content-hashed Flutter output plus a small no-cache
 `version.json`. The server must route unknown application paths to

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -41,7 +41,7 @@ rules remain fail-closed.
 | Client Windows x64 | installer and current fail-closed signing workflow definition | SANAD-12 unsigned-policy workflow adaptation, disclosure, SHA-256/manifest/provenance, Windows 11 clean installer/update/rollback and Defender/SmartScreen |
 | Client Android APK/AAB | signed local APK/AAB, package identity and keystore fingerprint | signed hosted build, clean install/upgrade |
 | Client iOS | signed IPA export for NanoSoft LY LLC; App Store Connect record and API key ready | Internal TestFlight upload |
-| Client Web | release build, version marker, and native-platform startup guard | protected atomic deployment, cache/SPA checks, clean-browser visible render with no uncaught startup/CSP/CanvasKit/Wasm error, rollback |
+| Client Web | analyzer, startup contract test, Production-profile release build, exact source and version markers, Flutter shell/bootstrap/favicon probes, and hosted readability | attested-run/source match, protected immutable deployment, public source probe, automatic selector rollback, cache/SPA checks, and clean-browser visible render with no uncaught startup/CSP/CanvasKit/Wasm error |
 
 Windows 11 evidence follows the dedicated
 [Windows Release Clean-Machine Validation](windows_release_clean_machine.md)

--- a/docs/technical/hosted_services_boundary.md
+++ b/docs/technical/hosted_services_boundary.md
@@ -24,8 +24,9 @@ Authenticated clients and daemons connect to the official Gateway for remote
 device inventory and event relay. Public source runs, including primary
 checkouts, independent clones, linked worktrees, and modified forks, select the
 Production profile by default and use the hosted service exactly as ordinary
-users. The development profile and process-level endpoint overrides are explicit
-internal Backend/Portal integration tools and are never selected implicitly.
+users. A private Backend/Portal integration build must inject its hosted
+endpoint overrides explicitly; selecting a non-local environment name alone
+continues to use the official Production endpoints.
 `--no-cloud` disables hosted communication while preserving direct local use.
 
 Source availability and service availability are separate guarantees: the
@@ -76,6 +77,12 @@ is manual, explicit, bounded, non-destructive, and never a required check.
 
 ## Configuration and Secrets
 
-Public client configuration may include official service URLs and platform application identifiers. Version `1.0.0` does not ship external telemetry or push configuration. Public configuration never includes OAuth client secrets, signing private keys, server environment values, deployment credentials, or user tokens.
+Public client configuration may include official service URLs and platform
+application identifiers. Privately operated Development and Staging endpoint
+values remain owned by private deployment automation and are injected when it
+builds an exact public commit. Version `1.0.0` does not ship external telemetry
+or push configuration. Public configuration never includes OAuth client
+secrets, signing private keys, server environment values, deployment
+credentials, or user tokens.
 
 Provider credentials and Sanad identity tokens are runtime user data stored outside Git. Diagnostics redact credential-shaped fields before serialization.

--- a/docs/technical/public_client_endpoint_configuration.md
+++ b/docs/technical/public_client_endpoint_configuration.md
@@ -1,0 +1,40 @@
+# Public Client Endpoint Configuration
+
+## Ownership boundary
+
+The public Flutter client owns the Production service endpoints and the
+loopback endpoints used by the explicit local profile. It does not own the
+hostnames of privately operated Development or Staging environments.
+
+`ENVIRONMENT` selects application behavior and diagnostics. It is not a
+directory of private infrastructure. Consequently, every non-local public
+profile defaults to the Production Backend and Portal unless the build owner
+provides explicit compile-time overrides.
+
+## Build-time inputs
+
+The supported hosted-service inputs are:
+
+| Input | Purpose | Public fallback |
+|---|---|---|
+| `ENVIRONMENT` | Identifies application behavior as `dev`, `stg`, or `prod` | `prod` |
+| `BACKEND_URL` | REST and Socket.IO cloud gateway origin | Production Backend |
+| `PORTAL_URL` | Authentication Portal origin | Production Portal |
+
+`LOCAL_GATEWAY_URL` is a separate desktop-only daemon boundary. It is not the
+hosted Backend address and must not be used to configure a Flutter Web build.
+
+Private deployment automation owns any Development or Staging values and
+injects both hosted URLs explicitly while building the pinned public commit.
+Those values do not belong in the tracked public JSON profiles, endpoint
+constants, or public deployment workflows.
+
+## Failure-safe behavior
+
+A missing private override cannot silently select another private environment.
+Development, Staging, unknown, and Production profile names all use Production
+hosted endpoints by default. Only the explicit `local` profile selects the
+tracked loopback Backend and Portal.
+
+This fallback prevents a public source build from depending on private
+infrastructure while preserving reproducible Production and local builds.


### PR DESCRIPTION
## Summary

- keep public non-local profiles on Production unless a private build explicitly injects Backend and Portal URLs
- remove privately operated Development endpoint values from active public source, tests, and guidance
- harden Production Flutter Web build artifacts with analysis, startup tests, source identity, output, favicon, and readability checks
- validate the selected release run and commit before immutable Production Web publication, then verify the public selector and roll back automatically on failure

## Verification

- `fvm flutter test test/unit/config/public_service_endpoints_test.dart test/unit/scripts/sanad_dev_cloud_endpoints_test.dart test/tool/app_web_startup_contract_test.dart`
- `fvm flutter analyze`
- `fvm flutter build web --release --dart-define-from-file=config/prod.json`
- `fvm dart test test/core/config_test.dart`
- `fvm dart analyze`
- workflow YAML parse and whitespace validation

No Production deployment was run by this PR.