### PR TITLE
Automate Stable Client download aliases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,13 @@ jobs:
           grep -F 'build/web/sanad-public-sha.txt' .github/workflows/release.yml
           grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
+          grep -F 'environment: client-downloads-production' .github/workflows/release.yml
+          grep -F 'sanad-client-downloads-control deploy' .github/workflows/release.yml
+          ! grep -Fq '/srv/sanad/' .github/workflows/deploy.yml
+          grep -Fq '/opt/sanad-sites/assets/web' .github/workflows/deploy.yml
+          grep -Fq '/opt/sanad-sites/assets/updates' .github/workflows/deploy.yml
+          grep -Fq '/opt/sanad-sites/assets/install' .github/workflows/deploy.yml
+          scripts/release/test_generate_client_download_redirects.sh
           grep -F -- '--draft' .github/workflows/release.yml
           grep -F 'release-manifest-rc.json' release/release-contract.json
           grep -F 'appcast-rc.xml' release/release-contract.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -92,15 +92,15 @@ jobs:
           set -euo pipefail
           tag="$RELEASE_TAG"
           expected_sha="$(git rev-parse HEAD)"
-          incoming="/srv/sanad/web/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          release="/srv/sanad/web/releases/$tag"
+          incoming="/opt/sanad-sites/assets/web/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          release="/opt/sanad-sites/assets/web/releases/$tag"
           if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
             "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'"; then
             echo "Reusing the existing immutable Production Web release $release."
             exit 0
           fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming' /srv/sanad/web/releases"
+            "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming' /opt/sanad-sites/assets/web/releases"
           rsync -az --delete --delay-updates web/ \
             "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
@@ -112,8 +112,8 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          release="/srv/sanad/web/releases/$RELEASE_TAG"
-          selector=/srv/sanad/web/current
+          release="/opt/sanad-sites/assets/web/releases/$RELEASE_TAG"
+          selector=/opt/sanad-sites/assets/web/current
           expected_sha="$(git rev-parse HEAD)"
           previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
           test -n "$previous"
@@ -203,11 +203,11 @@ jobs:
         run: |
           tag="${{ inputs.release_tag }}"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "mkdir -p /srv/sanad/updates/releases/$tag"
+            "mkdir -p /opt/sanad-sites/assets/updates/releases/$tag"
           rsync -az download/appcast.xml \
-            "$DEPLOY_USER@$DEPLOY_HOST:/srv/sanad/updates/releases/$tag/appcast.xml"
+            "$DEPLOY_USER@$DEPLOY_HOST:/opt/sanad-sites/assets/updates/releases/$tag/appcast.xml"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn /srv/sanad/updates/releases/$tag /srv/sanad/updates/current"
+            "set -eu; ln -sfn /opt/sanad-sites/assets/updates/releases/$tag /opt/sanad-sites/assets/updates/current"
 
   installers:
     if: inputs.deploy_installers == true
@@ -233,8 +233,8 @@ jobs:
         run: |
           revision="$(git rev-parse HEAD)"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "mkdir -p /srv/sanad/install/releases/$revision"
+            "mkdir -p /opt/sanad-sites/assets/install/releases/$revision"
           rsync -az scripts/install.sh scripts/install.ps1 \
-            "$DEPLOY_USER@$DEPLOY_HOST:/srv/sanad/install/releases/$revision/"
+            "$DEPLOY_USER@$DEPLOY_HOST:/opt/sanad-sites/assets/install/releases/$revision/"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn /srv/sanad/install/releases/$revision /srv/sanad/install/current"
+            "set -eu; ln -sfn /opt/sanad-sites/assets/install/releases/$revision /opt/sanad-sites/assets/install/current"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -639,3 +639,75 @@ jobs:
             -F draft=false \
             -F prerelease="$EXPECTED_PRERELEASE" \
             --silent
+
+  client-download-aliases:
+    name: Verify and deploy Stable Client aliases
+    needs: [validate, publish]
+    if: needs.validate.outputs.channel == 'stable'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: client-downloads-production
+    permissions:
+      contents: read
+      attestations: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.tag }}
+      - name: Configure pinned restricted SSH host
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          KNOWN_HOSTS: ${{ secrets.DEPLOY_SSH_KNOWN_HOSTS }}
+        run: |
+          install -d -m 700 "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_KEY" > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          chmod 600 "$HOME/.ssh/id_ed25519" "$HOME/.ssh/known_hosts"
+      - name: Verify published manifest and Client artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          release_state="$(gh release view "$RELEASE_TAG" --json isDraft,isPrerelease,tagName)"
+          jq -e --arg tag "$RELEASE_TAG" \
+            '.isDraft == false and .isPrerelease == false and .tagName == $tag' \
+            <<<"$release_state" >/dev/null
+          mkdir download generated
+          gh release download "$RELEASE_TAG" \
+            --pattern release-manifest.json --pattern SHA256SUMS --dir download
+          jq -e --arg tag "$RELEASE_TAG" --arg commit "$GITHUB_SHA" \
+            '.channel == "stable" and .tag == $tag and .commit == $commit' \
+            download/release-manifest.json >/dev/null
+          mapfile -t client_files < <(jq -r '
+            .artifacts[] |
+            select(.component == "client" and
+              ((.platform == "macos" and .architecture == "universal" and .format == "dmg") or
+               (.platform == "windows" and .architecture == "x64" and .format == "exe") or
+               (.platform == "linux" and .architecture == "x64" and .format == "tar.gz"))) |
+            .filename' download/release-manifest.json)
+          test "${#client_files[@]}" -eq 3
+          for file in "${client_files[@]}"; do
+            gh release download "$RELEASE_TAG" --pattern "$file" --dir download
+            gh attestation verify "download/$file" --repo "$GITHUB_REPOSITORY"
+          done
+          scripts/release/generate_client_download_redirects.sh \
+            download/release-manifest.json download/SHA256SUMS download \
+            generated/sanad-client-download-redirects.conf
+      - uses: actions/upload-artifact@v4
+        with:
+          name: stable-client-download-redirects-${{ needs.validate.outputs.tag }}
+          path: generated/sanad-client-download-redirects.conf
+          retention-days: ${{ env.RELEASE_ARTIFACT_RETENTION_DAYS }}
+          if-no-files-found: error
+      - name: Candidate, activate, verify, and roll back on failure
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
+          RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          manifest_sha="$(sha256sum download/release-manifest.json | awk '{print $1}')"
+          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "sudo /usr/local/sbin/sanad-client-downloads-control deploy '$RELEASE_TAG' '$manifest_sha'" \
+            < generated/sanad-client-download-redirects.conf

--- a/README.ar.md
+++ b/README.ar.md
@@ -74,19 +74,26 @@
 
 ### للمستخدمين
 
-#### ثبّت الواجهة والوكيل على هذا الجهاز
+#### نزّل واجهة Sanad Client
 
-1. نزّل Sanad Client لمنصة متاحة للتوزيع العام من
-   [أحدث إصدار](https://github.com/EastStarAI/sanad-agent/releases/latest).
-   يتوفر إصدار iOS الأول عبر Internal TestFlight فقط، وليس كتنزيل عام داخل
-   GitHub Releases.
-2. افتح واجهة سطح المكتب واختر **Run Locally**. ستنزّل الواجهة نسخة Sanad Agent
-   المطابقة وتتحقق منها وتثبتها وتشغلها على الجهاز نفسه.
-3. أضف مزودًا محليًا مثل Ollama أو LM Studio أو llama.cpp، أو أضف مزودًا
-   مستضافًا.
-4. اختر مساحة عمل وابدأ العمل.
+<p align="center">
+  <a href="https://downloads.sanad.eaststarai.com/client/macos"><img src="https://img.shields.io/badge/Download-macOS-2563EB?style=for-the-badge&logo=apple&logoColor=white" alt="تنزيل واجهة Sanad Client لنظام macOS"></a>
+  <a href="https://downloads.sanad.eaststarai.com/client/windows"><img src="https://img.shields.io/badge/Download-Windows-2563EB?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4OCA4OCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0wIDBoNDB2NDBIMHptNDggMGg0MHY0MEg0OHpNMCA0OGg0MHY0MEgwem00OCAwaDQwdjQwSDQ4eiIvPjwvc3ZnPg==" alt="تنزيل واجهة Sanad Client لنظام Windows"></a>
+  <a href="https://downloads.sanad.eaststarai.com/client/linux"><img src="https://img.shields.io/badge/Download-Linux-2563EB?style=for-the-badge&logo=linux&logoColor=white" alt="تنزيل واجهة Sanad Client لنظام Linux"></a>
+</p>
 
-لا يلزم حساب Sanad أو pairing token لهذا المسار المحلي.
+1. نزّل Sanad Client لمنصة سطح المكتب وافتحه.
+2. اختر **Run Locally**. تنزّل الواجهة نسخة Sanad Agent المطابقة وتتحقق منها
+   وتثبتها وتشغلها تلقائيًا؛ لا تحتاج إلى تنزيل Agent منفصلًا.
+3. أضف مزود نماذج محليًا أو مستضافًا، واختر مساحة عمل، وابدأ العمل.
+
+لا يلزم حساب Sanad أو pairing token لهذا المسار المحلي. على الهاتف، استخدم
+[Web Client](https://app.sanad.eaststarai.com) حتى تتوفر إصدارات Android وiOS
+المستقرة للعامة.
+
+> **بناء Windows غير موقّع:** إصدار Windows الحالي غير موقّع. نزّله فقط من
+> الزر الرسمي أعلاه واتبع إرشادات التحقق في
+> [دليل تثبيت واستخدام Sanad Agent](docs/operations/user_guide.md).
 
 #### صِل جهازًا آخر أو خادمًا بعيدًا
 

--- a/README.md
+++ b/README.md
@@ -65,19 +65,26 @@ safely carry out the path you choose. Then let Sanad handle the rest.
 
 ### For users
 
-#### Install the Client and Agent on this computer
+#### Download Sanad Client
 
-1. Download Sanad Client for a publicly distributed platform from the
-   [latest release](https://github.com/EastStarAI/sanad-agent/releases/latest).
-   The first iOS release is available only through Internal TestFlight, not as
-   a public GitHub Release download.
-2. Launch the desktop Client and choose **Run Locally**. The Client downloads,
-   verifies, installs, and starts the matching Sanad Agent on this computer.
-3. Add a local provider such as Ollama, LM Studio, or llama.cpp—or add a hosted
-   provider.
-4. Select a workspace and start working.
+<p align="center">
+  <a href="https://downloads.sanad.eaststarai.com/client/macos"><img src="https://img.shields.io/badge/Download_for-macOS-2563EB?style=for-the-badge&logo=apple&logoColor=white" alt="Download Sanad Client for macOS"></a>
+  <a href="https://downloads.sanad.eaststarai.com/client/windows"><img src="https://img.shields.io/badge/Download_for-Windows-2563EB?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA4OCA4OCIgZmlsbD0id2hpdGUiPjxwYXRoIGQ9Ik0wIDBoNDB2NDBIMHptNDggMGg0MHY0MEg0OHpNMCA0OGg0MHY0MEgwem00OCAwaDQwdjQwSDQ4eiIvPjwvc3ZnPg==" alt="Download Sanad Client for Windows"></a>
+  <a href="https://downloads.sanad.eaststarai.com/client/linux"><img src="https://img.shields.io/badge/Download_for-Linux-2563EB?style=for-the-badge&logo=linux&logoColor=white" alt="Download Sanad Client for Linux"></a>
+</p>
 
-A Sanad account and a pairing token are not required for this local-only path.
+1. Download and launch Sanad Client for your desktop platform.
+2. Choose **Run Locally**. The Client downloads, verifies, installs, and starts
+   the matching Sanad Agent automatically; you do not download Agent separately.
+3. Add a local or hosted model provider, select a workspace, and start working.
+
+A Sanad account and pairing token are not required for this local-only path.
+On mobile, use the [Web Client](https://app.sanad.eaststarai.com) until stable
+Android and iOS apps are publicly available.
+
+> **Unsigned Windows build:** The current Windows release is unsigned. Download it
+> only through the official button above and follow the verification guidance in
+> [Install and Use Sanad Agent](docs/operations/user_guide.md).
 
 #### Connect another computer or a server
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -63,6 +63,7 @@ These files are mandatory execution contracts governing subdirectories. Always r
 - [Develop Sanad Agent](docs/operations/developer_guide.md): Set up the public repository, run the Dart agent and Flutter client, test changes, and use isolated development runtimes.
 - [Release, Signing, and Deployment Architecture](docs/operations/release_and_signing.md): The stable release pipeline, protected signing boundaries, artifact publication, and live-release handoff.
 - [Install and Use Sanad Agent](docs/operations/user_guide.md): Install the Sanad client and agent, connect local or remote devices, configure providers, manage the service, and update Sanad.
+- [README Client Downloads](docs/plans/tasks/readme-client-downloads.md): Limited English/Arabic Quick Start refresh using the Production-only stable Client convenience links.
 - [خارطة متطلبات المنتج والأعمال](docs/product/MOC.md): فهرس وخارطة وثائق متطلبات المنتج، تجربة المستخدم، والأعمال الاستراتيجية للمشروع.
 - [Sanad Client Interface](docs/product/client_interface.md): Current user experience for devices, workspaces, conversations, providers, permissions, and active agent interactions.
 - [Conversation Navigation UX Spec](docs/product/conversation_navigation_ux_spec.md): UX specifications for conversation navigation destinations, history, deletion, and restart recovery.

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -71,6 +71,7 @@ private key is never copied into the Client checkout.
 | `windows-update-signing` | WinSparkle DSA update signing only; it does not provide Authenticode publisher identity |
 | `android-signing` | Android APK/AAB release signing |
 | `release-publication` | Atomic publication of an already reviewed Draft RC or Stable Release |
+| `client-downloads-production` | Post-publication verification and restricted deployment of Production-only Stable Client redirects |
 | `web-production` | Atomic Web deployment |
 | `updates-production` | Atomic Appcast deployment |
 | `installers-production` | Publishing canonical installer sources |
@@ -115,7 +116,9 @@ It requires an exact public `main` commit, inventories existing `v1` tags and
 Releases before the gate, has no write permission, and never creates a candidate.
 Probe approval is not Release publication approval.
 
-The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. The private Web handoff
+The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. After an approved Stable publication, the protected Client-download job downloads the public manifest, checksum file, and three desktop Client artifacts; verifies canonical URLs, byte sizes, SHA-256 values, and GitHub attestations; generates a deterministic Nginx redirect include; and sends only that include to the server's restricted control command. RC publication never enters this path. The server remains a redirector rather than an artifact mirror and owns candidate validation, atomic activation, public regression verification, and automatic rollback.
+
+Production Web, Appcast, and installer releases use `/opt/sanad-sites/assets/web`, `/opt/sanad-sites/assets/updates`, and `/opt/sanad-sites/assets/install`; the obsolete `/srv/sanad/*` workflow roots are not valid deployment targets. The private Web handoff
 is downloaded from the explicitly selected successful release-workflow run and
 verified against its GitHub build attestation. Server deployment then writes a
 versioned directory and changes a `current` symlink only after the transfer

--- a/docs/operations/user_guide.md
+++ b/docs/operations/user_guide.md
@@ -18,17 +18,22 @@ install only the standalone Agent on the remote machine.
 
 ## Install Sanad Client
 
-Open the [latest Sanad Agent release](https://github.com/EastStarAI/sanad-agent/releases/latest)
-and choose the client package for your platform:
+Use the Production convenience link for your platform. Each link redirects to
+the matching public Stable Client artifact, so end users do not need to choose
+from the mixed Client, Agent, checksum, and update files on GitHub Releases.
 
-| Platform | Package |
+| Platform | Install or open |
 |---|---|
-| macOS | `sanad-client-<version>-macos-universal.dmg` |
-| Windows | `sanad-client-<version>-windows-x64.exe` |
-| Linux | `sanad-client-<version>-linux-x64.tar.gz` |
-| Android | `sanad-client-<version>-android-universal.apk` |
-| iOS | Internal TestFlight invitation only for the first release |
+| macOS | [Download Sanad Client for macOS](https://downloads.sanad.eaststarai.com/client/macos) |
+| Windows | [Download Sanad Client for Windows](https://downloads.sanad.eaststarai.com/client/windows) |
+| Linux | [Download Sanad Client for Linux](https://downloads.sanad.eaststarai.com/client/linux) |
+| Android | No stable public app yet; use the Web Client |
+| iOS | No stable public app yet; use the Web Client |
 | Web | [app.sanad.eaststarai.com](https://app.sanad.eaststarai.com) |
+
+These aliases exist only on the unprefixed Production downloads host. Their
+Stable destinations are verified against the release manifest before an edge
+configuration update; Development and Staging do not publish equivalent links.
 
 ### macOS
 

--- a/docs/plans/tasks/readme-client-downloads.md
+++ b/docs/plans/tasks/readme-client-downloads.md
@@ -1,0 +1,27 @@
+# README Client Downloads
+
+## Status
+
+Complete.
+
+## Goal
+
+Simplify only the end-user Quick Start in the English and Arabic READMEs so users download Sanad Client directly without navigating the mixed GitHub Release asset list.
+
+## Contract
+
+- Keep the overall README structure and technical content unchanged.
+- Present direct Production-only convenience links for macOS, Windows, and Linux.
+- After each approved Stable publication, verify the public manifest, checksums, artifact sizes, hashes, and attestations before generating and deploying the three redirect destinations through the protected `client-downloads-production` Environment.
+- Keep GitHub Releases as the artifact origin; the private server returns redirects and never mirrors or proxies Client bytes.
+- Explain that Run Locally manages the matching Agent; users do not download Agent separately.
+- Keep Android and iOS out of the native download buttons until stable distribution is approved.
+- Preserve a concise Windows unsigned-build warning and link to the full user guide.
+- Keep English and Arabic flows equivalent.
+
+## Definition of Done
+
+- Both READMEs expose the same three platform actions in the same order.
+- Every action uses `https://downloads.sanad.eaststarai.com/client/<platform>`.
+- No Quick Start action sends an end user to the mixed GitHub Release page.
+- Documentation link and static parity checks pass.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -74,6 +74,10 @@ inventory again found zero `v1` tags and zero `v1` Releases or Drafts. This
 closes the rejection/no-partial-publication evidence only; it grants no
 approval for RC1 or any later publication.
 
+## Stable Client convenience-link gate
+
+Only an approved, published Stable Release may update the Production convenience links. The post-publication job must reject Drafts, prereleases, non-canonical repositories or URLs, missing or duplicate desktop Client entries, Agent artifacts, and any size, SHA-256, checksum-file, or attestation mismatch. Its generated include contains exactly macOS, Windows, and Linux redirects and is retained as workflow evidence. The restricted server command must pass a loopback candidate before atomic activation, verify Production plus Development and Staging regressions, and restore the preceding include on any reload or verification failure. Development and Staging never expose equivalent aliases, and Client bytes continue to download directly from GitHub Releases.
+
 ## Update failure coverage
 
 Automated tests cover contract parsing, invalid tag rejection, deterministic

--- a/scripts/release/generate_client_download_redirects.sh
+++ b/scripts/release/generate_client_download_redirects.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST="${1:-}"
+CHECKSUMS="${2:-}"
+ASSET_DIR="${3:-}"
+OUTPUT="${4:-}"
+
+test -f "$MANIFEST" && test -f "$CHECKSUMS" && test -d "$ASSET_DIR" && test -n "$OUTPUT" || {
+  echo "Usage: $0 <release-manifest.json> <SHA256SUMS> <asset-directory> <output.conf>" >&2
+  exit 64
+}
+command -v jq >/dev/null
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
+repository="$(jq -er '.repository' "$MANIFEST")"
+tag="$(jq -er '.tag' "$MANIFEST")"
+version="$(jq -er '.version' "$MANIFEST")"
+commit="$(jq -er '.commit' "$MANIFEST")"
+channel="$(jq -er '.channel' "$MANIFEST")"
+
+[[ "$repository" == EastStarAI/sanad-agent ]]
+[[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+[[ "$version" == "${tag#v}" ]]
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]]
+[[ "$channel" == stable ]]
+
+manifest_sha="$(sha256_file "$MANIFEST")"
+temporary="$(mktemp -t sanad-client-redirects.XXXXXX)"
+trap 'rm -f "$temporary"' EXIT
+{
+  echo "# Generated from $repository $tag ($commit)."
+  echo "# release-manifest.json sha256: $manifest_sha"
+} > "$temporary"
+
+while IFS=$'\t' read -r platform architecture format; do
+  entry="$(jq -ec \
+    --arg platform "$platform" --arg architecture "$architecture" --arg format "$format" \
+    '[.artifacts[] | select(.component == "client" and .platform == $platform and .architecture == $architecture and .format == $format and .public == true)] | if length == 1 then .[0] else error("expected exactly one public Client artifact") end' \
+    "$MANIFEST")"
+  filename="$(jq -er '.filename' <<<"$entry")"
+  url="$(jq -er '.url' <<<"$entry")"
+  expected_sha="$(jq -er '.sha256' <<<"$entry")"
+  expected_size="$(jq -er '.size' <<<"$entry")"
+  expected_url="https://github.com/$repository/releases/download/$tag/$filename"
+  [[ "$url" == "$expected_url" ]]
+  [[ "$expected_sha" =~ ^[0-9a-f]{64}$ ]]
+  [[ "$expected_size" =~ ^[1-9][0-9]*$ ]]
+  asset="$ASSET_DIR/$filename"
+  test -f "$asset"
+  [[ "$(wc -c < "$asset" | tr -d ' ')" == "$expected_size" ]]
+  [[ "$(sha256_file "$asset")" == "$expected_sha" ]]
+  [[ "$(awk -v file="$filename" '$2 == file {print $1}' "$CHECKSUMS")" == "$expected_sha" ]]
+  [[ "$(awk -v file="$filename" '$2 == file {count++} END {print count+0}' "$CHECKSUMS")" == 1 ]]
+  printf 'location = /client/%s { return 302 %s; }\n' "$platform" "$url" >> "$temporary"
+done <<'PLATFORMS'
+macos	universal	dmg
+windows	x64	exe
+linux	x64	tar.gz
+PLATFORMS
+
+install -m 0644 "$temporary" "$OUTPUT"
+echo "client-download-redirects=verified tag=$tag manifest_sha256=$manifest_sha"

--- a/scripts/release/test_generate_client_download_redirects.sh
+++ b/scripts/release/test_generate_client_download_redirects.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+GENERATOR="$SCRIPT_DIR/generate_client_download_redirects.sh"
+ROOT="$(mktemp -d -t sanad-client-redirect-test.XXXXXX)"
+trap 'rm -rf "$ROOT"' EXIT
+mkdir "$ROOT/assets"
+printf macos > "$ROOT/assets/client-macos.dmg"
+printf windows > "$ROOT/assets/client-windows.exe"
+printf linux > "$ROOT/assets/client-linux.tar.gz"
+
+sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi; }
+for file in "$ROOT"/assets/*; do printf '%s  %s\n' "$(sha "$file")" "$(basename "$file")"; done > "$ROOT/SHA256SUMS"
+
+jq -n \
+  --arg mac_sha "$(sha "$ROOT/assets/client-macos.dmg")" \
+  --arg win_sha "$(sha "$ROOT/assets/client-windows.exe")" \
+  --arg linux_sha "$(sha "$ROOT/assets/client-linux.tar.gz")" \
+  '{schema_version:1,version:"9.8.7",tag:"v9.8.7",commit:"0123456789abcdef0123456789abcdef01234567",channel:"stable",repository:"EastStarAI/sanad-agent",artifacts:[
+    {component:"client",platform:"macos",architecture:"universal",format:"dmg",filename:"client-macos.dmg",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-macos.dmg",sha256:$mac_sha,size:5,public:true},
+    {component:"client",platform:"windows",architecture:"x64",format:"exe",filename:"client-windows.exe",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-windows.exe",sha256:$win_sha,size:7,public:true},
+    {component:"client",platform:"linux",architecture:"x64",format:"tar.gz",filename:"client-linux.tar.gz",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-linux.tar.gz",sha256:$linux_sha,size:5,public:true}
+  ]}' > "$ROOT/manifest.json"
+
+"$GENERATOR" "$ROOT/manifest.json" "$ROOT/SHA256SUMS" "$ROOT/assets" "$ROOT/redirects.conf" >/dev/null
+for platform in macos windows linux; do test "$(grep -Fc "location = /client/$platform" "$ROOT/redirects.conf")" -eq 1; done
+! grep -Fq sanad-agent- "$ROOT/redirects.conf"
+
+jq '.channel = "rc"' "$ROOT/manifest.json" > "$ROOT/bad.json"
+! "$GENERATOR" "$ROOT/bad.json" "$ROOT/SHA256SUMS" "$ROOT/assets" "$ROOT/bad.conf" >/dev/null 2>&1
+jq '.artifacts[0].component = "agent"' "$ROOT/manifest.json" > "$ROOT/bad.json"
+! "$GENERATOR" "$ROOT/bad.json" "$ROOT/SHA256SUMS" "$ROOT/assets" "$ROOT/bad.conf" >/dev/null 2>&1
+jq '.artifacts[1].size = 8' "$ROOT/manifest.json" > "$ROOT/bad.json"
+! "$GENERATOR" "$ROOT/bad.json" "$ROOT/SHA256SUMS" "$ROOT/assets" "$ROOT/bad.conf" >/dev/null 2>&1
+
+echo "client-download-redirect-generator=pass"


### PR DESCRIPTION
## Summary
- add direct Client download actions to the English and Arabic READMEs
- verify every published Stable desktop Client artifact against the manifest, size, SHA-256, checksum file, and GitHub attestation
- generate deterministic Production-only redirects and deploy them through a protected restricted server path
- normalize prepared Production asset workflow roots under `/opt/sanad-sites/assets`

## Verification
- generator fixture and failure tests
- real v1.0.0 manifest/artifact size and SHA-256 verification
- workflow YAML parse
- documentation and diff checks