### PR TITLE
fix(release): harden cross-platform validation gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,13 @@ jobs:
           grep -F 'name: Build and verify signed private IPA' .github/workflows/release.yml
           grep -F 'fvm flutter test test/tool/app_web_startup_contract_test.dart' .github/workflows/release.yml
           grep -F 'build/web/sanad-public-sha.txt' .github/workflows/release.yml
+          grep -F 'xcrun notarytool log "$submission_id"' .github/workflows/release.yml
+          grep -F '.status == "Accepted"' .github/workflows/release.yml
+          grep -F '.ticketContents[]' .github/workflows/release.yml
+          grep -F '(.cdhash | ascii_downcase) == $cdhash' .github/workflows/release.yml
+          grep -F '.arch == $arch' .github/workflows/release.yml
+          grep -F 'fvm dart compile exe "-DSANAD_AGENT_VERSION=${{ needs.validate.outputs.version }}" bin/sanad_agent.dart -o' .github/workflows/release.yml
+          ! grep -F 'fvm dart compile exe `' .github/workflows/release.yml
           grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F 'environment: client-downloads-production' .github/workflows/release.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           grep -F '.ticketContents[]' .github/workflows/release.yml
           grep -F '(.cdhash | ascii_downcase) == $cdhash' .github/workflows/release.yml
           grep -F '.arch == $arch' .github/workflows/release.yml
-          grep -F 'fvm dart compile exe "-DSANAD_AGENT_VERSION=${{ needs.validate.outputs.version }}" bin/sanad_agent.dart -o' .github/workflows/release.yml
+          grep -F 'fvm dart compile exe "-DSANAD_AGENT_VERSION=' .github/workflows/release.yml
           ! grep -F 'fvm dart compile exe `' .github/workflows/release.yml
           grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,10 +167,7 @@ jobs:
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Path ../dist -Force | Out-Null
-          fvm dart compile exe `
-            -DSANAD_AGENT_VERSION=${{ needs.validate.outputs.version }} `
-            bin/sanad_agent.dart `
-            -o "../dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-windows-x64.exe"
+          fvm dart compile exe "-DSANAD_AGENT_VERSION=${{ needs.validate.outputs.version }}" bin/sanad_agent.dart -o "../dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-windows-x64.exe"
       - name: Import Apple Developer ID
         if: matrix.platform == 'macos'
         shell: bash
@@ -215,24 +212,47 @@ jobs:
           agent="dist/sanad-agent-${{ needs.validate.outputs.artifact_version }}-${{ matrix.platform }}-${{ matrix.architecture }}"
           archive="$RUNNER_TEMP/sanad-agent-notarization.zip"
           ditto -c -k --keepParent "$agent" "$archive"
+          submission_result="$RUNNER_TEMP/notary-submission.json"
+          notary_log="$RUNNER_TEMP/notary-log.json"
           xcrun notarytool submit "$archive" \
             --key "$RUNNER_TEMP/AuthKey.p8" \
             --key-id "$APPLE_API_KEY_ID" \
             --issuer "$APPLE_API_ISSUER_ID" \
-            --wait
-          ticket_verified=false
+            --wait \
+            --output-format json > "$submission_result"
+          submission_id="$(jq -r '.id // empty' "$submission_result")"
+          test -n "$submission_id"
+          jq -e '.status == "Accepted"' "$submission_result" >/dev/null
+          log_fetched=false
           for attempt in {1..12}; do
-            if codesign --verify --strict --test-requirement '=notarized' \
-              --verbose=2 "$agent"; then
-              ticket_verified=true
+            if xcrun notarytool log "$submission_id" \
+              --key "$RUNNER_TEMP/AuthKey.p8" \
+              --key-id "$APPLE_API_KEY_ID" \
+              --issuer "$APPLE_API_ISSUER_ID" \
+              "$notary_log"; then
+              log_fetched=true
               break
             fi
             if [[ "$attempt" -lt 12 ]]; then
-              echo "Notarization ticket is not queryable yet; retrying ($attempt/12)."
+              echo "Accepted notarization log is not queryable yet; retrying ($attempt/12)."
               sleep 10
             fi
           done
-          test "$ticket_verified" = true
+          test "$log_fetched" = true
+          binary_cdhash="$(codesign -d --verbose=4 "$agent" 2>&1 |
+            sed -n 's/^CDHash=//p' | head -n 1 | tr '[:upper:]' '[:lower:]')"
+          binary_arch="$(lipo -archs "$agent")"
+          test -n "$binary_cdhash"
+          test -n "$binary_arch"
+          jq -e --arg cdhash "$binary_cdhash" --arg arch "$binary_arch" '
+            .status == "Accepted" and
+            .statusCode == 0 and
+            (.issues == null or .issues == []) and
+            any(.ticketContents[];
+              (.cdhash | ascii_downcase) == $cdhash and
+              .arch == $arch and
+              .digestAlgorithm == "SHA-256")
+          ' "$notary_log" >/dev/null
       - uses: actions/upload-artifact@v4
         with:
           name: agent-${{ matrix.platform }}-${{ matrix.architecture }}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -63,7 +63,6 @@ These files are mandatory execution contracts governing subdirectories. Always r
 - [Develop Sanad Agent](docs/operations/developer_guide.md): Set up the public repository, run the Dart agent and Flutter client, test changes, and use isolated development runtimes.
 - [Release, Signing, and Deployment Architecture](docs/operations/release_and_signing.md): The stable release pipeline, protected signing boundaries, artifact publication, and live-release handoff.
 - [Install and Use Sanad Agent](docs/operations/user_guide.md): Install the Sanad client and agent, connect local or remote devices, configure providers, manage the service, and update Sanad.
-- [README Client Downloads](docs/plans/tasks/readme-client-downloads.md): Limited English/Arabic Quick Start refresh using the Production-only stable Client convenience links.
 - [خارطة متطلبات المنتج والأعمال](docs/product/MOC.md): فهرس وخارطة وثائق متطلبات المنتج، تجربة المستخدم، والأعمال الاستراتيجية للمشروع.
 - [Sanad Client Interface](docs/product/client_interface.md): Current user experience for devices, workspaces, conversations, providers, permissions, and active agent interactions.
 - [Conversation Navigation UX Spec](docs/product/conversation_navigation_ux_spec.md): UX specifications for conversation navigation destinations, history, deletion, and restart recovery.

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -49,11 +49,14 @@ The macOS Agent uses Hardened Runtime with the narrowly scoped
 `com.apple.security.cs.allow-unsigned-executable-memory` entitlement required by
 Dart AOT runtime stubs. The workflow injects the validated release-contract
 version at compilation, signs with that entitlement, executes the signed binary,
-and submits it for notarization. Raw CLI notarization is checked with
-`codesign --test-requirement '=notarized'`; after Apple accepts the submission,
-the workflow allows a short bounded retry window for ticket lookup propagation
-and still fails closed when the requirement remains unsatisfied. `spctl --type
-execute` is not used because it rejects valid notarized non-bundle executables.
+and submits it for notarization. After Apple accepts the submission, the
+workflow fetches the authoritative notary log with a bounded retry and requires
+`Accepted`, status code zero, no issues, SHA-256 ticket metadata, and an exact
+architecture plus `cdhash` match to the signed executable. This avoids relying
+on the local `codesign --test-requirement '=notarized'` online-ticket cache,
+which remained unavailable for more than ten minutes despite an accepted ticket
+for the exact raw CLI. `spctl --type execute` is not used because it rejects
+valid notarized non-bundle executables.
 
 The hosted macOS Client job restores the exported Sparkle Ed25519 key to a
 runner-temporary file and passes that file directly to Sparkle `sign_update`.

--- a/docs/plans/tasks/macos-agent-notarization-ticket-propagation.md
+++ b/docs/plans/tasks/macos-agent-notarization-ticket-propagation.md
@@ -1,28 +1,53 @@
 ---
-title: "macOS Agent Notarization Ticket Propagation"
-description: "Keep the macOS release gate strict while allowing bounded time for an accepted notarization ticket to become queryable."
+title: "macOS Agent Notarization Ticket Verification"
+description: "Bind Apple notarization acceptance deterministically to the exact signed macOS Agent executable without relying on delayed local ticket caches."
 ---
 
-# macOS Agent Notarization Ticket Propagation
+# macOS Agent Notarization Ticket Verification
 
 ## Problem
 
 Both hosted macOS Agent submissions were accepted by Apple, but the immediate
-raw-executable `codesign --test-requirement '=notarized'` lookup failed. The
-same check passed in earlier release probes, indicating a delay between accepted
-submission processing and ticket lookup availability rather than a signing or
-notarization rejection.
+raw-executable `codesign --test-requirement '=notarized'` lookup failed. A fresh
+local arm64 submission reproduced the result through the proposed 120-second
+retry and again through an extended ten-minute retry. Apple’s notary log still
+reported `Ready for distribution`, status code zero, no issues, and ticket
+content for the exact submitted executable.
+
+The local online-ticket cache is therefore not a reliable release gate for this
+raw CLI. Increasing its timeout would retain a nondeterministic failure without
+adding trust.
 
 ## Change
 
-Keep Apple acceptance and the explicit raw-executable notarization requirement
-mandatory. Retry only the ticket lookup for a short bounded interval, then fail
-closed if no attempt succeeds.
+Keep Developer ID signature verification, Hardened Runtime, entitlement checks,
+binary execution/version verification, and `notarytool submit --wait`
+acceptance mandatory. Fetch the authoritative notary log with a bounded retry,
+then require:
+
+- status `Accepted` and status code `0`;
+- no reported issues;
+- a `ticketContents` entry using SHA-256;
+- exact architecture equality with `lipo -archs`;
+- exact case-normalized `cdhash` equality with the signed executable.
+
+This binds Apple’s accepted ticket to the exact bytes produced by the release
+job and fails closed on a missing log, rejection, issue, architecture mismatch,
+or hash mismatch.
+
+## Evidence
+
+Local macOS 26 arm64 submission `62b83964-8910-4f08-9882-8d5f18e31c5c`
+returned `Accepted`. The old query failed for ten minutes; the replacement gate
+matched the log’s arm64 SHA-256 ticket entry to the signed binary’s `cdhash` and
+passed. No credential values or private signing material entered repository
+evidence.
 
 ## Definition of Done
 
-- The workflow still requires `notarytool submit --wait` success.
-- The explicit `=notarized` requirement remains mandatory for both Agent architectures.
-- Retries are bounded and end in failure when the ticket stays unavailable.
-- Workflow syntax and repository release checks pass locally.
-- A macOS machine or hosted runner provides final `codesign` evidence.
+- The workflow still requires successful Developer ID verification and
+  `notarytool submit --wait` acceptance.
+- The authoritative log is fetched only with bounded retries.
+- Ticket architecture and `cdhash` must match the exact signed binary.
+- Missing, rejected, issued, or mismatched evidence fails closed.
+- Workflow syntax, release checks, and a real macOS submission pass.

--- a/docs/plans/tasks/readme-client-downloads.md
+++ b/docs/plans/tasks/readme-client-downloads.md
@@ -1,3 +1,8 @@
+---
+title: "README Client Downloads"
+description: "Limited English/Arabic Quick Start refresh using the Production-only stable Client convenience links."
+---
+
 # README Client Downloads
 
 ## Status

--- a/docs/plans/tasks/windows-agent-release-handshake-race.md
+++ b/docs/plans/tasks/windows-agent-release-handshake-race.md
@@ -12,6 +12,11 @@ PowerShell writes `started` but before the detached script completes its final
 self-cleanup. The release test then fails on the still-present script even
 though the replacement handshake succeeded.
 
+After that race was fixed, hosted validation reached the Windows compile step
+and exposed an independent workflow parsing failure: the PowerShell backtick
+continuations did not pass the define, entry point, or output arguments to Dart,
+which reported `Missing Dart entry point`.
+
 ## Change
 
 Keep the production replacement protocol unchanged. Make the native Windows
@@ -19,10 +24,17 @@ release test wait for both terminal evidence: the result file exists and the
 detached replacement script has been removed. Retain explicit assertions for
 the `started` status and script cleanup.
 
+Invoke the Windows release compiler on one PowerShell line with an explicitly
+quoted version define. A static workflow contract requires that complete command
+and rejects the former backtick form.
+
 ## Definition of Done
 
 - The focused native Windows handshake test passes locally.
 - The complete Windows release/update test file passes locally.
 - `fvm dart analyze` passes in `agent/`.
-- A release-version Windows Agent executable compiles locally.
-- The release verification guide records the race-safe terminal assertion.
+- A release-version Windows Agent executable compiles locally and on the hosted
+  Windows release runner.
+- The workflow contains no backtick-continued Windows Dart compile command.
+- The release verification guide records both the race-safe terminal assertion
+  and the hosted compile parsing boundary.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -33,7 +33,7 @@ rules remain fail-closed.
 
 | Target | Local evidence | Hosted or clean-machine evidence still required |
 |---|---|---|
-| Agent macOS arm64/x64 | compilation, version, architecture, Developer ID verification, bounded accepted-ticket lookup | both hosted runners, clean install, real upgrade and rollback |
+| Agent macOS arm64/x64 | compilation, version, architecture, Developer ID verification, accepted notary log with exact architecture/`cdhash` ticket match | both hosted runners, clean install, real upgrade and rollback |
 | Agent Linux x64 | contract and workflow path | hosted build, provenance, clean install, service/update/rollback |
 | Agent Windows x64 | contract and workflow path | Unsigned Windows build disclosure, SHA-256/manifest/provenance, Defender/SmartScreen and lifecycle on Windows 11, service/update/rollback |
 | Client macOS universal | universal Mach-O inspection, Developer ID-signed and notarized DMG, staple, Gatekeeper, Sparkle signature | clean update and rollback |
@@ -194,6 +194,25 @@ private. The Draft and publication jobs were skipped, and the run left no tag,
 Draft, or Release. This closes the hosted full-matrix build probe; clean-machine
 installation, update, rollback, Windows Defender/SmartScreen, and Internal
 TestFlight upload remain separate live gates.
+
+## 1.0.1 validation race follow-up
+
+Validation-only run `31293235254` at `b70bd25` accepted both macOS Agent
+submissions but exposed that the local raw-CLI ticket cache can remain
+unavailable despite Apple acceptance. Local macOS 26 arm64 submissions
+`c15943cf-f9a1-4955-817b-740f83b026e9` and
+`62b83964-8910-4f08-9882-8d5f18e31c5c` reproduced failure through 120 seconds
+and ten minutes respectively. The authoritative replacement gate passed only
+a notary log with status code zero, no issues, SHA-256 ticket metadata, and an
+exact architecture/`cdhash` match to the signed executable.
+
+Follow-up validation run `31294256992` at `81de416` then reached the hosted
+Windows compile step and exposed a separate PowerShell continuation failure:
+Dart received `compile exe` without its define, entry point, or output and
+reported `Missing Dart entry point`. The workflow now uses one explicitly quoted
+PowerShell command line and statically rejects the former backtick form. The
+complete matrix must be rerun after both follow-up fixes; neither failed run is
+release evidence.
 
 ## SANAD-08 local evidence
 

--- a/docs/technical/update_architecture.md
+++ b/docs/technical/update_architecture.md
@@ -24,7 +24,7 @@ GitHub attestation locally.
 
 | Component/platform | Required manifest trust metadata | Runtime proof |
 |---|---|---|
-| Agent macOS | `developer-id+notarization+github-attestation` | canonical URL, size, SHA-256, Developer ID identity, and the raw-CLI `codesign --test-requirement '=notarized'` ticket check |
+| Agent macOS | `developer-id+notarization+github-attestation` | canonical URL, size, SHA-256, Developer ID identity, plus protected CI matching Apple’s accepted notary-log architecture and `cdhash` ticket to the exact signed executable |
 | Agent Windows | `unsigned+github-attestation` | canonical URL, size, and SHA-256; provenance is proved by protected release CI |
 | Agent Linux | `github-attestation` | canonical URL, size, and SHA-256 |
 | Client macOS | `developer-id+notarization+sparkle-ed25519` | Sparkle EdDSA plus Apple package trust |


### PR DESCRIPTION
## Problem / Goal

Two successive `validation-only` runs exposed independent false failures that block Sanad 1.0.1:

- macOS Agent notarization was accepted by Apple, but the local raw-CLI online-ticket cache remained unavailable through 120 seconds and a measured ten-minute retry.
- Windows Agent compilation used PowerShell backtick continuations that delivered `compile exe` without its define, entry point, or output arguments.

## Changes

- Replace the nondeterministic macOS cache lookup with an authoritative Apple notary-log gate requiring `Accepted`, status code zero, no issues, SHA-256 ticket metadata, and exact architecture/`cdhash` equality to the signed executable.
- Keep notary-log retrieval bounded and fail closed.
- Replace the Windows backtick compile command with one explicitly quoted PowerShell line.
- Add static CI contracts for both release boundaries.
- Record the failed runs, real macOS evidence, Windows compile boundary, and repair plans.
- Restore frontmatter for the PR #51 Client-download plan so generated documentation remains canonical.

## Verification

- Fresh macOS 26 arm64 Agent compiled as 1.0.1, Developer ID signed, and executed.
- Apple accepted submissions `c15943cf-f9a1-4955-817b-740f83b026e9` and `62b83964-8910-4f08-9882-8d5f18e31c5c`.
- Old `=notarized` lookup reproduced failure through ten minutes.
- Replacement gate matched arm64 and the exact binary `cdhash`; mismatched hash and architecture were rejected.
- Workflow-style explicit key/id/issuer notary-log retrieval passed without exposing values.
- `fvm dart analyze`.
- Focused Agent release/update suite: 20 passed, 1 Windows platform skip.
- Release workflow YAML parsing, static trust checks, documentation generation/lint, Graphify update, and `git diff --check` passed.

## Failed-run evidence

- Run 31293235254: Apple accepted both macOS Agent submissions; immediate ticket-cache checks failed.
- Run 31294256992: Windows tests passed, then hosted compile failed with `Missing Dart entry point`.

## Publication boundary

This PR publishes nothing. A new validation-only full matrix is required after merge before any tag, Draft, Release, or Production asset deployment.

Source commit: `19538a39fca706bba33a186a5953468dde85d653`
