### PR TITLE
fix(client): unify assistant markdown rendering

### DIFF
--- a/client/lib/features/conversations/presentation/widgets/app_markdown_renderer.dart
+++ b/client/lib/features/conversations/presentation/widgets/app_markdown_renderer.dart
@@ -1,21 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:flutter_streaming_text_markdown/flutter_streaming_text_markdown.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/markdown_style_helper.dart';
 
-/// Application-owned Markdown boundary for both progressive and completed text.
+/// Application-owned Markdown boundary for progressive and completed text.
 ///
-/// Keeping the package choice here prevents conversation widgets from depending
-/// on either renderer directly and makes fallback a one-line configuration
-/// change if the streaming package proves unsuitable.
+/// Both states deliberately use the final-answer [MarkdownBody] with one style,
+/// builder, directionality, and link-handling path.
 class AppMarkdownRenderer extends StatelessWidget {
-  static const bool enableStreamingRenderer = true;
-
   final String data;
   final bool isFinal;
   final void Function(String text, String? href, String title)? onTapLink;
   final Map<String, MarkdownElementBuilder>? builders;
-  final bool isStreaming;
 
   const AppMarkdownRenderer({
     super.key,
@@ -23,7 +18,6 @@ class AppMarkdownRenderer extends StatelessWidget {
     required this.isFinal,
     this.onTapLink,
     this.builders,
-    this.isStreaming = false,
   });
 
   @override
@@ -32,21 +26,6 @@ class AppMarkdownRenderer extends StatelessWidget {
       context,
       isFinal: isFinal,
     );
-    if (enableStreamingRenderer && isStreaming) {
-      return StreamingTextMarkdown(
-        text: data,
-        markdownEnabled: true,
-        animationsEnabled: false,
-        fadeInEnabled: false,
-        typingSpeed: Duration.zero,
-        autoScroll: false,
-        completeAnimationOnTap: false,
-        textDirection: Directionality.of(context),
-        styleSheet: markdownStyle.p,
-        onLinkTap: (url, title) => onTapLink?.call(url, url, title),
-      );
-    }
-
     return MarkdownBody(
       data: data,
       styleSheet: markdownStyle,

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -331,7 +331,6 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
             data: widget.event.text,
             isFinal: true,
             onTapLink: _onTapLink,
-            isStreaming: widget.event.status == EventStatus.running,
           ),
         ),
       ),
@@ -531,7 +530,6 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
             data: widget.event.text,
             isFinal: false,
             onTapLink: _onTapLink,
-            isStreaming: widget.event.status == EventStatus.running,
           ),
         );
     }

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -395,14 +395,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.7+1"
-  flutter_math_fork:
-    dependency: transitive
-    description:
-      name: flutter_math_fork
-      sha256: "6d5f2f1aa57ae539ffb0a04bb39d2da67af74601d685a161aff7ce5bda5fa407"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.7.4"
   flutter_rust_bridge:
     dependency: "direct overridden"
     description:
@@ -419,14 +411,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
-  flutter_streaming_text_markdown:
-    dependency: "direct main"
-    description:
-      name: flutter_streaming_text_markdown
-      sha256: "4358850cbc339bd1d7c0d2ea942de0b389885c06e3f0fbfb1264c8f4c1cc5a3f"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.9.1"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -490,14 +474,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.3.3"
-  gpt_markdown:
-    dependency: transitive
-    description:
-      name: gpt_markdown
-      sha256: ab6fe339f500104816139a034b8a23a125dadbc1988eda1641c6616562a4962b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.8"
   highlight:
     dependency: "direct main"
     description:
@@ -1251,14 +1227,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
-  tuple:
-    dependency: transitive
-    description:
-      name: tuple
-      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -67,7 +67,6 @@ dependencies:
   flutter_highlight: ^0.7.0
   highlight: ^0.7.0
   flutter_markdown: ^0.7.7+1
-  flutter_streaming_text_markdown: ^1.9.1
   flutter_svg: ^2.0.17
   code_forge: ^5.1.0
   re_highlight: ^0.0.3

--- a/client/test/widget/reasoning_event_tile_test.dart
+++ b/client/test/widget/reasoning_event_tile_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
-import 'package:flutter_streaming_text_markdown/flutter_streaming_text_markdown.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/event_tile.dart';
@@ -9,7 +8,7 @@ import 'package:sanad_client/shared/widgets/copy_button.dart';
 
 void main() {
   testWidgets(
-    'running thinking uses the streaming Markdown renderer with app styling',
+    'running thinking uses the final-answer Markdown renderer and styling',
     (tester) async {
       await _pumpEvent(
         tester,
@@ -19,18 +18,62 @@ void main() {
           text: '### Shared heading',
         ),
       );
-      final rendererFinder = find.byType(StreamingTextMarkdown);
+      final rendererFinder = find.byType(MarkdownBody);
       final rendererContext = tester.element(rendererFinder);
       final finalStyle = MarkdownStyleHelper.getStyleSheet(
         rendererContext,
         isFinal: true,
       );
-      final renderer = tester.widget<StreamingTextMarkdown>(rendererFinder);
-      expect(renderer.markdownEnabled, isTrue);
-      expect(renderer.animationsEnabled, isFalse);
-      expect(renderer.autoScroll, isFalse);
-      expect(renderer.styleSheet, finalStyle.p);
+      final renderer = tester.widget<MarkdownBody>(rendererFinder);
+      expect(renderer.data, '### Shared heading');
+      expect(renderer.styleSheet, finalStyle);
+      expect(renderer.builders, isNotNull);
+      expect(renderer.builders.keys, contains('code'));
       expect(find.byKey(const Key('primary_markdown_thinking')), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'running and completed text use the same MarkdownBody configuration',
+    (tester) async {
+      await _pumpEvent(
+        tester,
+        _event(
+          kind: EventKind.thinking,
+          status: EventStatus.running,
+          text: '**Shared content**',
+        ),
+      );
+      final runningRenderer = tester.widget<MarkdownBody>(
+        find.byType(MarkdownBody),
+      );
+
+      await _pumpEvent(
+        tester,
+        _event(
+          kind: EventKind.thinking,
+          status: EventStatus.done,
+          text: '**Shared content**',
+        ),
+      );
+      final completedRenderer = tester.widget<MarkdownBody>(
+        find.byType(MarkdownBody),
+      );
+      final runningStyle = runningRenderer.styleSheet!;
+      final completedStyle = completedRenderer.styleSheet!;
+
+      expect(runningStyle.p, completedStyle.p);
+      expect(runningStyle.code, completedStyle.code);
+      expect(runningStyle.blockquote, completedStyle.blockquote);
+      expect(
+        runningStyle.codeblockDecoration,
+        completedStyle.codeblockDecoration,
+      );
+      expect(runningRenderer.builders.keys, completedRenderer.builders.keys);
+      expect(
+        runningRenderer.builders['code'].runtimeType,
+        completedRenderer.builders['code'].runtimeType,
+      );
     },
   );
 

--- a/docs/plans/tasks/69-streaming-markdown-snapshot-steer-parity.md
+++ b/docs/plans/tasks/69-streaming-markdown-snapshot-steer-parity.md
@@ -4,7 +4,7 @@
 Keep progressive Markdown readable, make in-flight projection mutation single-owner, and preserve a completed assistant segment when a late steer continues the same run.
 
 ## Implementation
-1. Introduce one application Markdown abstraction with a streaming renderer and the existing final renderer while preserving styles, links, inline code, RTL, selection, and web compatibility.
+1. Keep one application Markdown abstraction and render both streaming and completed assistant text with the existing final-answer renderer, preserving styles, links, inline code, RTL, selection, and web compatibility. Remove the alternative progressive renderer dependency so only one Markdown implementation can enter the conversation widget tree.
 2. Remove in-flight snapshot mutation from per-platform protocol translation and project each response exactly once before platform fan-out.
 3. At a late-steer continuation boundary, publish the completed pre-steer assistant segment as a done thought before resetting terminal accumulation and starting the next model step.
 4. Hydrate the same superseded assistant segment as a thought from history.
@@ -14,5 +14,5 @@ Keep progressive Markdown readable, make in-flight projection mutation single-ow
 - Local and cloud fan-out cannot double-append an in-flight chunk.
 - Reopening an active session merges one snapshot with subsequent deltas without duplicated characters.
 - Live and historical late-steer timelines retain the completed pre-steer content in order.
-- Streaming Markdown uses the application abstraction on desktop, mobile, and web.
+- Streaming Markdown uses the same final-answer renderer through the application abstraction on desktop, mobile, and web.
 - Focused tests plus agent/client analyzers pass; owning technical and QA docs are current.

--- a/docs/technical/reasoning_thoughts_separation.md
+++ b/docs/technical/reasoning_thoughts_separation.md
@@ -134,14 +134,13 @@ reasoning streams are discarded.
 ### Markdown content
 
 `thinking` (Thoughts) and Final Answer pass through the application-owned
-`AppMarkdownRenderer` boundary. Running text uses the progressive Markdown
-renderer without artificial typing, fade, or nested auto-scroll; completed text
-uses `MarkdownBody`. The boundary preserves the application typography
-baseline, directionality, and link actions; completed content retains the
-application inline-code builder. The package choice remains isolated for
-rollback. There is no content-length threshold and no separate
-card, disclosure, measurement probe, bounded viewport, or nested scrollbar for
-streaming text.
+`AppMarkdownRenderer` boundary. Both running and completed text always use the
+final-answer `MarkdownBody` renderer with the same complete
+`MarkdownStyleSheet`, link handling, and inline-code builder. The former
+progressive Markdown dependency has been removed, so conversation content has
+only one Markdown implementation. There is no content-length threshold and no
+separate card, disclosure, measurement probe, bounded viewport, or nested
+scrollbar for streaming text.
 Long content grows naturally inside the conversation timeline.
 
 Final Answer may append response metadata below the shared renderer. The


### PR DESCRIPTION
## Problem / Goal

Running assistant thoughts and completed final answers used different Markdown implementations, causing headings, tables, colors, and typography to change when the final answer arrived. Use the final-answer renderer as the single conversation Markdown implementation.

Tracks the Markdown renderer work in `docs/plans/tasks/69-streaming-markdown-snapshot-steer-parity.md`.

## Changes

- Render running and completed assistant text through `MarkdownBody` only.
- Remove the obsolete `isStreaming` renderer branch from conversation widgets.
- Remove `flutter_streaming_text_markdown` and its now-unused transitive dependencies.
- Add widget regressions confirming running and completed thoughts use the same renderer, style sheet, and code builder.
- Update the owning task and technical design documentation.

## Verification

- `fvm flutter analyze`
- `fvm flutter test test/widget/reasoning_event_tile_test.dart`
- Manual Windows debug checks with Markdown tables and headings during thought streaming and final-answer rendering.

## Risk and cross-platform impact

Low-to-moderate presentation risk. Desktop, mobile, and web now use the existing final-answer `flutter_markdown` path for progressive assistant text. Content updates still rebuild from the accumulated stream, but the specialized progressive renderer and its animation behavior are removed.

## Documentation

- `docs/plans/tasks/69-streaming-markdown-snapshot-steer-parity.md`
- `docs/technical/reasoning_thoughts_separation.md`

## Rollback

Revert this PR to restore the separate progressive renderer dependency and status-based renderer branch.