### PR TITLE
fix(release): refresh production asset containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,12 @@ jobs:
           grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/appcast.xml' .github/workflows/deploy.yml
+          test "$(grep -Fc 'sanad-sites-control refresh-static production' .github/workflows/deploy.yml)" -eq 6
+          grep -F 'name: Activate, verify, and roll back Appcast on failure' .github/workflows/deploy.yml
+          grep -F 'https://updates.sanad.eaststarai.com/appcast.xml' .github/workflows/deploy.yml
+          grep -F 'name: Activate, verify, and roll back installer sources on failure' .github/workflows/deploy.yml
+          grep -F 'https://downloads.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
+          grep -F 'restoring the previous selector' .github/workflows/deploy.yml
           test "$(grep -Fc 'environment: client-downloads-production' .github/workflows/deploy.yml)" -eq 3
           ! grep -Eq 'environment: (web|updates|installers)-production' .github/workflows/deploy.yml
           grep -F 'environment: client-downloads-production' .github/workflows/release.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,7 +140,7 @@ jobs:
             "set -eu; sha256sum '$previous/index.html' | cut -d ' ' -f 1")"
           test -n "$previous_index_sha"
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'; ln -sfn '$release' '$selector'"
+            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production web"
 
           verify_web() {
             body="$(mktemp)"
@@ -168,7 +168,7 @@ jobs:
           if [[ "$activated" != true ]]; then
             echo "Production Web verification failed; restoring the previous selector."
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test -s '$previous/index.html'; ln -sfn '$previous' '$selector'"
+              "set -eu; test -s '$previous/index.html'; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production web"
             rollback_verified=false
             for attempt in $(seq 1 12); do
               rolled_back_index="$(mktemp)"
@@ -217,18 +217,49 @@ jobs:
           (cd download && sha256sum --check SHA256SUMS --ignore-missing)
           gh attestation verify download/appcast.xml \
             --repo "$GITHUB_REPOSITORY"
-      - name: Atomic Appcast deployment
+      - name: Activate, verify, and roll back Appcast on failure
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
         run: |
+          set -euo pipefail
           tag="${{ inputs.release_tag }}"
+          release="/opt/sanad-sites/assets/updates/releases/$tag"
+          selector=/opt/sanad-sites/assets/updates/current
+          expected_sha="$(sha256sum download/appcast.xml | awk '{print $1}')"
+          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
+          previous_sha="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; sha256sum '$previous/appcast.xml' | awk '{print \$1}'")"
+          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; test -s '$release/appcast.xml'; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_sha'"; then
+            echo "Reusing the existing immutable Appcast release $release."
+          else
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; test ! -e '$release'; mkdir -p '$release'"
+            rsync -az download/appcast.xml \
+              "$DEPLOY_USER@$DEPLOY_HOST:$release/appcast.xml"
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_sha'"
+          fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "mkdir -p /opt/sanad-sites/assets/updates/releases/$tag"
-          rsync -az download/appcast.xml \
-            "$DEPLOY_USER@$DEPLOY_HOST:/opt/sanad-sites/assets/updates/releases/$tag/appcast.xml"
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn /opt/sanad-sites/assets/updates/releases/$tag /opt/sanad-sites/assets/updates/current"
+            "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
+
+          public_appcast="$(mktemp)"
+          rollback_appcast="$(mktemp)"
+          trap 'rm -f "$public_appcast" "$rollback_appcast"' EXIT
+          if ! curl --fail --silent --show-error --max-time 20 \
+            "https://updates.sanad.eaststarai.com/appcast.xml?release=$tag" \
+            -o "$public_appcast" || \
+            [[ "$(sha256sum "$public_appcast" | awk '{print $1}')" != "$expected_sha" ]]; then
+            echo "Appcast verification failed; restoring the previous selector."
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
+            curl --fail --silent --show-error --max-time 20 \
+              "https://updates.sanad.eaststarai.com/appcast.xml?rollback=$previous_sha" \
+              -o "$rollback_appcast"
+            test "$(sha256sum "$rollback_appcast" | awk '{print $1}')" = "$previous_sha"
+            exit 1
+          fi
 
   installers:
     if: inputs.deploy_installers == true
@@ -247,15 +278,51 @@ jobs:
           printf '%s\n' "$DEPLOY_KEY" > "$HOME/.ssh/id_ed25519"
           printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
           chmod 600 "$HOME/.ssh/id_ed25519" "$HOME/.ssh/known_hosts"
-      - name: Publish canonical installer sources
+      - name: Activate, verify, and roll back installer sources on failure
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
         run: |
+          set -euo pipefail
           revision="$(git rev-parse HEAD)"
+          release="/opt/sanad-sites/assets/install/releases/$revision"
+          selector=/opt/sanad-sites/assets/install/current
+          expected_sh="$(sha256sum scripts/install.sh | awk '{print $1}')"
+          expected_ps1="$(sha256sum scripts/install.ps1 | awk '{print $1}')"
+          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
+          previous_sh="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; sha256sum '$previous/install.sh' | awk '{print \$1}'")"
+          previous_ps1="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; sha256sum '$previous/install.ps1' | awk '{print \$1}'")"
+          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"; then
+            echo "Reusing the existing immutable installer release $release."
+          else
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; test ! -e '$release'; mkdir -p '$release'"
+            rsync -az scripts/install.sh scripts/install.ps1 \
+              "$DEPLOY_USER@$DEPLOY_HOST:$release/"
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"
+          fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "mkdir -p /opt/sanad-sites/assets/install/releases/$revision"
-          rsync -az scripts/install.sh scripts/install.ps1 \
-            "$DEPLOY_USER@$DEPLOY_HOST:/opt/sanad-sites/assets/install/releases/$revision/"
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn /opt/sanad-sites/assets/install/releases/$revision /opt/sanad-sites/assets/install/current"
+            "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production downloads"
+
+          verify_installer() {
+            local name="$1" expected="$2" output="$3" marker="$4"
+            curl --fail --silent --show-error --max-time 20 \
+              "https://downloads.sanad.eaststarai.com/$name?$marker" -o "$output"
+            test "$(sha256sum "$output" | awk '{print $1}')" = "$expected"
+          }
+
+          temporary="$(mktemp -d)"
+          trap 'rm -rf "$temporary"' EXIT
+          if ! verify_installer install.sh "$expected_sh" "$temporary/install.sh" "release=$revision" || \
+            ! verify_installer install.ps1 "$expected_ps1" "$temporary/install.ps1" "release=$revision"; then
+            echo "Installer verification failed; restoring the previous selector."
+            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+              "set -eu; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production downloads"
+            verify_installer install.sh "$previous_sh" "$temporary/rollback.sh" "rollback=$previous_sh"
+            verify_installer install.ps1 "$previous_ps1" "$temporary/rollback.ps1" "rollback=$previous_ps1"
+            exit 1
+          fi

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -124,14 +124,21 @@ A manual `Deploy prepared release assets` dispatch is recovery-only. It must ide
 
 Production Web, Appcast, and installer releases use `/opt/sanad-sites/assets/web`, `/opt/sanad-sites/assets/updates`, and `/opt/sanad-sites/assets/install`; the obsolete `/srv/sanad/*` workflow roots are not valid deployment targets. The private Web handoff
 is downloaded from the explicitly selected successful release-workflow run and
-verified against its GitHub build attestation. Server deployment then writes a
-versioned directory and changes a `current` symlink only after the transfer
-succeeds. The Web handoff records its exact public commit, validates the Flutter
-shell, bootstrap, favicon, version marker, and hosted readability before
-activation, then verifies the public Production URL. A failed public probe
-restores the preceding selector automatically. Rollback switches that symlink
-to the last known good version; it does not rebuild or mutate a published
-release.
+verified against its GitHub build attestation. Server deployment writes an
+immutable versioned directory, changes the owning `current` symlink only after
+the transfer succeeds, and invokes the private host-owned
+`sanad-sites-control refresh-static production` action for exactly the affected
+Web, updates, or downloads container. This refresh is required because Docker
+bind mounts resolve the selected directory when the container is created; a
+symlink change alone does not update a running container.
+
+The Web handoff records its exact public commit and validates the Flutter shell,
+bootstrap, favicon, version marker, and hosted readability. Appcast activation
+verifies the attested public bytes, while installer activation verifies both
+canonical public source files. Any public mismatch restores the preceding
+selector, refreshes only the affected static container, and verifies the prior
+public bytes. Rollback never rebuilds or mutates a published release, and the
+public workflow receives neither Docker access nor general host authority.
 
 Web assets use content-hashed Flutter output plus a small no-cache
 `version.json`. The server must route unknown application paths to

--- a/docs/plans/tasks/stable-production-release-deployment.md
+++ b/docs/plans/tasks/stable-production-release-deployment.md
@@ -60,3 +60,27 @@ deploy Production assets.
       deployment and manual recovery prerequisites.
 - [x] Focused workflow/static validation passes with bounded output.
 - [x] Graphify is updated after the workflow/documentation change.
+
+## Live activation follow-up
+
+The first `v1.0.1` recovery run proved that changing a host selector does not
+refresh an existing Docker bind mount. Web activation failed before selection
+because the canonical root lacked a baseline, while Appcast and installer jobs
+changed their new selectors without changing the publicly mounted legacy
+content. The permanent handoff therefore also requires a bounded Production
+static-container refresh after every selector change and rollback.
+
+### Follow-up Definition of Done
+
+- [x] Web activation refreshes only `app-site` after selecting or restoring a
+      release.
+- [x] Appcast activation captures the previous selector, refreshes only
+      `updates-site`, verifies the exact public bytes, and rolls back on failure.
+- [x] Installer activation captures the previous selector, refreshes only
+      `downloads-site`, verifies both exact public source files, and rolls back
+      on failure.
+- [x] Every refresh uses the private host-owned `sanad-sites-control
+      refresh-static production <surface>` command; the public workflow does not
+      gain Docker or general host authority.
+- [x] Manual and automatic Stable deployments share the same reusable workflow.
+- [x] Focused workflow contracts, documentation checks, and Graphify update pass.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -92,9 +92,13 @@ Static verification rejects separate `web-production`, `updates-production`, or
 provisioned and protected in a separate reviewed change. Manual recovery from
 `main` remains blocked by the Environment branch policy until an operator
 explicitly authorizes that ref; tag-restricted automatic releases require no
-such exception. Runtime acceptance still requires the exact public Web commit
-and version markers, Appcast identity, canonical installer content, and a clean
-browser render. HTTP-only success is insufficient.
+such exception. Each selector activation and rollback must invoke the bounded
+Production static refresh for exactly one service. Runtime acceptance requires
+the exact public Web commit and version markers, the public Appcast SHA-256, both
+public installer-source SHA-256 values, and a clean browser render. A stale bind
+mount, selector-only success, or HTTP-only shell response fails the gate. A
+failed surface must restore and publicly verify its preceding bytes without
+recreating data or application services.
 
 ## Update failure coverage
 


### PR DESCRIPTION
## Problem / Goal

Stable release automation changes Production asset selectors, but Docker bind mounts retain the directory resolved when each static container was created. The first v1.0.1 recovery exposed stale public Web, Appcast, and installer content. Ensure future Stable releases such as v1.0.2 refresh and verify every Production surface automatically.

## Changes

- refresh only `app-site`, `updates-site`, or `downloads-site` after its selector changes
- refresh again after restoring a selector during rollback
- verify exact public Appcast and installer-source SHA-256 values
- preserve Web commit/version verification, attestation, immutable releases, and rollback
- add CI assertions plus release architecture, QA, and plan documentation

## Verification

- parsed CI/deploy/release workflow YAML
- ran focused workflow contract assertions
- ran `scripts/release/test_generate_client_download_redirects.sh`
- ran `git diff --check`
- ran `graphify update .`

## Risk / Rollback

The workflow still runs only through the existing protected Stable/manual paths. It calls a fixed private host control action and receives no Docker or general host authority. Each surface captures its previous selector and public hashes before activation. Reverting this PR restores the prior selector-only behavior.

## Dependency

Requires the private host-control PR and one-time Production static-root migration before live execution.
