### PR TITLE
feat(auth): reload credentials on init/refresh and sync desktop tokens with auth.json

### DIFF
--- a/agent/lib/core/auth/auth_manager.dart
+++ b/agent/lib/core/auth/auth_manager.dart
@@ -24,6 +24,15 @@ class AuthManager {
       _pairingToken != null && _pendingDeviceToken != null;
 
   Future<void> initialize() async {
+    await reload();
+
+    if (_hardwareId == null || _hardwareId!.isEmpty) {
+      _hardwareId = const Uuid().v4();
+      await _saveAuth();
+    }
+  }
+
+  Future<void> reload() async {
     final boundary = SanadHomeBootstrap.identity();
 
     if (boundary.fileExists('auth.json')) {
@@ -41,11 +50,6 @@ class AuthManager {
       } catch (e) {
         // Silently fail if file is malformed
       }
-    }
-
-    if (_hardwareId == null || _hardwareId!.isEmpty) {
-      _hardwareId = const Uuid().v4();
-      await _saveAuth();
     }
   }
 
@@ -91,6 +95,7 @@ class AuthManager {
   }
 
   Future<bool> refreshAccessToken(String portalUrl) async {
+    await reload();
     if (_refreshToken == null || _refreshToken!.isEmpty) {
       _logger.warning('Refresh token is null or empty');
       return false;

--- a/agent/lib/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart
+++ b/agent/lib/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart
@@ -260,6 +260,7 @@ class ServerSanadGatewayPlatform extends BasePlatform
 
   Future<void> _register() async {
     final authManager = getIt<AuthManager>();
+    await authManager.reload();
     final capabilities = await loadSanadCapabilities();
 
     final isPairing = authManager.hasPendingDevicePairing;

--- a/client/lib/features/auth/infrastructure/auth_service.dart
+++ b/client/lib/features/auth/infrastructure/auth_service.dart
@@ -402,6 +402,30 @@ class AuthService {
 
   Future<bool> _refreshAccessTokenInternal() async {
     try {
+      if (AppPlatform.isDesktop) {
+        try {
+          final authDoc = await _settingsStore.readAuthDocument();
+          final fileAccessToken = authDoc['access_token'] as String?;
+          final fileRefreshToken = authDoc['refresh_token'] as String?;
+          if (fileAccessToken != null && fileAccessToken != _backendAccessToken) {
+            _logger.info('Detected updated access token in auth.json. Adopting it.');
+            _backendAccessToken = fileAccessToken;
+            if (fileRefreshToken != null && fileRefreshToken.isNotEmpty) {
+              _backendRefreshToken = fileRefreshToken;
+            }
+            final prefs = await _getPrefs();
+            await prefs.setString('backend_access_token', _backendAccessToken!);
+            if (_backendRefreshToken != null) {
+              await prefs.setString('backend_refresh_token', _backendRefreshToken!);
+            }
+            _emitAccessToken();
+            return true;
+          }
+        } catch (e) {
+          _logger.warning('Failed to sync with auth.json before refresh: $e');
+        }
+      }
+
       if (_backendRefreshToken == null || _backendRefreshToken!.isEmpty) {
         _logger.warning('No refresh token available.');
         return false;


### PR DESCRIPTION
## Problem / Goal
- Allow desktop/daemon environments to dynamically reload auth credentials from auth.json during initialization and access token refresh.
- Sync active desktop backend access tokens and emit events when tokens change in the background.

## Technical Changes
- agent/lib/core/auth/auth_manager.dart: Reload auth document from home boundary on initialization and before refreshing access token.
- agent/lib/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart: Force auth manager reload before registering device capabilities.
- client/lib/features/auth/infrastructure/auth_service.dart: Read latest auth.json before refreshing token, adopting any updated access token in the filesystem and emitting token change events.

## Verification
- Unit tests run and passed in both agent (fvm dart test test/core/auth_test.dart) and client (fvm flutter test test/unit/services/auth_service_test.dart).
- Analyzed client and agent packages with no issues found.
