### PR TITLE
sec(gateway): disable remote workspace management and enforce local-only selection

### DIFF
--- a/agent/lib/interfaces/AGENTS.md
+++ b/agent/lib/interfaces/AGENTS.md
@@ -23,4 +23,6 @@ This contract applies to `agent/lib/interfaces/`.
 ## Runtime Query Boundary
 - The daemon owns workspace browsing/creation, MCP management, skill inventory/load, slash commands, device settings, provider runtime, and conversation history/list queries.
 - Query responses must remain transport-neutral and usable over both local and cloud Sanad transports.
-- Remote filesystem navigation uses daemon-provided roots and parent metadata; clients must not infer host path semantics.
+- Cloud filesystem navigation and workspace-path mutation are disabled at the
+  cloud adapter boundary. Transport-neutral handlers may expose daemon-provided
+  roots and parent metadata only to an admitted local caller.

--- a/agent/lib/interfaces/platforms/sanad_gateway/AGENTS.md
+++ b/agent/lib/interfaces/platforms/sanad_gateway/AGENTS.md
@@ -53,7 +53,11 @@ This contract applies to `agent/lib/interfaces/platforms/sanad_gateway/`.
 - Provider account usage limits (Task 55) are read-only and instance-first: `provider.usage.get` fetches a `ProviderUsageResult` typed `available | unsupported | unavailable | auth_required | failed`; `provider.usage.support` returns per-instance capability flags so clients never hardcode a catalog. Result snapshots never carry credentials or raw provider payloads. Usage failure is fully contained — it must not change instance status, readiness, or the ability to execute model requests.
 - Keep workspace and MCP commands in the single workspace command owner unless architecture documentation explicitly replaces that ownership; do not fragment it by convenience.
 - Workspace browsing starts from real host roots and returns parent metadata; path-only workspace creation derives display name from the folder basename.
-- Remote folder create, rename, and delete remain in the workspace handler, preserve request correlation, return normalized paths, and emit canonical errors for validation or filesystem failures.
+- Workspace filesystem handlers remain transport-neutral for local runtime use,
+  but the cloud adapter rejects remote create, relocate, browse, folder-create,
+  folder-rename, and folder-delete admission before session registration or
+  bridge dispatch. Every rejection preserves request correlation and returns
+  `remote_workspace_management_disabled`.
 - Device settings expose a whitelist only, never secrets, validate the complete mutation before write, report process-environment overrides as externally managed, and acknowledge restart-requiring mutation before scheduling controlled restart.
 - Capabilities remain safe with zero configured providers and do not instantiate adapters or perform provider model discovery.
 - Provider templates hide unimplemented auth flows.

--- a/agent/lib/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart
+++ b/agent/lib/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
+
 import 'package:logging/logging.dart';
 import 'package:socket_io_client/socket_io_client.dart' as io;
 import 'package:sanad_agent/core/auth/auth_manager.dart';
@@ -22,6 +24,19 @@ import 'package:sanad_agent/interfaces/runtime/platform_runtime_bridge.dart';
 
 class ServerSanadGatewayPlatform extends BasePlatform
     with SanadGatewayBehavior {
+  static const _remoteWorkspaceManagementCommands = <String>{
+    CanonicalEventTypes.createWorkspace,
+    CanonicalEventTypes.relocateWorkspace,
+    CanonicalEventTypes.browseWorkspaceTree,
+    CanonicalEventTypes.createFolder,
+    CanonicalEventTypes.renameFolder,
+    CanonicalEventTypes.deleteFolder,
+  };
+  static const _remoteWorkspaceManagementDisabledCode =
+      'remote_workspace_management_disabled';
+  static const _remoteWorkspaceManagementDisabledMessage =
+      'Remote workspace management is disabled for security reasons.';
+
   final _logger = Logger('ServerSanadGatewayPlatform');
 
   @override
@@ -39,6 +54,9 @@ class ServerSanadGatewayPlatform extends BasePlatform
   String? _registeredDeviceId;
 
   io.Socket? get socket => _socket;
+
+  @visibleForTesting
+  set socketForTesting(io.Socket? s) => _socket = s;
 
   @override
   String get platformId => 'sanad_gateway';
@@ -70,18 +88,20 @@ class ServerSanadGatewayPlatform extends BasePlatform
       return;
     }
 
-    final config = getIt<Config>();
-    final gatewayUrl = config.gatewayUrl;
+    if (_socket == null) {
+      final config = getIt<Config>();
+      final gatewayUrl = config.gatewayUrl;
 
-    _logger.info('Connecting to Sanad Gateway at $gatewayUrl...');
+      _logger.info('Connecting to Sanad Gateway at $gatewayUrl...');
 
-    _socket = io.io(
-      gatewayUrl,
-      io.OptionBuilder()
-          .setTransports(['websocket'])
-          .disableAutoConnect()
-          .build(),
-    );
+      _socket = io.io(
+        gatewayUrl,
+        io.OptionBuilder()
+            .setTransports(['websocket'])
+            .disableAutoConnect()
+            .build(),
+      );
+    }
 
     _socket!.onConnect((_) async {
       _logger.info('⚡ Connected to Sanad Gateway');
@@ -162,6 +182,18 @@ class ServerSanadGatewayPlatform extends BasePlatform
           (payload['device_id'] as String?) ??
           '';
 
+      if (_isRemoteWorkspaceManagementCommand(command)) {
+        await _rejectRemoteWorkspaceManagement(
+          command: command!,
+          requestId:
+              envelope['request_id']?.toString() ??
+              payload['request_id']?.toString(),
+          sessionId: sessionId,
+          deviceId: deviceId,
+        );
+        return;
+      }
+
       final bridge = getIt<PlatformRuntimeBridge>();
       bridge.registerSessionClient(
         sessionId,
@@ -203,6 +235,22 @@ class ServerSanadGatewayPlatform extends BasePlatform
     _socket!.on('protocol_event', (data) async {
       final envelope = toMap(data);
       final event = CanonicalEvent.fromJson(envelope);
+      final sessionId =
+          event.sessionId ?? envelope['session_id'] as String? ?? 'default';
+      final deviceId = envelope['device_id'] as String? ?? '';
+
+      if (_isRemoteWorkspaceManagementCommand(event.type)) {
+        await _rejectRemoteWorkspaceManagement(
+          command: event.type,
+          requestId:
+              event.payload['request_id']?.toString() ??
+              envelope['request_id']?.toString(),
+          sessionId: sessionId,
+          deviceId: deviceId,
+        );
+        return;
+      }
+
       final bridge = getIt<PlatformRuntimeBridge>();
       await handleIncomingProtocolEvent(
         event: event,
@@ -213,6 +261,29 @@ class ServerSanadGatewayPlatform extends BasePlatform
     });
 
     _socket!.connect();
+  }
+
+  bool _isRemoteWorkspaceManagementCommand(String? command) =>
+      command != null && _remoteWorkspaceManagementCommands.contains(command);
+
+  Future<void> _rejectRemoteWorkspaceManagement({
+    required String command,
+    required String? requestId,
+    required String sessionId,
+    required String deviceId,
+  }) async {
+    _logger.warning('Blocking remote workspace command: $command');
+    await _emitAgentEvent({
+      'device_id': _registeredDeviceId ?? deviceId,
+      'type': 'event',
+      'event': 'error',
+      'payload': {
+        'request_id': requestId,
+        'code': _remoteWorkspaceManagementDisabledCode,
+        'message': _remoteWorkspaceManagementDisabledMessage,
+      },
+      'session_id': sessionId,
+    });
   }
 
   Future<void> _startVoiceSession(String sessionId, String deviceId) async {

--- a/agent/test/interfaces/server_sanad_gateway_platform_security_test.dart
+++ b/agent/test/interfaces/server_sanad_gateway_platform_security_test.dart
@@ -1,0 +1,310 @@
+import 'dart:io';
+
+import 'package:get_it/get_it.dart';
+import 'package:sanad_agent/core/auth/auth_manager.dart';
+import 'package:sanad_agent/core/config.dart';
+import 'package:sanad_agent/interfaces/platforms/sanad_gateway/protocol/canonical_events.dart';
+import 'package:sanad_agent/interfaces/platforms/sanad_gateway/sanad_protocol_bridge.dart';
+import 'package:sanad_agent/interfaces/platforms/sanad_gateway/server_sanad_gateway_platform.dart';
+import 'package:sanad_agent/interfaces/runtime/local_workspace_runtime_service.dart';
+import 'package:sanad_agent/interfaces/runtime/platform_runtime_bridge.dart';
+import 'package:sanad_agent/interfaces/runtime/platform_session_channel.dart';
+import 'package:socket_io_client/socket_io_client.dart' as socket_io;
+import 'package:socket_io_client/src/manager.dart';
+import 'package:test/test.dart';
+
+const blockedWorkspaceCommands = <String>[
+  CanonicalEventTypes.createWorkspace,
+  CanonicalEventTypes.relocateWorkspace,
+  CanonicalEventTypes.browseWorkspaceTree,
+  CanonicalEventTypes.createFolder,
+  CanonicalEventTypes.renameFolder,
+  CanonicalEventTypes.deleteFolder,
+];
+
+class FakeManager implements Manager {
+  @override
+  Function() on(String event, Function fn) => () {};
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => null;
+}
+
+class FakeSocket implements socket_io.Socket {
+  final Map<String, List<Function>> listeners = {};
+  final List<Map<String, dynamic>> emittedEvents = [];
+  bool isConnected = false;
+
+  @override
+  Function() on(String event, Function fn) {
+    listeners.putIfAbsent(event, () => []).add(fn);
+    return () {};
+  }
+
+  @override
+  socket_io.Socket emit(String event, [dynamic data]) {
+    emittedEvents.add({'event': event, 'data': data});
+    return this;
+  }
+
+  @override
+  socket_io.Socket connect() {
+    isConnected = true;
+    unawaitedTrigger('connect', null);
+    return this;
+  }
+
+  Future<void> trigger(String event, dynamic data) async {
+    for (final callback in listeners[event] ?? const <Function>[]) {
+      final result = callback(data);
+      if (result is Future) {
+        await result;
+      }
+    }
+  }
+
+  void unawaitedTrigger(String event, dynamic data) {
+    for (final callback in listeners[event] ?? const <Function>[]) {
+      callback(data);
+    }
+  }
+
+  @override
+  bool get connected => isConnected;
+
+  @override
+  Manager get io => FakeManager();
+
+  @override
+  void dispose() {
+    listeners.clear();
+    isConnected = false;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeAuthManager extends AuthManager {
+  @override
+  bool get isAuthenticated => true;
+
+  @override
+  String get hardwareId => 'test-device-id';
+}
+
+class TrackingPlatformRuntimeBridge extends PlatformRuntimeBridge {
+  int registeredSessionCount = 0;
+
+  @override
+  void registerSessionClient(
+    String sessionId,
+    PlatformSessionChannel channel, {
+    String? deviceId,
+  }) {
+    registeredSessionCount += 1;
+    super.registerSessionClient(sessionId, channel, deviceId: deviceId);
+  }
+}
+
+class TrackingWorkspaceRuntimeService extends LocalWorkspaceRuntimeService {
+  TrackingWorkspaceRuntimeService({required super.sanadHomePath});
+
+  final List<String> calls = [];
+
+  @override
+  Future<List<Map<String, dynamic>>> listWorkspaces() async {
+    calls.add(CanonicalEventTypes.listWorkspaces);
+    return const [];
+  }
+
+  @override
+  Future<Map<String, dynamic>> createWorkspace({
+    String? name,
+    String? path,
+  }) async {
+    calls.add(CanonicalEventTypes.createWorkspace);
+    return const {};
+  }
+
+  @override
+  Future<Map<String, dynamic>> relocateWorkspace({
+    required String workspaceId,
+    required String newPath,
+  }) async {
+    calls.add(CanonicalEventTypes.relocateWorkspace);
+    return const {};
+  }
+
+  @override
+  Future<Map<String, dynamic>> browseWorkspaceTree({
+    String? workspaceId,
+    String? path,
+    int maxEntries = 200,
+  }) async {
+    calls.add(CanonicalEventTypes.browseWorkspaceTree);
+    return const {};
+  }
+
+  @override
+  Future<String> createFolder({
+    required String parentPath,
+    required String name,
+  }) async {
+    calls.add(CanonicalEventTypes.createFolder);
+    return parentPath;
+  }
+
+  @override
+  Future<String> renameFolder({
+    required String path,
+    required String newName,
+  }) async {
+    calls.add(CanonicalEventTypes.renameFolder);
+    return path;
+  }
+
+  @override
+  Future<String> deleteFolder(String path) async {
+    calls.add(CanonicalEventTypes.deleteFolder);
+    return path;
+  }
+}
+
+void main() {
+  final getIt = GetIt.instance;
+  late Directory tempDir;
+  late FakeSocket socket;
+  late TrackingPlatformRuntimeBridge runtimeBridge;
+  late TrackingWorkspaceRuntimeService workspaceRuntime;
+  late ServerSanadGatewayPlatform platform;
+
+  setUp(() async {
+    getIt.allowReassignment = true;
+    tempDir = await Directory.systemTemp.createTemp('sanad-platform-test');
+    socket = FakeSocket();
+    runtimeBridge = TrackingPlatformRuntimeBridge();
+    workspaceRuntime = TrackingWorkspaceRuntimeService(
+      sanadHomePath: tempDir.path,
+    );
+
+    getIt.registerSingleton<AuthManager>(FakeAuthManager());
+    getIt.registerSingleton<Config>(Config());
+    getIt.registerSingleton<SanadProtocolBridge>(SanadProtocolBridge());
+    getIt.registerSingleton<PlatformRuntimeBridge>(runtimeBridge);
+    getIt.registerSingleton<LocalWorkspaceRuntimeService>(workspaceRuntime);
+
+    platform = ServerSanadGatewayPlatform();
+    platform.socketForTesting = socket;
+    await platform.initialize();
+    await socket.trigger('register_success', {'device_id': 'test-device-id'});
+    socket.emittedEvents.clear();
+  });
+
+  tearDown(() async {
+    await platform.dispose();
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+    await getIt.reset();
+  });
+
+  group('cloud remote workspace admission', () {
+    test(
+      'rejects every execute_command before session or runtime mutation',
+      () async {
+        for (final command in blockedWorkspaceCommands) {
+          socket.emittedEvents.clear();
+
+          await socket.trigger('execute_command', {
+            'command': command,
+            'device_id': 'request-device',
+            'payload': {
+              'request_id': 'req-$command',
+              'session_id': 'sess-123',
+              'workspace_id': 'workspace-1',
+              'path': tempDir.path,
+              'new_path': tempDir.path,
+              'parent_path': tempDir.path,
+              'name': 'blocked-folder',
+              'new_name': 'blocked-folder',
+            },
+          });
+
+          _expectDisabledError(socket.emittedEvents, requestId: 'req-$command');
+        }
+
+        expect(runtimeBridge.registeredSessionCount, 0);
+        expect(workspaceRuntime.calls, isEmpty);
+        expect(
+          Directory('${tempDir.path}/blocked-folder').existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test(
+      'rejects every protocol_event before workspace runtime mutation',
+      () async {
+        for (final eventType in blockedWorkspaceCommands) {
+          socket.emittedEvents.clear();
+
+          await socket.trigger('protocol_event', {
+            'event': eventType,
+            'type': eventType,
+            'session_id': 'sess-123',
+            'payload': {
+              'request_id': 'req-$eventType',
+              'path': tempDir.path,
+              'parent_path': tempDir.path,
+              'name': 'blocked-folder',
+            },
+          });
+
+          _expectDisabledError(
+            socket.emittedEvents,
+            requestId: 'req-$eventType',
+          );
+        }
+
+        expect(workspaceRuntime.calls, isEmpty);
+        expect(
+          Directory('${tempDir.path}/blocked-folder').existsSync(),
+          isFalse,
+        );
+      },
+    );
+
+    test('allows list_workspaces through the cloud adapter', () async {
+      await socket.trigger('execute_command', {
+        'command': CanonicalEventTypes.listWorkspaces,
+        'payload': {'request_id': 'req-list', 'session_id': 'sess-list'},
+      });
+
+      expect(workspaceRuntime.calls, [CanonicalEventTypes.listWorkspaces]);
+      expect(runtimeBridge.registeredSessionCount, 1);
+      final response = socket.emittedEvents.singleWhere(
+        (item) => item['event'] == 'device_event',
+      );
+      final data = response['data'] as Map<String, dynamic>;
+      expect(data['event'], CanonicalEventTypes.workspacesList);
+      expect(data['payload'], containsPair('request_id', 'req-list'));
+    });
+  });
+}
+
+void _expectDisabledError(
+  List<Map<String, dynamic>> emittedEvents, {
+  required String requestId,
+}) {
+  expect(emittedEvents, hasLength(1));
+  final emitted = emittedEvents.single;
+  expect(emitted['event'], 'device_event');
+  final data = emitted['data'] as Map<String, dynamic>;
+  expect(data['type'], 'event');
+  expect(data['event'], 'error');
+  expect(data['session_id'], 'sess-123');
+  final payload = data['payload'] as Map<String, dynamic>;
+  expect(payload['request_id'], requestId);
+  expect(payload['code'], 'remote_workspace_management_disabled');
+}

--- a/client/lib/features/conversations/presentation/AGENTS.md
+++ b/client/lib/features/conversations/presentation/AGENTS.md
@@ -19,8 +19,9 @@ This contract applies to `client/lib/features/conversations/presentation/`.
 - Do not eagerly hydrate history for a session created locally for its first outgoing turn.
 - Block normal message dispatch before session creation when either the provider instance or model selection is absent.
 - Slash queries run only on explicit composer intent and use the daemon query surface, never local skill discovery or mount-time prefetch.
-- Use a native folder picker only for a confirmed same-desktop local device; otherwise use daemon-owned workspace browsing and parent-path metadata.
-- Remote workspace browsing may create, rename, or delete directories through repository intents; keep the current snapshot on failure, refresh after success, and require explicit confirmation before recursive delete.
+- Route every workspace-path picker entry through the shared picker helper. Use
+  the native folder picker only for a confirmed same-desktop local device;
+  remote selection shows the security notice and sends no filesystem command.
 
 ## Delivery Controls
 - Enter/send emits typed automatic intent; Command+Enter and Control+Enter emit typed queue intent.

--- a/client/lib/features/conversations/presentation/widgets/conversation_input_panel.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input_panel.dart
@@ -18,15 +18,13 @@ import 'package:sanad_client/features/conversations/data/repositories/conversati
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/conversation_input_composer.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/conversation_input_slices.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/queued_messages_box.dart';
-import 'package:sanad_client/features/conversations/presentation/widgets/workspace_browser_dialog.dart';
+import 'package:sanad_client/utils/workspace_picker_helper.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/sidebar/sidebar_composition.dart';
 import 'package:sanad_client/features/voice/presentation/bloc/voice_stream_cubit.dart';
 import 'package:sanad_client/features/voice/presentation/bloc/voice_stream_state.dart';
 import 'package:sanad_client/features/voice/presentation/widgets/voice_stream_panel.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/conversation_context_chips.dart';
-import 'package:sanad_client/utils/app_platform.dart';
 import 'package:sanad_client/utils/toast_utils.dart';
-import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sanad_client/features/conversations/domain/models/message_delivery_intent.dart';
@@ -653,16 +651,11 @@ class _ConversationInputPanelState extends State<ConversationInputPanel> {
   }
 
   Future<void> _pickAndCreateWorkspace(DeviceConfig? activeAgent) async {
-    final selectedPath = _shouldUseNativeWorkspacePicker(activeAgent)
-        ? await _pickWorkspacePathLocally()
-        : await showDialog<String>(
-            context: context,
-            builder: (dialogContext) => WorkspaceBrowserDialog(
-              loader: ({path}) {
-                return context.read<ConversationInputCubit>().browseWorkspaceTree(path: path);
-              },
-            ),
-          );
+    final selectedPath = await WorkspacePickerHelper.pickWorkspacePath(
+      context: context,
+      device: activeAgent,
+      debugOverride: ConversationInputPanel.debugPickDirectoryPath,
+    );
     if (!mounted || selectedPath == null || selectedPath.trim().isEmpty) {
       return;
     }
@@ -673,17 +666,6 @@ class _ConversationInputPanelState extends State<ConversationInputPanel> {
     }
 
     ToastUtils.showSuccess(context, 'Workspace selected: ${workspace.name}');
-  }
-
-  bool _shouldUseNativeWorkspacePicker(DeviceConfig? activeAgent) {
-    return AppPlatform.isDesktop && activeAgent?.isLocalReachable == true;
-  }
-
-  Future<String?> _pickWorkspacePathLocally() async {
-    if (ConversationInputPanel.debugPickDirectoryPath != null) {
-      return ConversationInputPanel.debugPickDirectoryPath!();
-    }
-    return getDirectoryPath(confirmButtonText: 'Select Workspace');
   }
 
   Future<bool> _confirmFullAccess() async {

--- a/client/lib/features/conversations/presentation/widgets/sidebar/device_workspace_sidebar.dart
+++ b/client/lib/features/conversations/presentation/widgets/sidebar/device_workspace_sidebar.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:go_router/go_router.dart';
-import 'package:file_selector/file_selector.dart';
 import 'package:material_symbols_icons/symbols.dart';
 
 import '../../../../../core/navigation/app_routes.dart';
@@ -18,11 +17,10 @@ import '../../../domain/models/conversation_resource_state.dart';
 import '../../../domain/models/device_workspace.dart';
 import '../../../domain/models/session.dart';
 import '../../../domain/models/sidebar_conversation_group.dart';
-import '../../../domain/repositories/conversation_repository.dart';
+import '../../../../../utils/workspace_picker_helper.dart';
 import '../../bloc/session_cubit.dart';
 import '../../bloc/session_sidebar_cubit.dart';
 import '../../bloc/session_sidebar_state.dart';
-import '../workspace_browser_dialog.dart';
 import 'sidebar_composition.dart';
 import 'sidebar_device_header_bar.dart';
 import 'sidebar_sections.dart';
@@ -219,8 +217,6 @@ class _SidebarBody extends StatelessWidget {
     final sidebarCubit = context.read<SessionSidebarCubit>();
     final sessionCubit = context.read<SessionCubit>();
     final cacheRepository = context.read<ConversationCacheRepository>();
-    final conversationRepository = context.read<ConversationRepository>();
-
     void selectSession(SessionRef ref) {
       final sessions = cacheRepository.sessionsForDevice(device.id);
       Session? found;
@@ -236,21 +232,12 @@ class _SidebarBody extends StatelessWidget {
       if (isDrawerMode && onClose != null) onClose!();
     }
 
-    bool shouldUseNativeWorkspacePicker(DeviceConfig dev) {
-      return AppPlatform.isDesktop && dev.isLocalReachable;
-    }
-
-    Future<String?> pickWorkspacePathLocally() async {
-      if (DeviceWorkspaceSidebar.debugPickDirectoryPath != null) {
-        return DeviceWorkspaceSidebar.debugPickDirectoryPath!();
-      }
-      return getDirectoryPath(confirmButtonText: 'Select Workspace');
-    }
-
     Future<void> createWorkspace() async {
-      final path = shouldUseNativeWorkspacePicker(device)
-          ? await pickWorkspacePathLocally()
-          : await _pickWorkspacePath(context, device, conversationRepository);
+      final path = await WorkspacePickerHelper.pickWorkspacePath(
+        context: context,
+        device: device,
+        debugOverride: DeviceWorkspaceSidebar.debugPickDirectoryPath,
+      );
       if (path == null || path.trim().isEmpty) return;
       final workspace = await cacheRepository.createWorkspace(device, path: path);
       if (workspace != null && context.mounted) {
@@ -372,28 +359,6 @@ class _SidebarBody extends StatelessWidget {
     createdAt: DateTime.now(),
     updatedAt: DateTime.now(),
   );
-
-  static Future<String?> _pickWorkspacePath(
-    BuildContext context,
-    DeviceConfig device,
-    ConversationRepository conversationRepository,
-  ) async {
-    return showDialog<String>(
-      context: context,
-      builder: (dialogContext) => WorkspaceBrowserDialog(
-        loader: ({path}) {
-          return conversationRepository.browseWorkspaceTree(device, path: path);
-        },
-        onCreateFolder: (parentPath, name) => conversationRepository.createFolder(
-          device,
-          parentPath: parentPath,
-          name: name,
-        ),
-        onRenameFolder: (path, newName) => conversationRepository.renameFolder(device, path: path, newName: newName),
-        onDeleteFolder: (path) => conversationRepository.deleteFolder(device, path: path),
-      ),
-    );
-  }
 }
 
 class _WorkspaceShellSlice extends Equatable {

--- a/client/lib/features/settings/AGENTS.md
+++ b/client/lib/features/settings/AGENTS.md
@@ -6,7 +6,9 @@ This contract applies to `client/lib/features/settings/`.
 ## Destination Ownership
 - `/settings` is the only user-facing settings destination.
 - Workspace deep links carry explicit `device_id` and stable `workspace_id`; Settings selects that inspection scope without changing the active conversation device.
-- Workspace Settings owns display-name rename and Change Path; sidebar workspace rows only navigate to this destination.
+- Workspace Settings owns display-name rename and Change Path; sidebar workspace
+  rows only navigate to this destination. Change Path uses the shared picker
+  boundary and is available only for a confirmed same-desktop local device.
 - Settings mutation failures use the project `ToastUtils` surface with the actionable daemon-provided reason; do not use `SnackBar` or replace known reasons with generic copy.
 - Keep `/agents` as a redirect to the selected device Overview; do not recreate a separate Manage Devices surface.
 - Keep workspace destinations in primary Settings navigation. Show a bounded initial set with Show all / Show less rather than another navigation hierarchy.

--- a/client/lib/features/settings/presentation/screens/settings_screen.dart
+++ b/client/lib/features/settings/presentation/screens/settings_screen.dart
@@ -1,15 +1,13 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:file_selector/file_selector.dart';
 import 'package:go_router/go_router.dart';
 import 'package:sanad_client/core/di/injection.dart';
 import 'package:sanad_client/core/navigation/app_routes.dart';
 import 'package:sanad_client/features/conversations/data/repositories/conversation_cache_repository.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_conversation_cache_snapshot.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_workspace.dart';
-import 'package:sanad_client/features/conversations/domain/repositories/conversation_repository.dart';
-import 'package:sanad_client/features/conversations/presentation/widgets/workspace_browser_dialog.dart';
+import 'package:sanad_client/utils/workspace_picker_helper.dart';
 import 'package:sanad_client/features/devices/domain/models/device_config.dart';
 import 'package:sanad_client/features/devices/presentation/bloc/device_cubit.dart';
 import 'package:sanad_client/features/devices/presentation/bloc/device_state.dart';
@@ -31,7 +29,6 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   final _cache = getIt<ConversationCacheRepository>();
-  final _conversations = getIt<ConversationRepository>();
   SettingsDestination _destination = SettingsDestination.general;
   String? _selectedDeviceId;
   String? _selectedWorkspaceId;
@@ -149,25 +146,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
     DeviceConfig device,
     DeviceWorkspace workspace,
   ) async {
-    final path = AppPlatform.isDesktop && device.isLocalReachable
-        ? await getDirectoryPath(confirmButtonText: 'Change Path')
-        : await showDialog<String>(
-            context: context,
-            builder: (dialogContext) => WorkspaceBrowserDialog(
-              loader: ({path}) => _conversations.browseWorkspaceTree(device, path: path),
-              onCreateFolder: (parentPath, name) => _conversations.createFolder(
-                device,
-                parentPath: parentPath,
-                name: name,
-              ),
-              onRenameFolder: (path, newName) => _conversations.renameFolder(
-                device,
-                path: path,
-                newName: newName,
-              ),
-              onDeleteFolder: (path) => _conversations.deleteFolder(device, path: path),
-            ),
-          );
+    final path = await WorkspacePickerHelper.pickWorkspacePath(
+      context: context,
+      device: device,
+      confirmButtonText: 'Change Path',
+    );
     if (path == null || path.trim().isEmpty) return;
     try {
       await _cache.relocateWorkspace(

--- a/client/lib/utils/workspace_picker_helper.dart
+++ b/client/lib/utils/workspace_picker_helper.dart
@@ -1,0 +1,34 @@
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:sanad_client/features/devices/domain/models/device_config.dart';
+import 'package:sanad_client/utils/app_platform.dart';
+import 'package:sanad_client/utils/toast_utils.dart';
+
+class WorkspacePickerHelper {
+  static const remoteDisabledMessage = 'To create or modify a workspace, you must use a local connection.';
+
+  @visibleForTesting
+  static ValueChanged<String>? debugOnRemoteDisabled;
+
+  /// Opens the native picker locally or explains why remote selection is off.
+  static Future<String?> pickWorkspacePath({
+    required BuildContext context,
+    required DeviceConfig? device,
+    String confirmButtonText = 'Select Workspace',
+    Future<String?> Function()? debugOverride,
+  }) async {
+    final isLocal = AppPlatform.isDesktop && device?.isLocalReachable == true;
+    if (isLocal) {
+      if (debugOverride != null) {
+        return debugOverride();
+      }
+      return getDirectoryPath(confirmButtonText: confirmButtonText);
+    }
+
+    // TODO(security): Restore remote selection only after its filesystem
+    // authorization model has been reviewed and approved.
+    debugOnRemoteDisabled?.call(remoteDisabledMessage);
+    ToastUtils.showError(context, remoteDisabledMessage);
+    return null;
+  }
+}

--- a/client/test/widget/conversation_input_panel_rebuild_test.dart
+++ b/client/test/widget/conversation_input_panel_rebuild_test.dart
@@ -12,8 +12,6 @@ import 'package:sanad_client/features/conversations/domain/stores/conversation_c
 import 'package:sanad_client/features/conversations/domain/models/device_suspended_request.dart';
 import 'package:sanad_client/features/conversations/domain/models/runtime_notice.dart';
 import 'package:sanad_client/features/conversations/domain/models/session.dart';
-import 'package:sanad_client/features/conversations/domain/models/workspace_tree_entry.dart';
-import 'package:sanad_client/features/conversations/domain/models/workspace_tree_snapshot.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_cubit.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_state.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/session_cubit.dart';
@@ -30,6 +28,7 @@ import 'package:sanad_client/features/provider_setup/data/models/provider_instan
 import 'package:sanad_client/features/provider_setup/data/provider_setup_client.dart';
 import 'package:sanad_client/features/provider_setup/presentation/bloc/provider_usage_cubit.dart';
 import 'package:sanad_client/infrastructure/local_tools/workspace_policy.dart';
+import 'package:sanad_client/utils/workspace_picker_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -56,6 +55,7 @@ void main() {
   setUp(() async {
     await getIt.reset();
     ConversationInputPanel.debugPickDirectoryPath = null;
+    WorkspacePickerHelper.debugOnRemoteDisabled = null;
     socket = FakeSanadSocketService();
     socket.autoCapabilitiesPayload = const {
       'supports_workspaces': true,
@@ -97,6 +97,7 @@ void main() {
     ConversationInputPanel.debugOnBottomActionsBuild = null;
     ConversationInputPanel.debugPickDirectoryPath = null;
     ConversationInputPanel.debugOnValidationError = null;
+    WorkspacePickerHelper.debugOnRemoteDisabled = null;
     await sessionMessagesCubit.close();
     await sessionCubit.close();
     await agentCubit.close();
@@ -829,35 +830,16 @@ void main() {
     expect(conversationRepository.createdWorkspaces.single, containsPair('path', '/picked/local-workspace'));
   });
 
-  testWidgets('uses daemon workspace browser for remote agents when adding a workspace', (tester) async {
+  testWidgets('blocks remote workspace creation with a security notice', (tester) async {
     socket.setConnected(true);
-    conversationRepository.browseWorkspaceTreeHandler = ({agent, workspaceId, path}) async {
-      if (path == '/remote/workspace') {
-        return const WorkspaceTreeSnapshot(
-          workspaceId: '',
-          rootPath: '',
-          path: '/remote/workspace',
-          parentPath: '',
-          entries: [],
-          truncated: false,
-        );
-      }
-
-      return const WorkspaceTreeSnapshot(
-        workspaceId: '',
-        rootPath: '',
-        path: '',
-        parentPath: null,
-        entries: [
-          WorkspaceTreeEntry(
-            name: 'remote-workspace',
-            path: '/remote/workspace',
-            relativePath: '/remote/workspace',
-            isDirectory: true,
-          ),
-        ],
-        truncated: false,
-      );
+    var pickerCalled = false;
+    String? disabledMessage;
+    ConversationInputPanel.debugPickDirectoryPath = () async {
+      pickerCalled = true;
+      return '/remote/workspace';
+    };
+    WorkspacePickerHelper.debugOnRemoteDisabled = (message) {
+      disabledMessage = message;
     };
 
     await pumpTestApp(
@@ -873,20 +855,13 @@ void main() {
     await tester.tap(find.byKey(const Key('workspace_selector_btn')));
     await tester.pumpAndSettle();
     await tester.tap(find.text('Add New Workspace'));
-    await tester.pump();
-    await tester.pump();
-
-    expect(find.text('Choose Workspace'), findsOneWidget);
-    expect(conversationRepository.browseWorkspaceTreeRequests, hasLength(1));
-
-    await tester.tap(find.text('remote-workspace'));
-    await tester.pump();
-    await tester.pump();
-    await tester.tap(find.text('Use This Folder'));
     await tester.pumpAndSettle();
 
-    expect(conversationRepository.createdWorkspaces.single, containsPair('path', '/remote/workspace'));
-    expect(conversationRepository.browseWorkspaceTreeRequests.last, containsPair('path', '/remote/workspace'));
+    expect(find.text('Choose Workspace'), findsNothing);
+    expect(disabledMessage, WorkspacePickerHelper.remoteDisabledMessage);
+    expect(pickerCalled, isFalse);
+    expect(conversationRepository.browseWorkspaceTreeRequests, isEmpty);
+    expect(conversationRepository.createdWorkspaces, isEmpty);
   });
 }
 

--- a/docs/qa_maintenance/workspace_folder_management_qa.md
+++ b/docs/qa_maintenance/workspace_folder_management_qa.md
@@ -1,63 +1,67 @@
 ---
 title: "Remote Workspace Folder Management QA"
-description: "Regression matrix for create, rename, delete, validation, correlation, refresh, and error behavior in the remote workspace picker."
+description: "Regression matrix for the temporary cloud workspace-management shutdown and preserved local picker behavior."
 ---
 
 # Remote Workspace Folder Management QA
 
-## Product Boundary
+## Current Product Boundary
 
-- Local same-device workspace selection continues to use the native operating-system folder picker.
-- Folder-management controls appear only in Sanad's daemon-backed remote workspace browser.
-- The browser manages directories, not file contents.
+- Same-device desktop workspace selection continues to use the operating
+  system native folder picker.
+- Remote users may select existing registered workspaces for conversations.
+- Remote workspace creation, relocation, host-path browsing, folder creation,
+  folder rename, and folder deletion are temporarily disabled.
+- The cloud adapter is the enforcement boundary; hiding the Flutter browser is
+  presentation feedback, not the security control.
 
 ## Automated Coverage Matrix
 
 | Area | Required behavior |
 |---|---|
-| Runtime create | Creates one direct child and returns its normalized path. |
-| Runtime create conflicts | Existing files and directories fail rather than being treated as success. |
-| Name validation | Empty, dot, parent traversal, slash, and backslash names fail. |
-| Runtime rename | Renames within the existing parent and returns the new normalized path. |
-| Rename collision | Existing target file, folder, or link leaves the source unchanged. |
-| Runtime delete | Deletes confirmed folders recursively, including nested files. |
-| Protected targets | Files, filesystem roots, missing paths, and symbolic links fail. |
-| Protocol correlation | Every success and error preserves the original request id. |
-| Client transport | Create sends parent plus name; rename and delete send exact target identities. |
-| Client acknowledgment | Only the operation-specific canonical success event completes the request. |
-| Create UI | A valid name invokes the callback and refreshes the current path. |
-| Rename UI | A changed valid name invokes the callback and refreshes the current path. |
-| Delete UI | Cancel performs no mutation; Delete confirms recursive destructive intent and refreshes. |
-| Error UI | Mutation failure keeps the current snapshot visible and renders the failure. |
-| Abstract roots | Empty-path system-root snapshots expose no create, rename, or delete controls. |
-| Daemon boundary | A spawned isolated daemon performs create, rename, and recursive delete over the real socket protocol. |
+| Cloud `execute_command` | Each of the six suspended commands returns `remote_workspace_management_disabled`. |
+| Cloud `protocol_event` | Each equivalent canonical event returns the same structured error. |
+| Correlation | Every rejection preserves the original `request_id` and `session_id`. |
+| No side effects | Rejected commands do not register a session channel, invoke workspace runtime methods, or touch the filesystem. |
+| Allowed queries | `list_workspaces` remains allowed so remote users can choose an existing workspace. |
+| Client warning | A remote picker attempt displays the temporary security message. |
+| No remote browser | Conversation, Sidebar, and Settings use the shared helper, which returns no path remotely and never opens `WorkspaceBrowserDialog`. |
+| Local picker | A confirmed same-desktop local device still opens the native picker and can create or relocate a workspace using the selected path. |
 
 ## Manual Regression Scenarios
 
-### Remote macOS/Linux agent
+### Remote connection
 
-1. Open workspace selection for a remote agent and navigate to a writable directory.
-2. Create a folder and verify it appears after refresh.
-3. Rename that folder and verify the old name disappears.
-4. Add content to the folder, choose Delete, inspect the recursive warning, and cancel; verify the folder remains.
-5. Confirm deletion and verify the folder disappears.
-6. Attempt a duplicate name or a protected location and verify the current listing remains visible with an error.
+1. Connect to a remote device and open the workspace selector.
+2. Verify existing registered workspaces remain selectable.
+3. Choose the action to add a workspace and verify the security notice appears.
+4. Verify no remote browser opens and no workspace is created.
+5. Open Workspace Settings for the remote device and choose Change Path.
+6. Verify the same notice appears and the stored path is unchanged.
+7. Send each suspended command through a protocol test client and verify a
+   correlated `remote_workspace_management_disabled` error is returned without
+   a timeout.
 
-### Remote Windows agent
+### Local same-device connection
 
-1. Open the remote browser at the abstract drive list and verify mutation controls are absent.
-2. Enter a drive and a writable directory; verify controls become available.
-3. Repeat create, rename, cancel-delete, confirmed-delete, duplicate-name, and permission-denied scenarios.
+1. Open workspace selection for the confirmed local desktop device.
+2. Verify the operating system native folder picker opens.
+3. Select a directory and verify local workspace creation still completes.
+4. From Workspace Settings, choose Change Path and verify the native picker and
+   local relocation flow still work.
 
-### Local sanad project
+## Suspended Runtime Coverage
 
-1. Open workspace selection for the confirmed same-device local agent.
-2. Verify the operating system native folder picker still opens.
-3. Verify no Sanad remote-browser folder-management dialog replaces it.
+Keep the existing local unit tests for `LocalWorkspaceRuntimeService` and the
+shared workspace handlers. They validate path normalization, name validation,
+collision handling, symlink and root protection, request correlation, and
+recursive deletion. These are local defense-in-depth tests for dormant shared
+runtime behavior; they do not indicate that cloud filesystem management is
+enabled.
 
-## Safety Regression
+## Release Gate
 
-- Names containing `../`, `..\`, `/`, or `\` never create or rename outside the displayed parent.
-- A filesystem root cannot be renamed or recursively deleted.
-- A symbolic link is not followed and its target is not renamed or deleted.
-- A daemon error cannot be mistaken for success because the envelope transport type is `event`; matching uses the canonical `event` field.
+Do not restore the remote browser or remove the cloud rejection guard until a
+new authorization design has been documented, reviewed, and covered by tests
+for allowed roots, request origin, destructive confirmation, and filesystem
+escape attempts.

--- a/docs/technical/workspace_folder_mutation_protocol.md
+++ b/docs/technical/workspace_folder_mutation_protocol.md
@@ -1,110 +1,66 @@
 ---
 title: "Remote Workspace Folder Mutation Protocol"
-description: "Daemon-owned protocol and validation model for creating, renaming, and deleting folders while selecting a remote workspace."
+description: "Current cloud rejection boundary and suspended design for remote workspace filesystem management."
 ---
 
 # Remote Workspace Folder Mutation Protocol
 
-## Scope
+## Current Security Boundary
 
-Sanad uses two workspace-selection experiences:
+Remote workspace selection and filesystem management are temporarily disabled
+on the cloud Sanad Gateway. The cloud adapter rejects these six commands before
+registering a session channel or forwarding work to the shared protocol bridge:
 
-- A same-device sanad project uses the operating system's native folder picker. Sanad does not replace or augment the native picker's folder-management behavior.
-- A remote agent uses `WorkspaceBrowserDialog` and the daemon-owned workspace tree. This browser supports creating, renaming, and deleting directories before the user chooses a workspace path.
+- `create_workspace`
+- `workspace.relocate`
+- `browse_workspace_tree`
+- `workspace.create_folder`
+- `workspace.rename_folder`
+- `workspace.delete_folder`
 
-The feature manages directories only. It does not create files or edit file contents.
+Both `execute_command` and `protocol_event` envelopes receive an `error` event
+with the original `request_id`, the code
+`remote_workspace_management_disabled`, and a user-presentable message. A
+rejected request must not reach `LocalWorkspaceRuntimeService` or mutate the
+host filesystem.
 
-## Ownership and Flow
+The boundary belongs to the cloud adapter because the same canonical protocol
+and runtime handlers serve trusted same-device flows. The shared
+`SanadProtocolBridge`, workspace handlers, local runtime service, and operating
+system native picker remain unchanged.
 
-```text
-WorkspaceBrowserDialog
-  -> ConversationRepository
-  -> ConversationClient
-  -> ConversationCommands
-  -> Sanad device command
-  -> SanadProtocolBridge
-  -> WorkspaceCommandHandler
-  -> LocalWorkspaceRuntimeService
-  -> host filesystem
-```
+## Client Behavior
 
-The client sends user intent and refreshes the current tree after success. The daemon validates and executes every filesystem mutation. Client-side validation exists only for immediate feedback and is not an authority boundary.
+The conversation composer, device workspace sidebar, and Workspace Settings
+share one picker decision helper:
 
-## Canonical Commands
+- A confirmed same-desktop local device opens the operating system native
+  folder picker.
+- Every other connection shows an English security notice and returns no path.
+- The remote browser dialog is not opened and no remote workspace mutation is
+  sent.
 
-### Create folder
+Existing registered workspaces remain available for remote conversation use.
+Only creating a workspace, changing its path, browsing host paths, and mutating
+folders through the remote picker are suspended.
 
-Command: `workspace.create_folder`
+## Suspended Historical Design
 
-Payload:
+The codebase still contains transport-neutral workspace handlers and runtime
+validation that previously supported a daemon-backed remote browser. That
+design allowed the client to browse host roots and request folder creation,
+rename, or recursive deletion before selecting a workspace. It is retained for
+local runtime compatibility and future security redesign, but it is not an
+active cloud product capability.
 
-```json
-{
-  "request_id": "opaque-request-id",
-  "parent_path": "/selected/parent",
-  "name": "new-folder"
-}
-```
+If this design is restored, it requires a separately reviewed authorization
+model that constrains visible roots and filesystem mutations. Removing only the
+client warning or only the cloud adapter guard is not sufficient to restore the
+feature safely.
 
-Success event: `workspace.folder_created`
+## Historical Runtime Validation
 
-```json
-{
-  "request_id": "opaque-request-id",
-  "path": "/selected/parent/new-folder"
-}
-```
-
-Create is non-recursive and fails if any filesystem entity already owns the target name.
-
-### Rename folder
-
-Command: `workspace.rename_folder`
-
-Payload:
-
-```json
-{
-  "request_id": "opaque-request-id",
-  "path": "/selected/parent/old-name",
-  "new_name": "new-name"
-}
-```
-
-Success event: `workspace.folder_renamed`, carrying the request id and normalized resulting `path`.
-
-### Delete folder
-
-Command: `workspace.delete_folder`
-
-Payload:
-
-```json
-{
-  "request_id": "opaque-request-id",
-  "path": "/selected/parent/folder"
-}
-```
-
-Success event: `workspace.folder_deleted`, carrying the request id and normalized deleted `path`.
-
-Delete is recursive. The client must show an explicit destructive confirmation describing that nested files and folders will also be deleted.
-
-## Failure Contract
-
-Validation or operating-system failures return a canonical `error` event with the original `request_id` and a user-presentable `message`. The client accepts a mutation only when the event name exactly matches the expected success event; a null, error, timeout, or unrelated response is failure.
-
-After failure, the remote picker keeps the current tree visible and presents the error. After success, it reloads the current daemon-owned path.
-
-## Validation Model
-
-A folder name is exactly one path segment. Empty names, `.`, `..`, `/`, and `\` separators are rejected by the daemon.
-
-Create requires an existing concrete parent directory. Rename and delete require an existing directory and reject:
-
-- regular files and missing entities;
-- symbolic links;
-- filesystem roots;
-- rename destinations already occupied by any file, directory, or link.
-
-The abstract Windows system-roots snapshot has an empty path and exposes no mutation controls. Host filesystem permissions remain authoritative for locations that pass structural validation.
+The suspended handlers reject invalid names, symbolic links, filesystem roots,
+missing paths, and conflicting rename targets. Those checks remain useful as
+defense in depth and are covered by local runtime tests, but they do not replace
+the current cloud admission boundary.


### PR DESCRIPTION
## Problem / Goal

Remote workspace selection and directory/folder mutation operations (create, rename, delete) present security implications when exposed remotely via the cloud gateway without an established and audited path authorization/permissions model.

To mitigate this security boundary, remote workspace folder selection and mutation commands are temporarily disabled when connecting via the cloud adapter, falling back strictly to same-device local native picker execution.

## Changes

- **Cloud Adapter Admission Boundary:**
  - Added interception in `ServerSanadGatewayPlatform` for remote workspace commands: `create_workspace`, `workspace.relocate`, `browse_workspace_tree`, `workspace.create_folder`, `workspace.rename_folder`, `workspace.delete_folder`.
  - Blocked commands return an error event with code `remote_workspace_management_disabled` and a descriptive message before reaching the shared protocol bridge or mutating the host filesystem.
- **Client Fallback:**
  - Created a unified `WorkspacePickerHelper` shared by the conversation composer, workspace sidebar, and settings screen.
  - Desktop-local connections open the operating system's native folder picker.
  - Remote connections display an English security message and block workspace modifications.
- **Documentation & QA Guidelines:**
  - Updated specifications in `docs/technical/workspace_folder_mutation_protocol.md` and QA test scripts in `docs/qa_maintenance/workspace_folder_management_qa.md`.
- **Security Tests:**
  - Added robust unit test coverage in `agent/test/interfaces/server_sanad_gateway_platform_security_test.dart` asserting command rejection boundaries.
  - Added client unit/widget test coverage in `client/test/widget/conversation_input_panel_rebuild_test.dart`.

## Verification

### Automated Tests
- Ran agent security tests:
  - `fvm dart test test/interfaces/server_sanad_gateway_platform_security_test.dart` -> All passed.
- Ran client widget tests:
  - `fvm flutter test test/widget/conversation_input_panel_rebuild_test.dart` -> All passed.
- Analyzers:
  - `fvm flutter analyze` in client -> clean.
  - `fvm dart analyze` in agent -> clean.
