### PR TITLE
fix(release): harden platform validation races

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,8 +220,19 @@ jobs:
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
             --wait
-          codesign --verify --strict --test-requirement '=notarized' \
-            --verbose=2 "$agent"
+          ticket_verified=false
+          for attempt in {1..12}; do
+            if codesign --verify --strict --test-requirement '=notarized' \
+              --verbose=2 "$agent"; then
+              ticket_verified=true
+              break
+            fi
+            if [[ "$attempt" -lt 12 ]]; then
+              echo "Notarization ticket is not queryable yet; retrying ($attempt/12)."
+              sleep 10
+            fi
+          done
+          test "$ticket_verified" = true
       - uses: actions/upload-artifact@v4
         with:
           name: agent-${{ matrix.platform }}-${{ matrix.architecture }}

--- a/agent/test/core/update/release_manifest_test.dart
+++ b/agent/test/core/update/release_manifest_test.dart
@@ -465,16 +465,18 @@ void main() {
 
         expect(await service.scheduleWindowsReplacement(result), isTrue);
         final resultFile = File('${target.path}.update-result.json');
+        final replacementScript = File('${staged.path}.replace.ps1');
         for (
           var attempt = 0;
-          attempt < 40 && !resultFile.existsSync();
+          attempt < 40 &&
+              (!resultFile.existsSync() || replacementScript.existsSync());
           attempt++
         ) {
           await Future<void>.delayed(const Duration(milliseconds: 100));
         }
         expect(resultFile.existsSync(), isTrue);
         expect(jsonDecode(resultFile.readAsStringSync())['status'], 'started');
-        expect(File('${staged.path}.replace.ps1').existsSync(), isFalse);
+        expect(replacementScript.existsSync(), isFalse);
       },
       skip: Platform.isWindows ? false : 'Windows native PowerShell gate.',
     );

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -50,8 +50,10 @@ The macOS Agent uses Hardened Runtime with the narrowly scoped
 Dart AOT runtime stubs. The workflow injects the validated release-contract
 version at compilation, signs with that entitlement, executes the signed binary,
 and submits it for notarization. Raw CLI notarization is checked with
-`codesign --test-requirement '=notarized'`; `spctl --type execute` is not used
-because it rejects valid notarized non-bundle executables.
+`codesign --test-requirement '=notarized'`; after Apple accepts the submission,
+the workflow allows a short bounded retry window for ticket lookup propagation
+and still fails closed when the requirement remains unsatisfied. `spctl --type
+execute` is not used because it rejects valid notarized non-bundle executables.
 
 The hosted macOS Client job restores the exported Sparkle Ed25519 key to a
 runner-temporary file and passes that file directly to Sparkle `sign_update`.

--- a/docs/plans/tasks/macos-agent-notarization-ticket-propagation.md
+++ b/docs/plans/tasks/macos-agent-notarization-ticket-propagation.md
@@ -1,0 +1,28 @@
+---
+title: "macOS Agent Notarization Ticket Propagation"
+description: "Keep the macOS release gate strict while allowing bounded time for an accepted notarization ticket to become queryable."
+---
+
+# macOS Agent Notarization Ticket Propagation
+
+## Problem
+
+Both hosted macOS Agent submissions were accepted by Apple, but the immediate
+raw-executable `codesign --test-requirement '=notarized'` lookup failed. The
+same check passed in earlier release probes, indicating a delay between accepted
+submission processing and ticket lookup availability rather than a signing or
+notarization rejection.
+
+## Change
+
+Keep Apple acceptance and the explicit raw-executable notarization requirement
+mandatory. Retry only the ticket lookup for a short bounded interval, then fail
+closed if no attempt succeeds.
+
+## Definition of Done
+
+- The workflow still requires `notarytool submit --wait` success.
+- The explicit `=notarized` requirement remains mandatory for both Agent architectures.
+- Retries are bounded and end in failure when the ticket stays unavailable.
+- Workflow syntax and repository release checks pass locally.
+- A macOS machine or hosted runner provides final `codesign` evidence.

--- a/docs/plans/tasks/windows-agent-release-handshake-race.md
+++ b/docs/plans/tasks/windows-agent-release-handshake-race.md
@@ -1,0 +1,28 @@
+---
+title: "Windows Agent Release Handshake Race"
+description: "Remove the timing race from the native Windows replacement release gate without weakening updater behavior."
+---
+
+# Windows Agent Release Handshake Race
+
+## Problem
+
+The hosted Windows Agent release gate can observe the updater result file after
+PowerShell writes `started` but before the detached script completes its final
+self-cleanup. The release test then fails on the still-present script even
+though the replacement handshake succeeded.
+
+## Change
+
+Keep the production replacement protocol unchanged. Make the native Windows
+release test wait for both terminal evidence: the result file exists and the
+detached replacement script has been removed. Retain explicit assertions for
+the `started` status and script cleanup.
+
+## Definition of Done
+
+- The focused native Windows handshake test passes locally.
+- The complete Windows release/update test file passes locally.
+- `fvm dart analyze` passes in `agent/`.
+- A release-version Windows Agent executable compiles locally.
+- The release verification guide records the race-safe terminal assertion.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -33,7 +33,7 @@ rules remain fail-closed.
 
 | Target | Local evidence | Hosted or clean-machine evidence still required |
 |---|---|---|
-| Agent macOS arm64/x64 | compilation, version, architecture, Developer ID verification | both hosted runners, clean install, real upgrade and rollback |
+| Agent macOS arm64/x64 | compilation, version, architecture, Developer ID verification, bounded accepted-ticket lookup | both hosted runners, clean install, real upgrade and rollback |
 | Agent Linux x64 | contract and workflow path | hosted build, provenance, clean install, service/update/rollback |
 | Agent Windows x64 | contract and workflow path | Unsigned Windows build disclosure, SHA-256/manifest/provenance, Defender/SmartScreen and lifecycle on Windows 11, service/update/rollback |
 | Client macOS universal | universal Mach-O inspection, Developer ID-signed and notarized DMG, staple, Gatekeeper, Sparkle signature | clean update and rollback |
@@ -82,7 +82,10 @@ Only an approved, published Stable Release may update the Production convenience
 
 Automated tests cover contract parsing, invalid tag rejection, deterministic
 Appcast output, source-managed no-mutation behavior, checksum rejection, client
-bootstrap selection, and existing daemon-controller behavior.
+bootstrap selection, and existing daemon-controller behavior. The native Windows
+replacement gate waits for both terminal result publication and detached-script
+cleanup, because PowerShell writes the result immediately before its final
+self-removal.
 
 Hosted validation begins with a `validation_only` full-matrix run from protected `main`. It requires no tag and must leave zero Drafts and Releases while retaining private Agent/Client artifacts, the signed IPA, manifest, checksums, SBOM, Appcast, and attestations. Later lifecycle validation additionally exercises interrupted downloads, wrong architecture, corrupted size and checksum, replacement failure, service restart, retained Sanad Home, repeated update requests, and rollback to the prior signed version.
 


### PR DESCRIPTION
## Problem / Goal

Release validation run 31293235254 exposed two timing races after the underlying operations succeeded: the Windows updater test observed its detached script before final self-cleanup, and both accepted macOS Agent notarizations were checked before the ticket became queryable.

## Changes

- Wait for both the Windows terminal result and detached-script cleanup in the native updater gate.
- Keep macOS notarization fail-closed while retrying the explicit raw-CLI ticket requirement for a bounded interval.
- Document both release verification boundaries and focused plans.

## Verification

- Native Windows PowerShell handshake: passed 10/10 repeated runs.
- `fvm dart test test/core/update/release_manifest_test.dart`: 21 passed.
- `fvm dart analyze` in `agent/`: no issues.
- Windows Agent release compile and `version`: 1.0.1 on Windows x64.
- Release contract validation: `v1.0.1+2 (stable)`.
- `release.yml` parsed successfully with the repository-resolved Dart YAML parser.
- `git diff --check`: passed.

## Risk / Cross-platform impact

The Windows production replacement protocol is unchanged; only its asynchronous test assertion is hardened. macOS still requires Apple acceptance and `=notarized`; retries are bounded to 12 attempts with 10-second waits and fail closed.

## Documentation

Updated release architecture and QA verification guidance, with focused task plans.

## Rollback

Revert this PR to restore the immediate assertions.
