### PR TITLE
feat(client): workspace cache sync, first-run composer defaults, desktop-only status bar

### DIFF
--- a/client/lib/features/conversations/presentation/AGENTS.md
+++ b/client/lib/features/conversations/presentation/AGENTS.md
@@ -16,6 +16,8 @@ This contract applies to `client/lib/features/conversations/presentation/`.
 - Draft workspace, provider, model, thinking, and text restore together per device. Permission remains workspace-policy-owned and must not be mutated by restore.
 - Existing-session selection must replace or explicitly clear all context fields before presentation swaps. An identity-only restored-session placeholder is not authoritative context and must preserve the persisted provider/model route until a complete route or authoritative route revision arrives.
 - `thinkingMode` is the Dart/domain name and `thinking_mode` is the wire/cache key; do not add aliases.
+- For a new device with no saved thinking preference, initialize and persist `balanced`; preserve any non-empty returning-user value.
+- A partial provider/model preference is not a valid route. Authoritative readiness may complete or replace a partial pair, while a complete saved pair remains user intent.
 - Do not eagerly hydrate history for a session created locally for its first outgoing turn.
 - Block normal message dispatch before session creation when either the provider instance or model selection is absent.
 - Slash queries run only on explicit composer intent and use the daemon query surface, never local skill discovery or mount-time prefetch.
@@ -62,6 +64,7 @@ This contract applies to `client/lib/features/conversations/presentation/`.
 - Missing workspaces remain visible with historical sessions; disable new workspace conversation intent and route hover-only workspace settings actions with explicit device and workspace ids.
 - `SessionSidebarCubit` is a pure projection of `ConversationCacheRepository.snapshotStream`; it owns no cache maps, cursors, or drafts.
 - Device selection comes from `DeviceCubit`; session/workspace data comes from the conversation cache repository.
+- Project cached workspace mutations into the composer selector immediately. Opening a popup must never be required to refresh state, and a newly created workspace must be present on the selector's first opening.
 - Invalidate a selected session from another device before restoring the new active device's last destination.
 - Do not request a collapsed workspace's first page during refresh.
 - Preserve canonical mutations received during in-flight pagination and do not remove newer workspaces with older responses.

--- a/client/lib/features/conversations/presentation/bloc/conversation_input_cubit.dart
+++ b/client/lib/features/conversations/presentation/bloc/conversation_input_cubit.dart
@@ -62,7 +62,7 @@ class ConversationInputCubit extends Cubit<ConversationInputState> {
     String? model,
     bool replaceExisting = false,
   }) {
-    if (!replaceExisting && (_hasText(state.nextMessageProviderId) || _hasText(state.nextMessageModel))) {
+    if (!replaceExisting && _hasText(state.nextMessageProviderId) && _hasText(state.nextMessageModel)) {
       return;
     }
     if (!_hasText(providerId) || !_hasText(model)) return;

--- a/client/lib/features/conversations/presentation/bloc/session_messages_cubit.dart
+++ b/client/lib/features/conversations/presentation/bloc/session_messages_cubit.dart
@@ -1,7 +1,10 @@
 import 'dart:async';
 import 'package:sanad_client/features/devices/domain/models/device_config.dart';
 import 'package:sanad_client/features/devices/domain/stores/device_capabilities_store.dart';
+import 'package:sanad_client/features/conversations/data/repositories/conversation_cache_repository.dart';
 import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
+import 'package:sanad_client/features/conversations/domain/models/conversation_resource_state.dart';
+import 'package:sanad_client/features/conversations/domain/models/device_conversation_cache_snapshot.dart';
 import 'package:sanad_client/features/conversations/domain/models/session.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_workspace.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_suspended_request.dart';
@@ -27,16 +30,19 @@ import 'package:uuid/uuid.dart';
 import 'session_messages_state.dart';
 
 class SessionMessagesCubit extends Cubit<SessionMessagesState> {
+  static const defaultThinkingMode = 'balanced';
   static final _logger = Logger('SessionMessagesCubit');
   final DeviceCubit agentCubit;
   final SessionCubit sessionCubit;
   final ConversationRepository conversationRepository;
+  final ConversationCacheRepository? conversationCacheRepository;
   final IDevicePreferencesRepository preferencesRepository;
   final DeviceCapabilitiesStore? capabilitiesStore;
   final LocalToolRuntimeService? localToolRuntime;
   final WorkspaceToolRuntimeContext? workspaceRuntimeContext;
   StreamSubscription<WorkspacePolicy>? _workspacePolicySubscription;
   StreamSubscription? _agentStateSubscription;
+  StreamSubscription<DeviceConversationCacheSnapshot>? _cacheSubscription;
   StreamSubscription? _sessionStateSubscription;
   StreamSubscription? _messageSubscription;
   StreamSubscription? _queuedMessagesSubscription;
@@ -66,16 +72,55 @@ class SessionMessagesCubit extends Cubit<SessionMessagesState> {
     required this.agentCubit,
     required this.sessionCubit,
     required this.conversationRepository,
+    this.conversationCacheRepository,
     required this.preferencesRepository,
     this.capabilitiesStore,
     this.localToolRuntime,
     this.workspaceRuntimeContext,
   }) : super(const SessionMessagesState()) {
     _agentStateSubscription = agentCubit.stream.listen(_handleDeviceStateChange);
+    _cacheSubscription = conversationCacheRepository?.snapshotStream.listen(_handleCacheSnapshot);
     _sessionStateSubscription = sessionCubit.stream.listen(_handleSessionStateChange);
     // Initial check
     _handleDeviceStateChange(agentCubit.state);
+    final cacheRepository = conversationCacheRepository;
+    if (cacheRepository != null) {
+      _handleCacheSnapshot(cacheRepository.snapshot);
+    }
     _handleSessionStateChange(sessionCubit.state);
+  }
+
+  void _handleCacheSnapshot(DeviceConversationCacheSnapshot snapshot) {
+    final agent = _currentAgent;
+    if (agent == null) return;
+    final cachedWorkspaces = snapshot.contexts[agent.id]?.workspaces;
+    if (cachedWorkspaces == null || !cachedWorkspaces.state.hasUsableSnapshot) return;
+
+    final workspaces = List<DeviceWorkspace>.unmodifiable(cachedWorkspaces.workspaces);
+    _workspacesByAgentId[agent.id] = workspaces;
+
+    final currentSelection = _selectedWorkspaceByAgentId[agent.id];
+    var selectedWorkspace = currentSelection;
+    if (currentSelection != null) {
+      for (final workspace in workspaces) {
+        if (workspace.id == currentSelection.id) {
+          selectedWorkspace = workspace;
+          break;
+        }
+      }
+      _selectedWorkspaceByAgentId[agent.id] = selectedWorkspace!;
+      workspaceRuntimeContext?.setActiveWorkspace(selectedWorkspace);
+    }
+
+    if (!isClosed) {
+      emit(
+        state.copyWith(
+          availableWorkspaces: workspaces,
+          selectedWorkspace: selectedWorkspace,
+          clearSelectedWorkspace: selectedWorkspace == null,
+        ),
+      );
+    }
   }
 
   void _handleDeviceStateChange(DeviceState agentState) {
@@ -420,9 +465,11 @@ class SessionMessagesCubit extends Cubit<SessionMessagesState> {
         }
       }
       if (!_nextMessageThinkingByAgentId.containsKey(agent.id)) {
-        final savedThinking = preferencesRepository.getLastThinkingMode(agent.id);
-        if (savedThinking != null) {
-          _nextMessageThinkingByAgentId[agent.id] = savedThinking;
+        final savedThinking = preferencesRepository.getLastThinkingMode(agent.id)?.trim();
+        final thinkingMode = savedThinking?.isNotEmpty == true ? savedThinking! : defaultThinkingMode;
+        _nextMessageThinkingByAgentId[agent.id] = thinkingMode;
+        if (savedThinking == null || savedThinking.isEmpty) {
+          unawaited(preferencesRepository.setLastThinkingMode(agent.id, thinkingMode));
         }
       }
 
@@ -1335,11 +1382,18 @@ class SessionMessagesCubit extends Cubit<SessionMessagesState> {
     if (agent == null) return null;
 
     try {
-      final workspace = await conversationRepository.createWorkspace(
-        agent,
-        path: path,
-        name: name,
-      );
+      final workspace = conversationCacheRepository == null
+          ? await conversationRepository.createWorkspace(
+              agent,
+              path: path,
+              name: name,
+            )
+          : await conversationCacheRepository!.createWorkspace(
+              agent,
+              path: path,
+              name: name,
+            );
+      if (workspace == null) return null;
       final currentList = List<DeviceWorkspace>.from(_workspacesByAgentId[agent.id] ?? const []);
       currentList.removeWhere((item) => item.id == workspace.id);
       currentList.insert(0, workspace);
@@ -1586,6 +1640,7 @@ class SessionMessagesCubit extends Cubit<SessionMessagesState> {
   Future<void> close() async {
     _delayedLoadingTimer?.cancel();
     await _agentStateSubscription?.cancel();
+    await _cacheSubscription?.cancel();
     await _sessionStateSubscription?.cancel();
     await _messageSubscription?.cancel();
     await _queuedMessagesSubscription?.cancel();

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/conversation_bottom_actions.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/conversation_bottom_actions.dart
@@ -6,6 +6,7 @@ import 'package:sanad_client/features/devices/domain/models/device_config.dart';
 import 'package:sanad_client/features/conversations/domain/models/session.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_cubit.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/session_cubit.dart';
+import 'package:sanad_client/features/conversations/presentation/bloc/session_messages_cubit.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/session_state.dart';
 import 'package:sanad_client/features/conversations/presentation/utils/provider_route_label.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/conversation_input_slices.dart';
@@ -457,10 +458,12 @@ class _ConversationBottomActionsState extends State<ConversationBottomActions> {
   }
 
   String _firstThinkingMode() {
-    if (widget.capabilities.thinkingModesList.isEmpty) {
-      return 'balanced';
+    final modes = widget.capabilities.thinkingModesList;
+    if (modes.contains(SessionMessagesCubit.defaultThinkingMode)) {
+      return SessionMessagesCubit.defaultThinkingMode;
     }
-    return widget.capabilities.thinkingModesList.first;
+    if (modes.isNotEmpty) return modes.first;
+    return SessionMessagesCubit.defaultThinkingMode;
   }
 
   String _permissionModeLabel(WorkspacePermissionMode mode) {

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/conversation_input_composer.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/conversation_input_composer.dart
@@ -905,8 +905,12 @@ class _ThinkingModeChip extends StatelessWidget {
   }
 
   String _firstMode() {
-    if (capabilities.thinkingModesList.isEmpty) return 'balanced';
-    return capabilities.thinkingModesList.first;
+    final modes = capabilities.thinkingModesList;
+    if (modes.contains(SessionMessagesCubit.defaultThinkingMode)) {
+      return SessionMessagesCubit.defaultThinkingMode;
+    }
+    if (modes.isNotEmpty) return modes.first;
+    return SessionMessagesCubit.defaultThinkingMode;
   }
 
   Widget _buildChip(BuildContext context, String text) {

--- a/client/lib/features/home/AGENTS.md
+++ b/client/lib/features/home/AGENTS.md
@@ -12,12 +12,13 @@ This contract applies to `client/lib/features/home/`.
 ## Active Device Integration
 - Re-check provider runtime readiness when the active Home device changes.
 - Open a provider-setup gate only after a successful authoritative readiness response says the selected connected device is not ready.
-- Initialize an empty conversation provider/model selection from the authoritative ready response without replacing existing user intent.
+- Initialize an empty or partial conversation provider/model selection from the authoritative ready response without replacing a complete existing user route. Provider and model are one pair; either value alone must not block initialization.
 - When the forced first-provider gate completes, replace any stale client provider/model route with the authoritative ready pair before dismissing the gate.
 - Persist an accepted empty-state provider/model initialization before depending on the current Home widget lifecycle; route replacement must not discard a late authoritative readiness response.
 - Preserve the current Home UI when readiness checks fail or time out during disconnect or restart.
 - Forced provider-setup gates must remain dismissible so users cannot be trapped outside Home.
 - Show the injected readable worktree label only for linked worktrees launched through the development runtime; normal and main-checkout runs must not show an isolation badge.
+- Render the bottom Home status bar only on native desktop platforms. Responsive width is a layout decision and must never make the status bar appear on Web or mobile.
 
 ## Navigation Integration
 - Use the shared conversation history controller and typed destinations as the navigation authority.

--- a/client/lib/features/home/presentation/screens/home_screen.dart
+++ b/client/lib/features/home/presentation/screens/home_screen.dart
@@ -139,6 +139,7 @@ class _HomeScreenState extends State<HomeScreen> {
             agentCubit: context.read<DeviceCubit>(),
             sessionCubit: context.read<SessionCubit>(),
             conversationRepository: context.read<ConversationRepository>(),
+            conversationCacheRepository: context.read<ConversationCacheRepository>(),
             preferencesRepository: context.read<IDevicePreferencesRepository>(),
             capabilitiesStore: getIt<DeviceCapabilitiesStore>(),
             localToolRuntime: getIt<LocalToolRuntimeService>(),
@@ -348,14 +349,15 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
     }
 
     final draft = cacheRepository.newConversationDraft(device.id);
-    final hasExistingSelection =
+    final hasExistingProvider =
         inputCubit.state.nextMessageProviderId?.trim().isNotEmpty == true ||
-        inputCubit.state.nextMessageModel?.trim().isNotEmpty == true ||
         preferencesRepository.getLastProvider(device.id)?.trim().isNotEmpty == true ||
+        draft.providerId?.trim().isNotEmpty == true;
+    final hasExistingModel =
+        inputCubit.state.nextMessageModel?.trim().isNotEmpty == true ||
         preferencesRepository.getLastModel(device.id)?.trim().isNotEmpty == true ||
-        draft.providerId?.trim().isNotEmpty == true ||
         draft.model?.trim().isNotEmpty == true;
-    if (!replaceExisting && hasExistingSelection) return;
+    if (!replaceExisting && hasExistingProvider && hasExistingModel) return;
 
     if (!inputCubit.isClosed) {
       inputCubit.initializeProviderSelection(
@@ -476,7 +478,7 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
                       ],
                     ),
                   ),
-                  if (isDesktop) const StatusBar(),
+                  const DesktopOnlyStatusBar(),
                 ],
               ),
             );

--- a/client/lib/features/home/presentation/widgets/status_bar.dart
+++ b/client/lib/features/home/presentation/widgets/status_bar.dart
@@ -8,6 +8,22 @@ import 'package:sanad_client/core/navigation/app_routes.dart';
 import 'package:sanad_client/features/auth/presentation/bloc/auth_cubit.dart';
 import 'package:sanad_client/features/devices/domain/models/gateway_connection_status.dart';
 import 'package:sanad_client/features/devices/presentation/bloc/gateway_connection_cubit.dart';
+import 'package:sanad_client/utils/app_platform.dart';
+
+class DesktopOnlyStatusBar extends StatelessWidget {
+  final Widget child;
+
+  const DesktopOnlyStatusBar({
+    super.key,
+    this.child = const StatusBar(),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (!AppPlatform.isDesktop) return const SizedBox.shrink();
+    return child;
+  }
+}
 
 class StatusBar extends StatelessWidget {
   final String worktreeName;

--- a/client/test/unit/bloc/conversation_input_cubit_test.dart
+++ b/client/test/unit/bloc/conversation_input_cubit_test.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'package:sanad_client/features/conversations/data/repositories/conversation_cache_repository.dart';
+import 'package:sanad_client/features/conversations/domain/stores/conversation_cache_store.dart';
 import 'package:sanad_client/features/devices/data/device_connection_coordinator.dart';
 import 'package:sanad_client/features/devices/domain/models/device_config.dart';
 import 'package:sanad_client/features/devices/domain/models/capability.dart';
@@ -36,6 +38,8 @@ void main() {
   late FakeDeviceClientRegistry agentClientRegistry;
   late TestDeviceCubit agentCubit;
   late FakeConversationRepository conversationRepository;
+  late ConversationCacheStore conversationCacheStore;
+  late ConversationCacheRepository conversationCacheRepository;
   late FakeDevicePreferencesRepository preferencesRepository;
   late SessionCubit sessionCubit;
   late _TestSessionMessagesCubit messagesCubit;
@@ -64,6 +68,11 @@ void main() {
       agentClientRegistry: agentClientRegistry,
     );
     conversationRepository = FakeConversationRepository();
+    conversationCacheStore = ConversationCacheStore();
+    conversationCacheRepository = ConversationCacheRepository(
+      cache: conversationCacheStore,
+      transport: conversationRepository,
+    );
     preferencesRepository = FakeDevicePreferencesRepository();
     resolver = createTestResolver(cloudSocket: socket, localSocket: socket);
     capabilitiesStore = DeviceCapabilitiesStore(resolver);
@@ -90,6 +99,7 @@ void main() {
       agentCubit: agentCubit,
       sessionCubit: sessionCubit,
       conversationRepository: conversationRepository,
+      conversationCacheRepository: conversationCacheRepository,
       preferencesRepository: preferencesRepository,
       capabilitiesStore: capabilitiesStore,
       localToolRuntime: localToolRuntime,
@@ -104,6 +114,7 @@ void main() {
     await sessionCubit.close();
     await agentCubit.close();
     await conversationRepository.dispose();
+    conversationCacheStore.dispose();
     resolver.dispose();
     socket.dispose();
   });
@@ -114,6 +125,37 @@ void main() {
 
     expect(inputCubit.state.isProcessing, isTrue);
     expect(inputCubit.state.activeSessionId, 'session-1');
+  });
+
+  test('new users default to balanced thinking mode', () async {
+    await Future<void>.delayed(Duration.zero);
+
+    expect(inputCubit.state.nextMessageThinkingMode, SessionMessagesCubit.defaultThinkingMode);
+    expect(
+      preferencesRepository.getLastThinkingMode(agent.id),
+      SessionMessagesCubit.defaultThinkingMode,
+    );
+  });
+
+  test('cache workspace creation updates the composer picker immediately', () async {
+    final created = await conversationCacheRepository.createWorkspace(
+      agent,
+      path: '/new-workspace',
+      name: 'New Workspace',
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(created, isNotNull);
+    expect(
+      inputCubit.state.availableWorkspaces,
+      contains(
+        const DeviceWorkspace(
+          id: '/new-workspace',
+          name: 'New Workspace',
+          path: '/new-workspace',
+        ),
+      ),
+    );
   });
 
   test('sendMessage trims drafts and delegates non-empty text', () async {
@@ -191,6 +233,7 @@ void main() {
       'workspace_id': 'workspace-1',
       'provider_id': 'provider-1',
       'model': 'model-1',
+      'thinking_mode': SessionMessagesCubit.defaultThinkingMode,
     });
     expect(conversationRepository.sentMessageRequests.single['session_id'], 'session-1');
     expect(
@@ -735,7 +778,7 @@ void main() {
     // 1. Save some preferences first
     await preferencesRepository.setLastProvider(agent.id, 'provider-1');
     await preferencesRepository.setLastModel(agent.id, 'claude-3-opus');
-    await preferencesRepository.setLastThinkingMode(agent.id, 'balanced');
+      await preferencesRepository.setLastThinkingMode(agent.id, 'deep');
 
     // 2. Re-subscribe to agent by re-initializing the cubit (simulating fresh start)
     final newMessagesCubit = _TestSessionMessagesCubit(
@@ -754,7 +797,7 @@ void main() {
 
     expect(newInputCubit.state.nextMessageProviderId, 'provider-1');
     expect(newInputCubit.state.nextMessageModel, 'claude-3-opus');
-    expect(newInputCubit.state.nextMessageThinkingMode, 'balanced');
+      expect(newInputCubit.state.nextMessageThinkingMode, 'deep');
 
     await newInputCubit.close();
     await newMessagesCubit.close();
@@ -795,6 +838,20 @@ void main() {
       await restartedMessagesCubit.close();
     },
   );
+
+  test('authoritative readiness repairs a provider-only route', () async {
+    messagesCubit.setNextMessagePreferences(providerId: 'provider-partial');
+    await Future<void>.delayed(Duration.zero);
+
+    inputCubit.initializeProviderSelection(
+      providerId: 'provider-default',
+      model: 'model-default',
+    );
+    await Future<void>.delayed(Duration.zero);
+
+    expect(inputCubit.state.nextMessageProviderId, 'provider-default');
+    expect(inputCubit.state.nextMessageModel, 'model-default');
+  });
 
   test('initializes an empty provider route once from authoritative readiness', () async {
     inputCubit.initializeProviderSelection(
@@ -861,6 +918,7 @@ class _TestSessionMessagesCubit extends SessionMessagesCubit {
     required super.agentCubit,
     required super.sessionCubit,
     required super.conversationRepository,
+    super.conversationCacheRepository,
     required super.preferencesRepository,
     required super.capabilitiesStore,
     super.localToolRuntime,

--- a/client/test/widget/status_bar_platform_test.dart
+++ b/client/test/widget/status_bar_platform_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/home/presentation/widgets/status_bar.dart';
+import 'package:sanad_client/utils/app_platform.dart';
+
+void main() {
+  tearDown(() {
+    AppPlatform.overrideIsDesktop = null;
+  });
+
+  testWidgets('renders the home status bar child on native desktop', (
+    tester,
+  ) async {
+    AppPlatform.overrideIsDesktop = true;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: DesktopOnlyStatusBar(
+            child: SizedBox(key: Key('status-bar-content')),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('status-bar-content')), findsOneWidget);
+  });
+
+  testWidgets('hides the home status bar child off desktop', (tester) async {
+    AppPlatform.overrideIsDesktop = false;
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: DesktopOnlyStatusBar(
+            child: SizedBox(key: Key('status-bar-content')),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const Key('status-bar-content')), findsNothing);
+  });
+}

--- a/docs/plans/tasks/open-source-launch-polish.md
+++ b/docs/plans/tasks/open-source-launch-polish.md
@@ -1,0 +1,47 @@
+---
+title: "Open-Source Launch Polish"
+description: "Close workspace synchronization, first-run composer defaults, and platform status-bar gaps before the public announcement."
+status: "implemented_pending_review"
+scope: "Public Flutter client"
+---
+
+# Open-Source Launch Polish
+
+## Goal
+
+Deliver the final public-client launch polish in one focused pull request while
+implementing and verifying each user-facing issue independently.
+
+## Gates
+
+### Workspace selector synchronization
+
+- [x] Project authoritative `ConversationCacheRepository` workspace snapshots
+      into the composer state.
+- [x] Make a workspace created from the sidebar/cache available before the
+      selector is opened; never depend on a popup-open refresh cycle.
+- [x] Add focused regression coverage and update product, technical, contract,
+      and QA documentation.
+
+### First-run composer defaults
+
+- [x] Default an unset thinking mode to `balanced` without replacing a saved
+      returning-user choice.
+- [x] When a provider route exists and no model preference is saved, select the
+      daemon-owned default model instead of rendering an empty selector.
+- [x] Cover new-user and returning-user paths.
+
+### Desktop-only home status bar
+
+- [x] Render the home status bar only on native desktop targets.
+- [x] Keep it hidden on Web and mobile.
+- [x] Add platform-focused widget coverage.
+
+## Verification
+
+- Run focused Flutter unit/widget tests for every gate.
+- Run `fvm flutter analyze` after all client changes.
+- Run broader fast tests only if shared-state blast radius warrants them.
+- Run `graphify update .` after code changes.
+
+No commit, push, or pull request is performed without explicit user approval.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -25,6 +25,9 @@ Changing the selected device changes the workspaces, conversations, provider
 configuration, and runtime state displayed by the client. It does not create a
 new conversation.
 
+The compact Home gateway/status bar is a native-desktop surface. Web and mobile
+never render it, regardless of browser or viewport width.
+
 When an empty device inventory is still being requested, the sidebar identifies
 that request as loading rather than claiming that no devices exist. If the
 request settles successfully, times out, or fails without returning a device,
@@ -78,7 +81,13 @@ created only after the first accepted send.
 
 The same composer is used for a new conversation and an existing session. It
 preserves per-device drafts and the selected workspace, provider, model, and
-thinking mode.
+thinking mode. A first-time user with no thinking preference starts at
+`balanced`, while saved returning-user choices remain unchanged. When the
+runtime has an authoritative provider/model route, the model selector is never
+left empty merely because only the provider half was restored.
+
+A workspace created elsewhere in the client appears on the selector's first
+opening; users never need to close and reopen the menu to refresh it.
 
 ## Active work
 

--- a/docs/qa_maintenance/new_conversation_composer_app_bar_qa.md
+++ b/docs/qa_maintenance/new_conversation_composer_app_bar_qa.md
@@ -5,6 +5,17 @@ description: "Focused Plan 32d scenarios for unified composition, device-scoped 
 
 # New Conversation, Composer, and App Bar QA
 
+## First-run defaults
+
+- With no saved thinking preference, New Conversation displays and sends
+  `balanced`; the first capability-list item must not implicitly become the
+  default.
+- A non-empty saved thinking preference is restored unchanged.
+- A provider-only or model-only restored preference is incomplete. A successful
+  authoritative readiness pair fills both selector values.
+- A complete saved provider/model pair remains unchanged unless an explicit
+  authoritative replacement flow owns the update.
+
 ## Scope
 
 This matrix validates the Plan 32d client surface without changing daemon authority. It covers the shared composer used before and after session creation, draft ownership transitions, and the session metadata shown above conversation content.

--- a/docs/qa_maintenance/workspace_folder_management_qa.md
+++ b/docs/qa_maintenance/workspace_folder_management_qa.md
@@ -27,6 +27,7 @@ description: "Regression matrix for the temporary cloud workspace-management shu
 | Client warning | A remote picker attempt displays the temporary security message. |
 | No remote browser | Conversation, Sidebar, and Settings use the shared helper, which returns no path remotely and never opens `WorkspaceBrowserDialog`. |
 | Local picker | A confirmed same-desktop local device still opens the native picker and can create or relocate a workspace using the selected path. |
+| Client projection | A workspace created from the sidebar/cache appears in the composer selector on its first opening without a close/reopen cycle. |
 
 ## Manual Regression Scenarios
 

--- a/docs/technical/client_conversation_cache_schema.md
+++ b/docs/technical/client_conversation_cache_schema.md
@@ -14,7 +14,7 @@ description: "Ownership, persistence schema, pagination rules, draft correlation
 `ConversationCacheStore` (`lib/features/conversations/domain/stores/conversation_cache_store.dart`) is the single in-memory owner of:
 
 - Active device context.
-- Cached workspace list per device.
+- Cached workspace list per device. Ready, refreshing, or stale-error workspace snapshots project immediately into both the sidebar and composer selector; a create/update mutation must not wait for the selector popup to open.
 - Unscoped conversation page per device.
 - Per-workspace conversation pages per `deviceId + workspaceId`.
 - Cursors, `hasMore`, loading/error state, and last-refresh time per resource.


### PR DESCRIPTION
## Problem / Goal
Final public-client launch polish (plan: `docs/plans/tasks/open-source-launch-polish.md`):
1. A workspace created from the sidebar was not visible in the composer selector until a popup-open refresh cycle.
2. New users saw an empty thinking-mode / model selector on first run.
3. The home status bar rendered on non-desktop targets.

## Technical Changes
- `session_messages_cubit.dart` — subscribe to `ConversationCacheRepository` snapshots and project cached workspaces into composer state; route workspace creation through the cache repository; default an unset thinking mode to `balanced` and persist it.
- `home_screen.dart` — treat provider and model defaults independently so a saved provider no longer blocks applying the daemon-owned default model; render the status bar via the desktop-only wrapper.
- `status_bar.dart` — add `DesktopOnlyStatusBar` (native desktop targets only).
- Tests: `conversation_input_cubit_test.dart` (new/returning-user defaults), new `status_bar_platform_test.dart` (desktop on/off).
- Docs: product interface, cache schema, AGENTS contracts, QA checklists, plan file.

## Verification
- `fvm flutter analyze` — no issues.
- `fvm flutter test test/unit/bloc/conversation_input_cubit_test.dart test/widget/status_bar_platform_test.dart` — 34/34 passed.
