### PR TITLE
fix(sanad-dev): resolve deferred switch recovery and client identity race

### DIFF
--- a/agent/lib/engine/agent_runner.dart
+++ b/agent/lib/engine/agent_runner.dart
@@ -36,6 +36,7 @@ import 'adapters/llm_http_exception.dart';
 import 'adapters/rate_limited_llm_adapter.dart';
 import 'adapters/provider_state_rejected_exception.dart';
 import 'runtime/continuation_checkpoint_coordinator.dart';
+import 'runtime/deferred_tool_result.dart';
 import 'runtime/llm_route_snapshot.dart';
 import 'runtime/response_continuation_coordinator.dart';
 import 'runtime/steer_coordinator.dart' as steer_lib;
@@ -55,6 +56,7 @@ class AgentRunner {
   final SessionManager sessionManager;
   final PluginManager pluginManager;
   final ContextEngine contextEngine;
+  final DeferredToolResultResolver? _deferredToolResultResolver;
   late final FileMemoryStore memoryStore;
   late final String sessionId;
 
@@ -244,8 +246,10 @@ class AgentRunner {
     PluginManager? pluginManager,
     ContextEngine? contextEngine,
     String? existingSessionId,
+    DeferredToolResultResolver? deferredToolResultResolver,
   }) : pluginManager = pluginManager ?? PluginManager(),
-       contextEngine = contextEngine ?? ContextEngine(adapter: adapter) {
+       contextEngine = contextEngine ?? ContextEngine(adapter: adapter),
+       _deferredToolResultResolver = deferredToolResultResolver {
     if (existingSessionId != null) {
       final session = sessionManager.getSession(existingSessionId);
       if (session != null) {
@@ -288,6 +292,7 @@ class AgentRunner {
       sessionManager: sessionManager,
       pluginManager: pluginManager,
       checkpointCoordinator: _checkpointCoordinator,
+      deferredToolResultResolver: _deferredToolResultResolver,
     );
     _steerCoordinator = steer_lib.SteerCoordinator(sessionId: sessionId);
   }
@@ -1629,22 +1634,25 @@ class AgentRunner {
     );
     if (result.resumeHistoryLength < 0) return; // no-op (no repo / no item)
 
-    final ambiguousRecoveryBatch = result.ambiguousToolCallIds.isEmpty
+    final recoveryToolCallIds = <String>{
+      ...result.ambiguousToolCallIds,
+      ...result.deferredToolCallIds,
+    }.toList();
+    final recoveryBatch = recoveryToolCallIds.isEmpty
         ? null
-        : _findAssistantToolBatch(result.ambiguousToolCallIds);
-    if (result.ambiguousToolCallIds.isNotEmpty &&
-        ambiguousRecoveryBatch == null) {
+        : _findAssistantToolBatch(recoveryToolCallIds);
+    if (recoveryToolCallIds.isNotEmpty && recoveryBatch == null) {
       throw StateError(
         'Cannot continue session $sessionId: the durable assistant tool-call '
-        'batch for the interrupted tools is missing from conversation history.',
+        'batch for the recovering tools is missing from conversation history.',
       );
     }
 
     if (history.length > result.resumeHistoryLength) {
       history = history.take(result.resumeHistoryLength).toList(growable: true);
-      if (ambiguousRecoveryBatch != null &&
-          !_containsAssistantToolBatch(ambiguousRecoveryBatch.toolCalls!)) {
-        history.add(ambiguousRecoveryBatch);
+      if (recoveryBatch != null &&
+          !_containsAssistantToolBatch(recoveryBatch.toolCalls!)) {
+        history.add(recoveryBatch);
       }
       _saveHistory();
     }
@@ -1657,9 +1665,14 @@ class AgentRunner {
       currentModelStepId = result.savedModelStepId;
     }
 
-    if (result.ambiguousToolCallIds.isNotEmpty) {
-      final toolCalls = ambiguousRecoveryBatch!.toolCalls!;
-      _recordAmbiguousToolInterruptions(result.ambiguousToolCallIds, toolCalls);
+    if (recoveryBatch != null) {
+      final toolCalls = recoveryBatch.toolCalls!;
+      if (result.ambiguousToolCallIds.isNotEmpty) {
+        _recordAmbiguousToolInterruptions(
+          result.ambiguousToolCallIds,
+          toolCalls,
+        );
+      }
       await _toolExecutionCoordinator.executeToolCalls(
         toolCalls,
         parallel: shouldParallelizeToolBatch(toolCalls),

--- a/agent/lib/engine/runtime/continuation_checkpoint_coordinator.dart
+++ b/agent/lib/engine/runtime/continuation_checkpoint_coordinator.dart
@@ -194,6 +194,7 @@ class ContinuationCheckpointCoordinator {
       meta['tool_replay_safety'] as Map? ?? const {},
     );
     final ambiguousToolCallIds = <String>[];
+    final deferredToolCallIds = <String>[];
     final deferredResults = Map<String, dynamic>.from(
       meta['deferred_tool_results'] as Map? ?? const {},
     );
@@ -205,6 +206,7 @@ class ContinuationCheckpointCoordinator {
       if (deferred != null &&
           deferred.requesterSessionId == sessionId &&
           deferred.requesterToolCallId == toolId) {
+        deferredToolCallIds.add(toolId);
         continue;
       }
       final isReplaySafe = toolReplaySafety[toolId] == true;
@@ -246,6 +248,7 @@ class ContinuationCheckpointCoordinator {
     return ResumeResult(
       resumeHistoryLength: resumeHistoryLength,
       ambiguousToolCallIds: ambiguousToolCallIds,
+      deferredToolCallIds: deferredToolCallIds,
       savedTurnStartIndex:
           (savedTurnStart != null &&
               savedTurnStart >= 0 &&
@@ -323,12 +326,14 @@ class ResumeResult {
   final int? savedTurnStartIndex;
   final String? savedModelStepId;
   final List<String> ambiguousToolCallIds;
+  final List<String> deferredToolCallIds;
 
   const ResumeResult({
     required this.resumeHistoryLength,
     this.savedTurnStartIndex,
     this.savedModelStepId,
     this.ambiguousToolCallIds = const [],
+    this.deferredToolCallIds = const [],
   });
 
   static const ResumeResult empty = ResumeResult(resumeHistoryLength: -1);

--- a/agent/test/engine/agent_runner_test.dart
+++ b/agent/test/engine/agent_runner_test.dart
@@ -35,6 +35,7 @@ import 'package:sanad_agent/evolution/models/session_execution_snapshot.dart';
 import 'package:sanad_agent/evolution/models/suspended_checkpoint.dart';
 import 'package:sanad_agent/engine/adapters/llm_http_exception.dart';
 import 'package:sanad_agent/engine/adapters/provider_state_rejected_exception.dart';
+import 'package:sanad_agent/engine/runtime/deferred_tool_result.dart';
 
 class MockAdapter implements LLMAdapter {
   final List<AgentResponse> responses;
@@ -3729,6 +3730,119 @@ void main() {
             blockedItem.continuationMetadata['resume_failure_reason'],
             contains('not idempotent'),
           );
+        },
+      );
+
+      test(
+        'resume resolves deferred tool batch without replaying the tool call',
+        () async {
+          final session = sessionManager.createSession('gpt-4o');
+          sessionManager.saveSessionHistory(session.sessionId, [
+            Message(role: MessageRole.user, content: 'switch source'),
+            Message(
+              role: MessageRole.assistant,
+              toolCalls: [
+                ToolCall(
+                  id: 'call-deferred-switch',
+                  name: 'shell_execute',
+                  arguments: const {'command': 'sanad-dev switch'},
+                ),
+              ],
+            ),
+          ]);
+
+          final stateDb = AgentStateDatabase.inMemory();
+          final repo = PersistedRuntimeStateRepository(stateDb.db);
+          GetIt.I.registerSingleton<PersistedRuntimeStateRepository>(repo);
+          addTearDown(() {
+            GetIt.I.unregister<PersistedRuntimeStateRepository>();
+            stateDb.dispose();
+          });
+          stateDb.db.execute(
+            "INSERT INTO sessions (session_id, model, created_at, updated_at) VALUES ('${session.sessionId}', 'gpt-4o', '2026-08-09', '2026-08-09')",
+          );
+          repo.insertWorkItem(
+            SessionWorkItem(
+              workItemId: 'w-deferred-switch',
+              sessionId: session.sessionId,
+              requestId: 'req-deferred-switch',
+              sequence: 1,
+              state: SessionWorkState.resuming,
+              attempt: 0,
+              continuationMetadata: {
+                'checkpoint_kind': 'initial_model_request',
+                'resume_history_length': 1,
+                'currently_executing_tools': ['call-deferred-switch'],
+                'completed_tool_results': <String, dynamic>{},
+                'tool_replay_safety': {'call-deferred-switch': false},
+                'deferred_tool_results': {
+                  'call-deferred-switch': {
+                    'kind': 'sanad_dev_switch',
+                    'transaction_id': 'switch-1',
+                    'manifest_path':
+                        '${Directory.systemTemp.path}/home/dev/runtime-switch-58085.json',
+                    'requester_session_id': session.sessionId,
+                    'requester_tool_call_id': 'call-deferred-switch',
+                  },
+                },
+              },
+              createdAt: DateTime.now(),
+              updatedAt: DateTime.now(),
+            ),
+          );
+          var manifestReads = 0;
+          final adapter = MockAdapter([
+            AgentResponse(
+              message: Message(
+                role: MessageRole.assistant,
+                content: 'continued after switch',
+              ),
+            ),
+          ]);
+          final home = '${Directory.systemTemp.path}/home';
+          final runner = AgentRunner(
+            adapter,
+            registry,
+            sessionManager,
+            existingSessionId: session.sessionId,
+            deferredToolResultResolver: DeferredToolResultResolver(
+              environment: {'SANAD_HOME': home},
+              readManifest: (_) async {
+                manifestReads++;
+                return '{'
+                    '"id":"switch-1",'
+                    '"requester_session_id":"${session.sessionId}",'
+                    '"requester_tool_call_id":"call-deferred-switch",'
+                    '"target_worktree_name":"target",'
+                    '"status":"complete"}';
+              },
+            ),
+          );
+
+          final chunks = await runner.resumeStream().toList();
+
+          expect(chunks.join(), 'continued after switch');
+          expect(manifestReads, 1);
+          expect(
+            runner.history
+                .where(
+                  (message) =>
+                      message.role == MessageRole.assistant &&
+                      message.toolCalls?.single.id == 'call-deferred-switch',
+                )
+                .length,
+            1,
+          );
+          final toolMessages = runner.history.where(
+            (message) => message.toolCallId == 'call-deferred-switch',
+          );
+          expect(toolMessages, hasLength(1));
+          expect(toolMessages.single.content, contains('Switch complete'));
+          final metadata = repo
+              .findWorkItem('w-deferred-switch')!
+              .continuationMetadata;
+          expect(metadata['deferred_tool_results'], isNull);
+          expect(metadata['currently_executing_tools'], isNull);
         },
       );
 

--- a/client/test/unit/scripts/sanad_dev_runtime_switch_test.dart
+++ b/client/test/unit/scripts/sanad_dev_runtime_switch_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+import '../../../../scripts/sanad_dev.dart' as sanad_dev;
 import '../../../../scripts/sanad_dev/client_launch_profile.dart';
 import '../../../../scripts/sanad_dev/runtime_switch.dart';
 
@@ -223,6 +224,83 @@ void main() {
       );
     }
   });
+
+  test(
+    'replacement waits for previous process and VM resources to disappear',
+    () async {
+      var processChecks = 0;
+      var vmChecks = 0;
+
+      final unavailable = await sanad_dev.waitForClientResourcesUnavailable(
+        clientPidsByVmPort: const {51123: 101},
+        timeout: const Duration(seconds: 1),
+        pollInterval: Duration.zero,
+        processRunning: (_) async => processChecks++ == 0,
+        vmServiceAvailable: (_) async => vmChecks++ == 0,
+      );
+
+      expect(unavailable, isTrue);
+      expect(processChecks, 3);
+      expect(vmChecks, 2);
+    },
+  );
+
+  test(
+    'managed PID selection rejects a stale source on the retained VM port',
+    () {
+      sanad_dev.ClientInstance client({
+        required int pid,
+        required String path,
+        required String workspaceHash,
+      }) {
+        return sanad_dev.ClientInstance(
+          51123,
+          'token',
+          path,
+          'macos',
+          pid: pid,
+          launchProfile: extractClientLaunchProfile([
+            '--dart-define=LOCAL_GATEWAY_URL=http://127.0.0.1:58091',
+            '--dart-define=SANAD_DEV_LAUNCHER_ID=launcher-1',
+            '--dart-define=SANAD_DEV_RUNTIME_NONCE=nonce-1',
+            '--dart-define=SANAD_DEV_WORKSPACE_HASH=$workspaceHash',
+          ]),
+        );
+      }
+
+      final stale = client(
+        pid: 101,
+        path: '/source/client',
+        workspaceHash: 'old',
+      );
+      expect(
+        sanad_dev.exactManagedClientPids(
+          discoveredClients: [stale],
+          expectedVmServicePorts: const {51123},
+          launcherId: 'launcher-1',
+          runtimeNonce: 'nonce-1',
+          workspaceHash: 'target',
+        ),
+        isNull,
+      );
+
+      final target = client(
+        pid: 202,
+        path: '/target/client',
+        workspaceHash: 'target',
+      );
+      expect(
+        sanad_dev.exactManagedClientPids(
+          discoveredClients: [stale, target],
+          expectedVmServicePorts: const {51123},
+          launcherId: 'launcher-1',
+          runtimeNonce: 'nonce-1',
+          workspaceHash: 'target',
+        ),
+        [202],
+      );
+    },
+  );
 
   test('process tree orders descendants after their owning parent', () {
     const listing = '''

--- a/docs/plans/tasks/sanad_dev_switch_recovery_and_client_identity_race.md
+++ b/docs/plans/tasks/sanad_dev_switch_recovery_and_client_identity_race.md
@@ -1,0 +1,98 @@
+---
+title: "sanad-dev Switch Recovery and Client Identity Race"
+description: "Prevent duplicate source-switch execution and stale Client lease identity during continuous handoff."
+status: "completed"
+---
+
+# sanad-dev Switch Recovery and Client Identity Race
+
+## Goal
+
+Make an authorized `sanad-dev switch --runtime current` complete exactly once,
+return the original launcher transaction result after daemon recovery, and mark
+the handoff complete only after every replacement Client has a target-source
+managed identity recorded in the launcher lease.
+
+## Incident triage
+
+A live main-to-worktree handoff exposed two gaps in the existing continuous
+handoff contract:
+
+1. The launcher terminates the previous Client tree without waiting for the old
+   VM service and managed launch identity to disappear. Target readiness can
+   therefore be satisfied by the old Client, and `_managedClientPids` can write
+   its PID because it filters only by VM port plus launcher id/nonce, not by
+   target source identity. The manifest reaches `complete` while the replacement
+   Client is still starting; when the old process exits, status reports
+   `client PIDs do not match lease`.
+2. Startup checkpoint restoration recognizes a requester-bound deferred result
+   as safe but does not return that tool-call id to `AgentRunner`. The runner
+   trims history to the pre-model checkpoint, removes the durable assistant
+   tool-call batch, and starts another model request instead of resolving the
+   existing launcher manifest. The model can then issue a second switch during
+   the Agent-before-Client startup window and receive `the selected agent has no
+   discoverable clients` even though the first transaction succeeds.
+
+These behaviors contradict the documented exact-once deferred-result contract
+and target-group health requirement. This task corrects the implementation and
+adds regression coverage; it does not weaken switch authorization or ownership
+validation.
+
+## Implementation
+
+- Return requester-bound deferred tool-call ids from checkpoint restoration.
+- Preserve the complete durable assistant tool-call batch across history trim
+  when it owns deferred or ambiguous interrupted calls.
+- Resume that batch through `ToolExecutionCoordinator`, allowing deferred
+  descriptors to resolve without replaying the external shell mutation and
+  preserving original batch order.
+- During source replacement, wait until each previous managed Client identity
+  and VM-service endpoint is gone before starting a target Client on the same
+  reserved port.
+- Verify target Clients by VM port, launcher id/nonce, and the expected target
+  workspace source marker before writing their PIDs into the lease or recording
+  terminal `complete`.
+- Apply the same identity verification to rollback so restored lease ownership
+  is exact.
+
+## Verification
+
+- Focused checkpoint/coordinator unit tests prove deferred ids survive restore
+  and the original assistant batch is resolved once rather than removed or
+  replayed.
+- Focused `sanad-dev` tests prove stale previous identities cannot satisfy
+  target readiness or lease PID collection.
+- Agent analyzer and focused Agent tests pass.
+- Flutter analyzer and focused `sanad_dev` unit tests pass.
+- Existing runtime ownership and source-switch QA documentation describes the
+  corrected boundaries.
+- `graphify update .` is run if Graphify is available; absence is recorded.
+
+## Verification evidence
+
+- `fvm dart analyze` — passed.
+- `fvm flutter analyze` — passed.
+- `fvm dart test test/engine/agent_runner_test.dart test/engine/history_healer_test.dart test/interfaces/runtime/session_restart_checkpoint_test.dart` — 72 tests passed.
+- `fvm flutter test test/unit/scripts/sanad_dev_runtime_switch_test.dart test/unit/scripts/sanad_dev_runtime_ownership_test.dart test/unit/scripts/sanad_dev_process_state_test.dart` — 33 tests passed.
+- Graphify update was skipped because this worktree has no
+  `graphify-out/graph.json`; creating a new graph is outside this task.
+- Authorized isolated process-level source handoff — passed: the original
+  command returned `Switch complete`; post-handoff status reported the target
+  Agent and Client source, one exact Client PID, `Runtime class: managed`, and
+  no cross-owned or unverifiable Clients. The isolated runtime was then stopped
+  and its temporary target worktree/branch removed.
+
+## Definition of Done
+
+- [x] A deferred switch manifest resolves into the original tool-call result
+  after recovery with no second shell execution.
+- [x] History trim preserves the owning assistant tool-call batch.
+- [x] A previous Client still visible on the retained VM port cannot satisfy
+  target startup.
+- [x] A terminal complete handoff lease accepts only target-workspace Client
+  PIDs.
+- [x] Rollback records only verified previous-workspace Client PIDs.
+- [x] Focused tests and analyzers pass.
+- [x] Technical and QA documentation is updated.
+- [x] An authorized isolated process-level source handoff confirms the complete
+  launcher/Agent/Client recovery path.

--- a/docs/qa_maintenance/runtime_source_switch_qa.md
+++ b/docs/qa_maintenance/runtime_source_switch_qa.md
@@ -17,7 +17,9 @@ description: "Regression matrix for moving one active sanad-dev pair between sou
 | Agent requests `switch --runtime current` from a target worktree after authorization | Only the requester pair drains and restarts from the target source. |
 | Authorized source handoff begins | The agent runs `status` from the source worktree first and records the selected source, branch, agent, and clients. |
 | Agent-origin target startup succeeds | The original switch tool call returns `complete`; the agent then runs `status` from the target worktree and verifies its source, branch, agent, and clients. |
-| Startup loads history while the switch shell tool owns a valid deferred result | History healing preserves the unanswered tool call, resume resolves the launcher manifest into the original tool result, and no duplicate `switch` command or transient missing-client error is produced. |
+| Startup loads history while the switch shell tool owns a valid deferred result | History healing and checkpoint trim preserve the complete assistant tool-call batch; resume resolves the launcher manifest into the original tool result before another model request, and no duplicate `switch` command or transient missing-client error is produced. |
+| Previous Client termination is delayed while the retained VM port still answers | Target startup waits; the previous source cannot satisfy readiness and the handoff cannot become `complete`. |
+| Previous and target Client identities overlap briefly on one retained VM port | Lease PID collection accepts exactly the target workspace source marker plus launcher id/nonce and rejects the stale previous identity. |
 | Agent-origin target startup fails and rollback succeeds | The original switch tool call returns `rolled_back` after the same durable session resumes on the previous source; target-scoped status remains diagnostic and cannot override that result. |
 | Target and rollback both fail | The original switch tool call returns `recovery_failed` and does not claim continuity. |
 | Safe drain or pre-replacement validation fails | The original switch tool call returns `failed` and the source group remains intact. |

--- a/docs/technical/sanad_dev_runtime_ownership.md
+++ b/docs/technical/sanad_dev_runtime_ownership.md
@@ -101,9 +101,23 @@ result into the original tool call:
 - `failed` means replacement did not begin or the safe drain was rejected;
 - `recovery_failed` means neither target nor previous group was verified.
 
-The switch mutation is never replayed. A crash after terminal persistence reads
-the already completed tool result. `status` keeps the outcome as `Last source
-switch` diagnostics, but the requester does not need a second command.
+The switch mutation is never replayed. Checkpoint restoration returns every
+requester-bound deferred tool-call id to the runner before trimming history. The
+runner preserves that call's complete durable assistant batch, resolves its
+launcher manifest through the tool coordinator, and only then continues the
+model loop. This prevents a second model-generated `switch` while the target
+Agent is healthy but its Clients are still starting. A crash after terminal
+persistence reads the already completed tool result. `status` keeps the outcome
+as `Last source switch` diagnostics, but the requester does not need a second
+command.
+
+Before replacement starts, the launcher waits for every previous managed Client
+process and retained VM-service endpoint to disappear. Target or rollback
+readiness then requires exactly one discovered Client per reserved VM port whose
+workspace source marker, launcher id, and runtime nonce match the expected
+group. A stale previous-source Client can neither satisfy readiness nor
+supply a PID to the rewritten launcher lease; terminal `complete` or
+`rolled_back` is persisted only after this exact identity set is available.
 
 ## Resumable development shutdown
 

--- a/scripts/sanad_dev/switch_commands.dart
+++ b/scripts/sanad_dev/switch_commands.dart
@@ -185,6 +185,54 @@ Future<void> handleRuntimeSwitch({
   }
 }
 
+Future<bool> waitForClientResourcesUnavailable({
+  required Map<int, int?> clientPidsByVmPort,
+  Duration timeout = const Duration(seconds: 15),
+  Duration pollInterval = const Duration(milliseconds: 100),
+  Future<bool> Function(int pid)? processRunning,
+  Future<bool> Function(int port)? vmServiceAvailable,
+}) async {
+  final isRunning = processRunning ?? isProcessRunning;
+  final vmAvailable = vmServiceAvailable ?? _vmServiceIsAvailable;
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    var unavailable = true;
+    for (final client in clientPidsByVmPort.entries) {
+      if ((client.value != null && await isRunning(client.value!)) ||
+          await vmAvailable(client.key)) {
+        unavailable = false;
+        break;
+      }
+    }
+    if (unavailable) return true;
+    await Future<void>.delayed(pollInterval);
+  }
+  return false;
+}
+
+List<int>? exactManagedClientPids({
+  required Iterable<ClientInstance> discoveredClients,
+  required Set<int> expectedVmServicePorts,
+  required String launcherId,
+  required String runtimeNonce,
+  required String workspaceHash,
+}) {
+  final pids = <int>[];
+  for (final expectedPort in expectedVmServicePorts) {
+    final matches = discoveredClients.where((client) {
+      final profile = client.launchProfile;
+      return client.port == expectedPort &&
+          client.pid != null &&
+          profile?.define('SANAD_DEV_LAUNCHER_ID') == launcherId &&
+          profile?.define('SANAD_DEV_RUNTIME_NONCE') == runtimeNonce &&
+          profile?.define('SANAD_DEV_WORKSPACE_HASH') == workspaceHash;
+    }).toList();
+    if (matches.length != 1) return null;
+    pids.add(matches.single.pid!);
+  }
+  return pids;
+}
+
 int? _requestingAgentPort() {
   final direct = int.tryParse(
     Platform.environment['LOCAL_GATEWAY_PORT']?.trim() ?? '',
@@ -894,6 +942,16 @@ class _SwitchableRuntimeController {
         .toList();
 
     try {
+      if (!await waitForClientResourcesUnavailable(
+        clientPidsByVmPort: {
+          for (final client in previousClients)
+            client.vmServicePort: client.pid,
+        },
+      )) {
+        throw StateError(
+          'Previous Client identity remained active after termination.',
+        );
+      }
       await _startAgent(targetAgentDirectory);
       final agentHealthy = await _waitForAgentHash(
         request.targetWorkspaceHash,
@@ -917,7 +975,10 @@ class _SwitchableRuntimeController {
       _agentDirectory = targetAgentDirectory;
       _clientDirectory = targetClientDirectory;
       _currentWorkspaceHash = request.targetWorkspaceHash;
-      final managedClientPids = await _managedClientPids(targetClients);
+      final managedClientPids = await _managedClientPids(
+        targetClients,
+        workspaceHash: request.targetWorkspaceHash,
+      );
       _launcherRecord = _launcherRecord.copyWith(
         workspaceHash: request.targetWorkspaceHash,
         sourceRoot: request.targetRepositoryRoot,
@@ -951,7 +1012,10 @@ class _SwitchableRuntimeController {
       List<int>? restoredClientPids;
       if (restored) {
         try {
-          restoredClientPids = await _managedClientPids(previousClients);
+          restoredClientPids = await _managedClientPids(
+            previousClients,
+            workspaceHash: previousWorkspaceHash,
+          );
         } on Object {
           restored = false;
         }
@@ -1014,28 +1078,26 @@ class _SwitchableRuntimeController {
   }
 
   Future<List<int>> _managedClientPids(
-    List<_RuntimeClientLaunch> expected,
-  ) async {
-    final expectedPorts = expected.map((item) => item.vmServicePort).toSet();
-    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    List<_RuntimeClientLaunch> expected, {
+    required String workspaceHash,
+    Duration timeout = sanadDevClientStartupTimeout,
+  }) async {
+    final expectedVmServicePorts = expected
+        .map((client) => client.vmServicePort)
+        .toSet();
+    final deadline = DateTime.now().add(timeout);
     while (DateTime.now().isBefore(deadline)) {
-      final discovered =
-          clientsForAgentPort(
-            await discoverClientInstances(),
-            runtime.agentPort,
-          ).where(
-            (client) =>
-                expectedPorts.contains(client.port) &&
-                client.launchProfile?.define('SANAD_DEV_LAUNCHER_ID') ==
-                    _launcherRecord.launcherId &&
-                client.launchProfile?.define('SANAD_DEV_RUNTIME_NONCE') ==
-                    _launcherRecord.runtimeNonce,
-          );
-      final pids = discovered
-          .map((client) => client.pid)
-          .whereType<int>()
-          .toList();
-      if (pids.length == expected.length) return pids;
+      final pids = exactManagedClientPids(
+        discoveredClients: clientsForAgentPort(
+          await discoverClientInstances(),
+          runtime.agentPort,
+        ),
+        expectedVmServicePorts: expectedVmServicePorts,
+        launcherId: _launcherRecord.launcherId,
+        runtimeNonce: _launcherRecord.runtimeNonce,
+        workspaceHash: workspaceHash,
+      );
+      if (pids != null) return pids;
       await Future<void>.delayed(const Duration(milliseconds: 100));
     }
     throw StateError('Managed client process identity is incomplete.');


### PR DESCRIPTION
## Problem / goal

Make an authorized \`sanad-dev switch --runtime current\` complete exactly once, return the original launcher transaction result after daemon recovery, and mark the handoff complete only after every replacement Client has a target-source managed identity recorded in the launcher lease.

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Security or privacy
- [ ] Performance or refactor
- [x] Test or maintenance

**Components:** agent / client / docs

**Platforms:** macOS / Windows / Linux

## Changes

- Return requester-bound deferred tool-call ids from checkpoint restoration (\`continuation_checkpoint_coordinator.dart\`).
- Preserve the complete durable assistant tool-call batch across history trim when it owns deferred or ambiguous interrupted calls (\`agent_runner.dart\`).
- Resume that batch through \`ToolExecutionCoordinator\`, allowing deferred descriptors to resolve without replaying the external shell mutation and preserving original batch order.
- During source replacement, wait until each previous managed Client identity and VM-service endpoint is gone before starting a target Client on the same reserved port (\`switch_commands.dart\`).
- Verify target Clients by VM port, launcher id/nonce, and the expected target workspace source marker before writing their PIDs into the lease or recording terminal \`complete\`.
- Apply the same identity verification to rollback so restored lease ownership is exact.
- Update technical and QA docs (\`sanad_dev_runtime_ownership.md\`, \`runtime_source_switch_qa.md\`) and add task record \`sanad_dev_switch_recovery_and_client_identity_race.md\`.

## Verification

| Check | Result |
|---|---|
| \`cd agent && fvm dart analyze\` | Passed (No issues found) |
| \`cd client && fvm flutter analyze\` | Passed (No issues found) |
| \`cd agent && fvm dart test test/engine/agent_runner_test.dart test/engine/history_healer_test.dart test/interfaces/runtime/session_restart_checkpoint_test.dart\` | Passed (72 tests passed) |
| \`cd client && fvm flutter test test/unit/scripts/sanad_dev_runtime_switch_test.dart test/unit/scripts/sanad_dev_runtime_ownership_test.dart test/unit/scripts/sanad_dev_process_state_test.dart\` | Passed (33 tests passed) |

## Risk and compatibility

- **Cross-platform impact:** No platform-specific regressions; uses standard process and VM service discovery.
- **Security/privacy impact:** None; maintains exact lease ownership and prevents unintended double-switch execution.
- **Migration/rollback:** Fully backward-compatible.

## Documentation and presentation

- [x] I reviewed the nearest \`AGENTS.md\` contracts.
- [x] I updated the owning \`docs/\` page, or this change does not alter documented behavior/design.
- [x] I updated a durable contract only if its law, ownership boundary, or invariant changed.
- [x] I added screenshots or recordings for visible changes, or this change has no visible UI.

## Contributor checks

- [x] I searched for duplicate Discussions, Issues, and pull requests.
- [x] This pull request is focused on one coherent change.
- [x] The title follows Conventional Commits and is suitable as the squash commit message.
- [x] I did not include secrets, private deployment details, personal paths, or unredacted user data.
- [x] Fork-origin verification does not require repository secrets.