### PR TITLE
fix(agent): persist typed tool error flag in history

### DIFF
--- a/agent/lib/engine/agent_runner.dart
+++ b/agent/lib/engine/agent_runner.dart
@@ -1820,7 +1820,11 @@ class _RunnerToolCallbacks implements ToolExecutionCallbacks {
   _RunnerToolCallbacks(this._runner);
 
   @override
-  Future<void> addToolMessage(ToolCall toolCall, String result) async {
+  Future<void> addToolMessage(
+    ToolCall toolCall,
+    String result, {
+    required bool isError,
+  }) async {
     final toolMessage = Message(
       role: MessageRole.tool,
       content: result,
@@ -1831,6 +1835,7 @@ class _RunnerToolCallbacks implements ToolExecutionCallbacks {
         'tool_call_id': toolCall.id,
         if (_runner.currentModelStepId != null)
           'model_step_id': _runner.currentModelStepId,
+        'is_error': isError,
       },
     );
     _runner.history.add(toolMessage);

--- a/agent/lib/engine/runtime/tool_execution_coordinator.dart
+++ b/agent/lib/engine/runtime/tool_execution_coordinator.dart
@@ -178,6 +178,9 @@ class ToolExecutionCoordinator {
     final allCompleted = Map<String, dynamic>.from(
       updatedMeta['completed_tool_results'] as Map? ?? const {},
     );
+    final allOutputs = Map<String, dynamic>.from(
+      updatedMeta['completed_tool_outputs'] as Map? ?? const {},
+    );
     for (final toolCall in toolCalls) {
       finalResults[toolCall.id] = ToolOutputGuard.guardResult(
         allCompleted[toolCall.id]?.toString() ??
@@ -196,7 +199,11 @@ class ToolExecutionCoordinator {
       final result = finalResults[toolCall.id]!;
       final alreadyAdded = callbacks.isToolMessagePresent(toolCall.id);
       if (!alreadyAdded) {
-        await callbacks.addToolMessage(toolCall, result);
+        final outputRecord = allOutputs[toolCall.id];
+        final isError =
+            (outputRecord is Map && outputRecord['is_error'] == true) ||
+            result.startsWith('Error');
+        await callbacks.addToolMessage(toolCall, result, isError: isError);
       }
     }
     callbacks.saveHistory();
@@ -553,7 +560,7 @@ class ToolExecutionCoordinator {
     }
 
     if (appendToHistory) {
-      await callbacks.addToolMessage(toolCall, result);
+      await callbacks.addToolMessage(toolCall, result, isError: isError);
     }
     return result;
   }
@@ -565,7 +572,11 @@ abstract class ToolExecutionCallbacks {
   /// Appends a tool-result [Message] for [toolCall] with [result], notifies
   /// plugins, saves history, and deletes the suspended checkpoint for the
   /// tool call id.
-  Future<void> addToolMessage(ToolCall toolCall, String result);
+  Future<void> addToolMessage(
+    ToolCall toolCall,
+    String result, {
+    required bool isError,
+  });
 
   /// Returns true if a tool message with [toolCallId] already exists in
   /// history (used to avoid duplicate appends after sequential execution).

--- a/agent/lib/interfaces/platforms/sanad_gateway/handlers/session_query_handler.dart
+++ b/agent/lib/interfaces/platforms/sanad_gateway/handlers/session_query_handler.dart
@@ -193,7 +193,9 @@ class SessionQueryHandler {
             message.metadata?['steer_original_content']?.toString() ??
             message.content ??
             '';
-        final isError = visibleContent.startsWith('Error:');
+        final isError =
+            message.metadata?['is_error'] == true ||
+            visibleContent.startsWith('Error:');
 
         historyMessages.add({
           'id': msgId,

--- a/agent/test/engine/agent_runner_test.dart
+++ b/agent/test/engine/agent_runner_test.dart
@@ -3321,6 +3321,7 @@ void main() {
           final lastMsg = runner.history.last;
           expect(lastMsg.role, equals(MessageRole.tool));
           expect(lastMsg.toolCallId, equals('call-2'));
+          expect(lastMsg.metadata?['is_error'], isTrue);
           expect(
             lastMsg.content,
             contains('interrupted by a daemon crash/restart'),

--- a/agent/test/interfaces/runtime/session_restart_checkpoint_test.dart
+++ b/agent/test/interfaces/runtime/session_restart_checkpoint_test.dart
@@ -261,7 +261,11 @@ class _ToolCallbacks implements ToolExecutionCallbacks {
   final Map<String, String> results = {};
 
   @override
-  Future<void> addToolMessage(ToolCall toolCall, String result) async {
+  Future<void> addToolMessage(
+    ToolCall toolCall,
+    String result, {
+    required bool isError,
+  }) async {
     results[toolCall.id] = result;
   }
 

--- a/agent/test/interfaces/sanad_bridge_test.dart
+++ b/agent/test/interfaces/sanad_bridge_test.dart
@@ -1245,6 +1245,59 @@ void main() {
     );
 
     test(
+      'get_session_history restores typed tool errors without relying on text prefixes',
+      () async {
+        final bridge = SanadProtocolBridge();
+        final sessionManager = getIt<SessionManager>();
+        const sessionId = 'session-tool-error-history';
+        sessionManager.db.saveSession(
+          SessionState(
+            sessionId: sessionId,
+            model: 'sanad-agent',
+            createdAt: DateTime.parse('2026-07-02T10:00:00Z'),
+            updatedAt: DateTime.parse('2026-07-02T10:01:00Z'),
+          ),
+        );
+        sessionManager.saveSessionHistory(sessionId, [
+          Message(role: MessageRole.user, content: 'Run the check'),
+          Message(
+            role: MessageRole.assistant,
+            toolCalls: [
+              ToolCall(
+                id: 'tool-error-1',
+                name: 'project_check',
+                arguments: const {},
+              ),
+            ],
+          ),
+          Message(
+            role: MessageRole.tool,
+            toolCallId: 'tool-error-1',
+            content: 'Validation failed for two files',
+            metadata: const {'is_error': true},
+          ),
+          Message(role: MessageRole.assistant, content: 'The check failed.'),
+        ]);
+
+        Map<String, dynamic>? emitted;
+        await bridge.handleCommand({
+          'command': 'get_session_history',
+          'payload': {
+            'request_id': 'req-tool-error-history',
+            'session_id': sessionId,
+          },
+        }, (envelope) async => emitted = envelope);
+
+        final messages = emitted?['payload']['messages'] as List;
+        final toolResult = messages.singleWhere(
+          (message) => message['type'] == 'tool_result',
+        );
+        expect(toolResult['output'], 'Validation failed for two files');
+        expect(toolResult['isError'], isTrue);
+      },
+    );
+
+    test(
       'get_session_history restores steer after its tool result without exposing markers',
       () async {
         final bridge = SanadProtocolBridge();

--- a/docs/plans/tasks/68-tool-error-live-history-parity.md
+++ b/docs/plans/tasks/68-tool-error-live-history-parity.md
@@ -1,0 +1,16 @@
+# Task 68 — Tool Error Live/History Parity
+
+## Goal
+Persist the authoritative tool execution error flag with each tool-result history message so history hydration reproduces the same success/error state shown during live execution.
+
+## Implementation
+1. Carry `isError` through the tool execution callback that appends runner-owned history.
+2. Recover the flag from typed checkpoint output records for resumed and batch execution.
+3. Emit history `isError` from persisted metadata, retaining the legacy `Error:` prefix fallback for old rows.
+4. Add protocol regression coverage for an error whose visible text does not begin with `Error:`.
+
+## Definition of Done
+- Live and hydrated tool events agree on error state.
+- Sequential, parallel, deferred, direct, and resumed paths preserve the typed flag.
+- Focused protocol/runtime tests and `fvm dart analyze` pass.
+- Conversation event parity QA documents the invariant.

--- a/docs/qa_maintenance/conversation_event_parity_qa.md
+++ b/docs/qa_maintenance/conversation_event_parity_qa.md
@@ -32,6 +32,7 @@ All items share one `run_id`. The three assistant segments have distinct `model_
 13. Local/cloud fan-out translates one response independently but updates the in-flight snapshot once at the stream source; two chunks hydrate as `A + B`, never `A + A + B + B`.
 14. A late steer completes the pre-steer running row as a visible thought before the steer continuation starts, and history hydration reproduces the same order.
 15. Running thought Markdown is exercised through the progressive renderer in widget tests; tests do not silently replace it with the completed-document renderer.
+16. Live and history tool execution events maintain identical error status parity (a tool failing with an error in the live run is hydrated as a tool error event in history).
 
 ## Automated ownership
 


### PR DESCRIPTION
## Problem / Goal
Tool results that fail without the `Error:` text prefix (e.g. validation failures) were hydrated from history as successful tool events, breaking live/history error-status parity.

## Technical Changes
- `agent/lib/engine/runtime/tool_execution_coordinator.dart` — thread an explicit `isError` flag through `addToolMessage` and recover it from `completed_tool_outputs` metadata during resume.
- `agent/lib/engine/agent_runner.dart` — persist `is_error` in tool-message metadata.
- `agent/lib/interfaces/platforms/sanad_gateway/handlers/session_query_handler.dart` — `get_session_history` prefers the typed `is_error` metadata over the `Error:` text prefix.
- Tests: runner crash-resume checkpoint asserts `is_error`; new bridge test hydrates a typed tool error without a text prefix.
- Docs: QA parity checklist item 16; task plan `68-tool-error-live-history-parity.md`.

## Verification
- `dart analyze` — no issues.
- `dart test test/engine/agent_runner_test.dart test/interfaces/runtime/session_restart_checkpoint_test.dart test/interfaces/sanad_bridge_test.dart` — 109/109 passed (re-verified after rebase onto latest main).
