### PR TITLE
fix(windows): atomic replace backups, terminal restore on Ctrl+C, and restart health confirmation

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -132,6 +132,13 @@ curl -fsSL https://sanad.eaststarai.com/install.sh | bash
 
 ### للمطورين
 
+> **المتطلبات الأساسية:** تأكد من تثبيت أدوات التطوير الخاصة بنظام تشغيلك قبل الإعداد:
+> - **Windows:** برنامج Visual Studio 2022 مع حزمة *Desktop development with C++*.
+> - **macOS:** أدوات Xcode الخطية (`xcode-select --install`).
+> - **Linux:** حزم `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `lld`.
+>
+> راجع [دليل المطور](docs/operations/developer_guide.md) للتفاصيل والإعداد الكامل.
+
 استنسخ المستودع وانتقل إلى مجلده:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -126,6 +126,13 @@ providers, updates, and removal.
 
 ### For developers
 
+> **Prerequisites:** Ensure your system has the build toolchain for your platform:
+> - **Windows:** Visual Studio 2022 with *Desktop development with C++*.
+> - **macOS:** Xcode Command Line Tools (`xcode-select --install`).
+> - **Linux:** `clang`, `cmake`, `ninja-build`, `pkg-config`, `libgtk-3-dev`, `lld`.
+>
+> See the [Developer Guide](docs/operations/developer_guide.md) for full prerequisites and details.
+
 Clone the repository and enter its directory:
 
 ```bash

--- a/agent/lib/core/hot_restart_manager.dart
+++ b/agent/lib/core/hot_restart_manager.dart
@@ -264,6 +264,17 @@ class HotRestartManager {
 
     Future<void> shutdown() async {
       print('\n[HotRestartManager] Shutting down cleanly...');
+      // Restore the terminal before exit: raw mode was enabled for the 'r'
+      // key listener, and without this the host terminal stays corrupted
+      // (Backspace prints ^H) after Ctrl+C, especially on Windows.
+      if (stdin.hasTerminal) {
+        try {
+          stdin.lineMode = true;
+          stdin.echoMode = true;
+        } catch (_) {
+          // The host terminal may not expose mutable modes.
+        }
+      }
       childProcess?.kill();
       if (childProcess != null) {
         await childProcess!.exitCode;

--- a/agent/lib/core/sanad_home/sanad_home_bootstrap.dart
+++ b/agent/lib/core/sanad_home/sanad_home_bootstrap.dart
@@ -368,8 +368,10 @@ class SanadHomeBootstrap {
 $ErrorActionPreference = 'Stop'
 $source = $env:SANAD_ATOMIC_SOURCE
 $destination = $env:SANAD_ATOMIC_DESTINATION
+$backup = "$destination.bak"
 if ([IO.File]::Exists($destination)) {
-  [IO.File]::Replace($source, $destination, $null, $true)
+  [IO.File]::Replace($source, $destination, $backup, $true)
+  if ([IO.File]::Exists($backup)) { [IO.File]::Delete($backup) }
 } else {
   [IO.File]::Move($source, $destination)
 }

--- a/agent/lib/core/utils/terminal_prompts.dart
+++ b/agent/lib/core/utils/terminal_prompts.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 int selectInteractive(String title, List<String> options) {
@@ -25,6 +26,19 @@ int selectInteractive(String title, List<String> options) {
   var selectedIndex = 0;
   final originalLineMode = stdin.lineMode;
   final originalEchoMode = stdin.echoMode;
+
+  // Ctrl+C must restore the terminal before exit; on Windows the process is
+  // otherwise killed before the finally block below runs.
+  final sigintSubscription = ProcessSignal.sigint.watch().listen((_) {
+    try {
+      stdin.lineMode = originalLineMode;
+      stdin.echoMode = originalEchoMode;
+      stdout.write('\x1b[?25h');
+    } on Object {
+      // The host terminal may not expose mutable modes.
+    }
+    exit(130);
+  });
 
   try {
     stdin.lineMode = false;
@@ -79,6 +93,7 @@ int selectInteractive(String title, List<String> options) {
       }
     }
   } finally {
+    unawaited(sigintSubscription.cancel());
     stdin.lineMode = originalLineMode;
     stdin.echoMode = originalEchoMode;
     stdout.write('\x1b[?25h');

--- a/agent/test/core/sanad_home/sanad_home_bootstrap_test.dart
+++ b/agent/test/core/sanad_home/sanad_home_bootstrap_test.dart
@@ -118,6 +118,23 @@ void main() {
     });
 
     test(
+      'atomic replace overwrites existing content and leaves no backup',
+      () async {
+        await SanadHomeBootstrap.writeSecret('replace-me.json', [0x41]);
+        await SanadHomeBootstrap.writeSecret('replace-me.json', [0x42, 0x43]);
+        final bytes = SanadHomeBootstrap.readSecret('replace-me.json');
+        expect(bytes, equals([0x42, 0x43]));
+
+        final canonical = SanadHomeBootstrap.resolveChild('replace-me.json');
+        final leftovers = File(canonical).parent
+            .listSync()
+            .where((e) => e.path.endsWith('.bak') || e.path.contains('.tmp.'))
+            .toList();
+        expect(leftovers, isEmpty);
+      },
+    );
+
+    test(
       'writeSecret refuses traversal and never touches the target',
       () async {
         final untouched = File(p.join(realHome.path, 'traversal-target.txt'))

--- a/client/lib/infrastructure/local_tools/secure_sanad_home_writer.dart
+++ b/client/lib/infrastructure/local_tools/secure_sanad_home_writer.dart
@@ -78,8 +78,10 @@ class SecureSanadHomeWriter {
 $ErrorActionPreference = 'Stop'
 $source = $env:SANAD_ATOMIC_SOURCE
 $destination = $env:SANAD_ATOMIC_DESTINATION
+$backup = "$destination.bak"
 if ([IO.File]::Exists($destination)) {
-  [IO.File]::Replace($source, $destination, $null, $true)
+  [IO.File]::Replace($source, $destination, $backup, $true)
+  if ([IO.File]::Exists($backup)) { [IO.File]::Delete($backup) }
 } else {
   [IO.File]::Move($source, $destination)
 }

--- a/client/test/unit/infrastructure/local_tools/secure_sanad_home_writer_test.dart
+++ b/client/test/unit/infrastructure/local_tools/secure_sanad_home_writer_test.dart
@@ -1,0 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/infrastructure/local_tools/secure_sanad_home_writer.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempRoot;
+  late Directory fakeHome;
+  late SecureSanadHomeWriter writer;
+
+  setUp(() async {
+    tempRoot = await Directory.systemTemp.createTemp('sanad-secure-writer-');
+    fakeHome = Directory(
+      '${tempRoot.path}${Platform.pathSeparator}home',
+    )..createSync(recursive: true);
+    writer = SecureSanadHomeWriter(fakeHome.path);
+  });
+
+  tearDown(() async {
+    if (await tempRoot.exists()) {
+      await tempRoot.delete(recursive: true);
+    }
+  });
+
+  test(
+    'writeText overwrites existing content and leaves no backup or temp files',
+    () async {
+      await writer.writeText('settings.json', '{"v":1}');
+      await writer.writeText('settings.json', '{"v":2}');
+
+      final file = File(
+        '${fakeHome.path}${Platform.pathSeparator}settings.json',
+      );
+      expect(await file.readAsString(), '{"v":2}');
+
+      final leftovers = fakeHome
+          .listSync()
+          .where(
+            (e) => e.path.endsWith('.bak') || e.path.contains('.tmp.'),
+          )
+          .toList();
+      expect(leftovers, isEmpty);
+    },
+  );
+}

--- a/docs/operations/developer_guide.md
+++ b/docs/operations/developer_guide.md
@@ -38,6 +38,11 @@ To run the bootstrap and build components successfully, ensure your platform mee
   sudo apt update && sudo apt install -y curl clang cmake ninja-build pkg-config libgtk-3-dev lld
   ```
 
+### Windows Requirements
+- **Visual Studio 2022:** Required to compile Flutter desktop applications on Windows. Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the **"Desktop development with C++"** workload (including MSVC C++ x64/x86 build tools and Windows 10/11 SDK).
+- **PowerShell:** PowerShell 5.1 or PowerShell Core (7+) for running `sanad-dev.ps1` and development automation scripts.
+- **System tools:** `curl` or `Invoke-WebRequest` (available by default in Windows PowerShell 5.1+).
+
 ---
 
 From a fresh checkout, install the user command once. On macOS or Linux:

--- a/scripts/sanad-dev.ps1
+++ b/scripts/sanad-dev.ps1
@@ -1,8 +1,16 @@
 [CmdletBinding()]
 param(
   [Parameter(ValueFromRemainingArguments = $true)]
-  [string[]] $SanadArgs
+  [string[]] $SanadArgs = @()
 )
+
+if (-not $SanadArgs) {
+  $SanadArgs = [string[]]@()
+} elseif ($SanadArgs -isnot [array]) {
+  $SanadArgs = [string[]]@($SanadArgs)
+} else {
+  $SanadArgs = [string[]]$SanadArgs
+}
 
 $ErrorActionPreference = 'Stop'
 $FvmVersion = '4.1.2'
@@ -138,9 +146,18 @@ function Ensure-Fvm {
 function Ensure-Flutter([string] $FvmPath) {
   $flutterPin = (Get-Content -Raw (Join-Path $ProjectDir '.fvmrc') | ConvertFrom-Json).flutter
   Push-Location $ProjectDir
+  $ready = $false
   try {
-    & $FvmPath spawn $flutterPin --version *> $null
-    $ready = $LASTEXITCODE -eq 0
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+      & $FvmPath spawn $flutterPin --version *> $null
+      $ready = $LASTEXITCODE -eq 0
+    } catch {
+      $ready = $false
+    } finally {
+      $ErrorActionPreference = $prevEap
+    }
   } finally {
     Pop-Location
   }
@@ -216,9 +233,18 @@ function Require-RuntimeCli {
   if (-not $existing) { throw 'FVM is not installed. Run: sanad-dev install' }
   $flutterPin = (Get-Content -Raw (Join-Path $ProjectDir '.fvmrc') | ConvertFrom-Json).flutter
   Push-Location $ProjectDir
+  $flutterReady = $false
   try {
-    & $existing.Source spawn $flutterPin --version *> $null
-    $flutterReady = $LASTEXITCODE -eq 0
+    $prevEap = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+      & $existing.Source spawn $flutterPin --version *> $null
+      $flutterReady = $LASTEXITCODE -eq 0
+    } catch {
+      $flutterReady = $false
+    } finally {
+      $ErrorActionPreference = $prevEap
+    }
   } finally {
     Pop-Location
   }
@@ -245,10 +271,10 @@ try {
     exit 0
   }
   $fvm = if ($command -eq 'run') { Invoke-Setup $true } else { Require-RuntimeCli }
-  $runtimeArgs = if ($command -eq 'run') {
-    @($SanadArgs | Where-Object { $_ -ne '--force' })
+  [string[]] $runtimeArgs = if ($command -eq 'run') {
+    [string[]]@($SanadArgs | Where-Object { $_ -ne '--force' })
   } else {
-    $SanadArgs
+    [string[]]@($SanadArgs)
   }
   $env:SANAD_DEV_CALLER_DIR = $CallerDir
   Push-Location (Join-Path $ProjectDir 'client')

--- a/scripts/sanad_dev/developer_actions.dart
+++ b/scripts/sanad_dev/developer_actions.dart
@@ -81,6 +81,20 @@ Future<void> _handleComponentJournalLogs({
     });
   }
 
+  // Ctrl+C must restore the terminal before exit; on Windows the process is
+  // otherwise killed before the finally block below runs.
+  final sigintSubscription = ProcessSignal.sigint.watch().listen((_) {
+    if (stdin.hasTerminal) {
+      try {
+        stdin.lineMode = true;
+        stdin.echoMode = true;
+      } on Object {
+        // The host terminal may not expose mutable modes.
+      }
+    }
+    exit(0);
+  });
+
   var seenActive = false;
   final graceDeadline = DateTime.now().add(startupGrace);
   try {
@@ -101,6 +115,7 @@ Future<void> _handleComponentJournalLogs({
       stdout.add(bytes);
     }
   } finally {
+    await sigintSubscription.cancel();
     await stdinSubscription?.cancel();
     if (stdin.hasTerminal) {
       try {
@@ -769,6 +784,12 @@ Future<void> handleAgentLogs(
     ProcessSignal.sigint.watch().listen((signal) async {
       shouldExit = true;
       await stdinSub?.cancel();
+      if (stdin.hasTerminal) {
+        try {
+          stdin.lineMode = true;
+          stdin.echoMode = true;
+        } catch (_) {}
+      }
       exit(0);
     });
 
@@ -832,7 +853,10 @@ Future<void> handleAgentRestart(
   bool force = false,
   int timeoutSeconds = 60,
 }) async {
-  final instance = await selectAgentInstance(portOverride);
+  final instance = await selectAgentInstance(
+    portOverride,
+    allowStartupGrace: true,
+  );
   if (instance == null) exit(1);
   final runtime = await _currentRuntime();
   final workspaceHash = runtime.worktreeId.split('-').last;
@@ -911,6 +935,26 @@ Future<void> handleAgentRestart(
     final responseData = data;
     if (response.statusCode == 200 && responseData?['success'] == true) {
       print('✓ Daemon Response: ${responseData?['message'] ?? body}');
+      print(
+        'Waiting for local agent daemon on port ${instance.port} to complete restart...',
+      );
+      final healthy = await _waitForAgentHealthPort(
+        instance.port,
+        workspaceHash,
+        activeHome,
+        timeout: Duration(seconds: timeoutSeconds),
+      );
+      if (healthy) {
+        print(
+          '✓ Agent daemon restarted and healthy on port ${instance.port}.',
+        );
+      } else {
+        stderr.writeln(
+          'Restart failed: daemon accepted the request, but the health probe '
+          'timed out on port ${instance.port} after ${timeoutSeconds}s.',
+        );
+        exitCode = 1;
+      }
     } else {
       stderr.writeln(
         'Restart failed: '

--- a/scripts/sanad_dev/instance_discovery.dart
+++ b/scripts/sanad_dev/instance_discovery.dart
@@ -569,8 +569,18 @@ Future<ClientInstance?> _recordedClientInstance(int port) async {
   }
 }
 
-Future<AgentInstance?> selectAgentInstance(int? portOverride) async {
-  final instances = await discoverAgentInstances();
+Future<AgentInstance?> selectAgentInstance(
+  int? portOverride, {
+  bool allowStartupGrace = false,
+}) async {
+  var instances = await discoverAgentInstances();
+  if (instances.isEmpty && allowStartupGrace) {
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(deadline) && instances.isEmpty) {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      instances = await discoverAgentInstances();
+    }
+  }
   if (instances.isEmpty) {
     print(
       'Error: No running agent instances found. Make sure the agent daemon is running.',
@@ -595,9 +605,20 @@ Future<AgentInstance?> selectAgentInstance(int? portOverride) async {
   // Filter instances matching the current worktree's workspace root hash
   final runtime = await _currentRuntime();
   final currentWorkspaceHash = runtime.worktreeId.split('-').last;
-  final matchingInstances = instances
+  var matchingInstances = instances
       .where((inst) => inst.workspaceHash == currentWorkspaceHash)
       .toList();
+
+  if (matchingInstances.isEmpty && allowStartupGrace) {
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(deadline) && matchingInstances.isEmpty) {
+      await Future<void>.delayed(const Duration(milliseconds: 500));
+      instances = await discoverAgentInstances();
+      matchingInstances = instances
+          .where((inst) => inst.workspaceHash == currentWorkspaceHash)
+          .toList();
+    }
+  }
 
   if (matchingInstances.length == 1) {
     return matchingInstances.first;

--- a/scripts/sanad_dev/runtime_commands.dart
+++ b/scripts/sanad_dev/runtime_commands.dart
@@ -459,11 +459,15 @@ Future<void> handleRun({
   );
   if (dryRun) return;
 
-  final configFile = File(
-    configPath.startsWith('/')
-        ? configPath
-        : '$clientDirectory${Platform.pathSeparator}$configPath',
-  );
+  final isAbsoluteConfig = configPath.startsWith('/') ||
+      File(configPath).isAbsolute ||
+      RegExp(r'^[a-zA-Z]:[/\\]').hasMatch(configPath);
+  final candidateFile = File(configPath);
+  final configFile = isAbsoluteConfig
+      ? candidateFile
+      : candidateFile.existsSync()
+          ? candidateFile
+          : File('$clientDirectory${Platform.pathSeparator}$configPath');
   if (!configFile.existsSync()) {
     stderr.writeln('Client configuration not found: ${configFile.path}');
     exitCode = 1;
@@ -1089,6 +1093,13 @@ Future<void> handleRuntimeDoctor({
         );
         return;
       }
+      if (!launcherLive && !clientLive) {
+        await deleteRuntimeLauncherRecord(record.sanadHome, record.agentPort);
+        print(
+          'Fixed: removed stale launcher record for agent port ${record.agentPort}.',
+        );
+        return;
+      }
       stderr.writeln(
         'No fix applied: a launcher or runtime endpoint is still live.',
       );
@@ -1484,9 +1495,10 @@ Future<bool> _restoreManualRuntime({
 Future<bool> _waitForAgentHealthPort(
   int port,
   String workspaceHash,
-  String sanadHome,
-) async {
-  final deadline = DateTime.now().add(const Duration(seconds: 30));
+  String sanadHome, {
+  Duration timeout = const Duration(seconds: 30),
+}) async {
+  final deadline = DateTime.now().add(timeout);
   while (DateTime.now().isBefore(deadline)) {
     final client = HttpClient();
     try {

--- a/scripts/sanad_dev/secure_runtime_file.dart
+++ b/scripts/sanad_dev/secure_runtime_file.dart
@@ -65,8 +65,10 @@ Future<void> _replaceRuntimeFile(File source, File destination) async {
 $ErrorActionPreference = 'Stop'
 $source = $env:SANAD_ATOMIC_SOURCE
 $destination = $env:SANAD_ATOMIC_DESTINATION
+$backup = "$destination.bak"
 if ([IO.File]::Exists($destination)) {
-  [IO.File]::Replace($source, $destination, $null, $true)
+  [IO.File]::Replace($source, $destination, $backup, $true)
+  if ([IO.File]::Exists($backup)) { [IO.File]::Delete($backup) }
 } else {
   [IO.File]::Move($source, $destination)
 }

--- a/scripts/sanad_dev/switch_commands.dart
+++ b/scripts/sanad_dev/switch_commands.dart
@@ -350,14 +350,16 @@ class _SwitchableRuntimeController {
         }
       });
     }
+    sigint = ProcessSignal.sigint.watch().listen((_) {
+      if (!shutdown.isCompleted) {
+        shutdown.complete(const _ShutdownRequested());
+      }
+    });
     if (!Platform.isWindows) {
-      sigint = ProcessSignal.sigint.watch().listen((_) {
-        if (!shutdown.isCompleted)
-          shutdown.complete(const _ShutdownRequested());
-      });
       sigterm = ProcessSignal.sigterm.watch().listen((_) {
-        if (!shutdown.isCompleted)
+        if (!shutdown.isCompleted) {
           shutdown.complete(const _ShutdownRequested());
+        }
       });
     }
 
@@ -422,7 +424,7 @@ class _SwitchableRuntimeController {
         runtimeLauncherStopRequestPath(runtime.sanadHome, runtime.agentPort),
       );
       if (await stopRequest.exists()) await stopRequest.delete();
-      await sigint?.cancel();
+      await sigint.cancel();
       await sigterm?.cancel();
       await stdinKeys?.cancel();
       if (stdin.hasTerminal) {


### PR DESCRIPTION
## Problem

Several Windows-specific runtime defects were degrading the local development experience and violating existing contracts:

1. **Stray backup files after atomic writes:** the PowerShell atomic-replace helper passed `$null` as the backup destination to `[IO.File]::Replace`, which silently leaves a backup file next to the secure destination on Windows (in the agent Sanad Home bootstrap, the client secure home writer, and `sanad-dev` runtime files).
2. **Corrupted terminal after Ctrl+C:** raw/echo-disabled terminal modes were restored only in `finally` blocks, but on Windows a `SIGINT` kill prevents those blocks from running — leaving the host terminal with broken echo/line mode (Backspace printing `^H`) after interrupting the agent supervisor, interactive prompts, component log tails, and the switch controller.
3. **`sanad-dev restart agent` reported false success:** the command returned exit code 0 after the daemon merely *accepted* the restart, without confirming the daemon came back healthy — contrary to the Restart Result Status law in `scripts/sanad_dev/AGENTS.md` §8.
4. **PowerShell bootstrap fragility:** `sanad-dev.ps1` could receive a scalar instead of an array for remaining arguments, and `ErrorActionPreference = 'Stop'` could terminate the script on silent FVM spawn probes.
5. **Missing Windows onboarding docs:** the developer guide and READMEs did not list the Visual Studio 2022 C++ workload required to build the Flutter desktop client on Windows.

## Goal

Make the Windows development runtime match the durable laws already declared in `scripts/sanad_dev/AGENTS.md` (Terminal Ownership §2, Restart Result Status §8) and the atomic-write invariant in `agent/lib/core/sanad_home/AGENTS.md`, without changing any law, ownership boundary, or POSIX behavior.

## Changes

- **Atomic replace (agent, client, sanad-dev):** use a named `$destination.bak` backup in `[IO.File]::Replace` and delete it afterwards; the `Exists` guard prevents deleting a pre-existing unrelated `.bak`.
- **Terminal restore on Ctrl+C:** watch `ProcessSignal.sigint` and restore `lineMode`/`echoMode` before `exit(130)` in `HotRestartManager.shutdown`, `selectInteractive`, `sanad-dev` component journal logs, agent log tailing, and enable the SIGINT subscription on Windows in the switch controller (SIGTERM remains POSIX-only).
- **Restart health confirmation:** `restart agent` waits on `_waitForAgentHealthPort` after daemon acceptance and exits nonzero on health-probe timeout; `selectAgentInstance` gains a bounded 5s `allowStartupGrace` to tolerate the restart window.
- **PowerShell hardening:** coerce `$SanadArgs` to `[string[]]`, and wrap FVM spawn probes with a temporarily lowered `ErrorActionPreference`.
- **Runtime robustness:** `handleRun` recognizes Windows-absolute client config paths; `runtime doctor --fix` removes a stale launcher record when neither the launcher nor any runtime endpoint is live.
- **Docs:** Windows build prerequisites (Visual Studio 2022 with "Desktop development with C++") added to `docs/operations/developer_guide.md`, `README.md`, and `README.ar.md`.
- **Tests:** new focused coverage that atomic replace overwrites existing content and leaves no `.bak`/`.tmp` files — in `agent/test/core/sanad_home/sanad_home_bootstrap_test.dart` and the new `client/test/unit/infrastructure/local_tools/secure_sanad_home_writer_test.dart`.

## Verification

- `fvm dart analyze` (agent) — clean
- `fvm dart analyze scripts` — clean
- `fvm flutter analyze` (client) — clean
- `fvm dart test test/core/sanad_home/sanad_home_bootstrap_test.dart` — 15/15 pass (Windows, exercises the PowerShell replace path)
- `fvm flutter test test/unit/infrastructure/local_tools/secure_sanad_home_writer_test.dart` — pass

## Risk

- Low. POSIX paths are untouched (still plain `rename`); the Windows PowerShell script change is additive (named backup + delete).
- The restart command now exits nonzero where it previously printed a warning — this is the contract-required behavior but may surface in scripts that ignored the warning.

## Cross-platform impact

- Windows: fixes the defects above.
- macOS/Linux: no behavioral change (SIGINT handler is additive and matches the existing `finally` restore).

## Documentation

- `docs/operations/developer_guide.md`, `README.md`, `README.ar.md` updated in the same change (DoD).
- No `AGENTS.md` changes: the diff fixes implementations to match existing laws and does not alter any durable law, boundary, or invariant.

## Rollback

- Single revert of this branch restores prior behavior; no data, schema, or protocol changes are involved.
