### PR TITLE
fix(release): publish complete static asset roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,13 @@ jobs:
           grep -F 'name: Activate, verify, and roll back Production Web on failure' .github/workflows/deploy.yml
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/appcast.xml' .github/workflows/deploy.yml
+          grep -F 'gh attestation verify download/release-manifest.json' .github/workflows/deploy.yml
           test "$(grep -Fc 'sanad-sites-control refresh-static production' .github/workflows/deploy.yml)" -eq 6
-          grep -F 'name: Activate, verify, and roll back Appcast on failure' .github/workflows/deploy.yml
-          grep -F 'https://updates.sanad.eaststarai.com/appcast.xml' .github/workflows/deploy.yml
+          grep -F 'name: Activate, verify, and roll back updates on failure' .github/workflows/deploy.yml
+          grep -F 'https://updates.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
+          test "$(grep -Fc \"cp -a '\$previous/.' '\$incoming/'\" .github/workflows/deploy.yml)" -eq 2
+          test "$(grep -Fc \"test -s '\$incoming/index.html'\" .github/workflows/deploy.yml)" -eq 3
+          test "$(grep -Fc \"test -s '\$incoming/favicon.svg'\" .github/workflows/deploy.yml)" -eq 2
           grep -F 'name: Activate, verify, and roll back installer sources on failure' .github/workflows/deploy.yml
           grep -F 'https://downloads.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
           grep -F 'restoring the previous selector' .github/workflows/deploy.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,9 @@ jobs:
           test "$(grep -Fc 'sanad-sites-control refresh-static production' .github/workflows/deploy.yml)" -eq 6
           grep -F 'name: Activate, verify, and roll back updates on failure' .github/workflows/deploy.yml
           grep -F 'https://updates.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
-          test "$(grep -Fc \"cp -a '\$previous/.' '\$incoming/'\" .github/workflows/deploy.yml)" -eq 2
-          test "$(grep -Fc \"test -s '\$incoming/index.html'\" .github/workflows/deploy.yml)" -eq 3
-          test "$(grep -Fc \"test -s '\$incoming/favicon.svg'\" .github/workflows/deploy.yml)" -eq 2
+          test "$(grep -Fc 'cp -a' .github/workflows/deploy.yml)" -eq 2
+          test "$(grep -Fc 'incoming/index.html' .github/workflows/deploy.yml)" -eq 3
+          test "$(grep -Fc 'incoming/favicon.svg' .github/workflows/deploy.yml)" -eq 2
           grep -F 'name: Activate, verify, and roll back installer sources on failure' .github/workflows/deploy.yml
           grep -F 'https://downloads.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
           grep -F 'restoring the previous selector' .github/workflows/deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -212,52 +212,62 @@ jobs:
         run: |
           gh release download "${{ inputs.release_tag }}" \
             --pattern appcast.xml \
+            --pattern release-manifest.json \
             --pattern SHA256SUMS \
             --dir download
           (cd download && sha256sum --check SHA256SUMS --ignore-missing)
           gh attestation verify download/appcast.xml \
             --repo "$GITHUB_REPOSITORY"
-      - name: Activate, verify, and roll back Appcast on failure
+          gh attestation verify download/release-manifest.json \
+            --repo "$GITHUB_REPOSITORY"
+      - name: Activate, verify, and roll back updates on failure
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
         run: |
           set -euo pipefail
           tag="${{ inputs.release_tag }}"
-          release="/opt/sanad-sites/assets/updates/releases/$tag"
-          selector=/opt/sanad-sites/assets/updates/current
-          expected_sha="$(sha256sum download/appcast.xml | awk '{print $1}')"
+          root=/opt/sanad-sites/assets/updates
+          release="$root/releases/$tag"
+          selector="$root/current"
+          incoming="$root/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          expected_appcast="$(sha256sum download/appcast.xml | awk '{print $1}')"
+          expected_manifest="$(sha256sum download/release-manifest.json | awk '{print $1}')"
           previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
-          previous_sha="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+          previous_appcast="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
             "set -eu; sha256sum '$previous/appcast.xml' | awk '{print \$1}'")"
+          previous_manifest="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
+            "set -eu; sha256sum '$previous/release-manifest.json' | awk '{print \$1}'")"
           if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/appcast.xml'; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_sha'"; then
-            echo "Reusing the existing immutable Appcast release $release."
+            "set -eu; test -s '$release/index.html'; test -s '$release/favicon.svg'; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_appcast'; test \"\$(sha256sum '$release/release-manifest.json' | awk '{print \$1}')\" = '$expected_manifest'"; then
+            echo "Reusing the existing complete immutable updates release $release."
           else
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test ! -e '$release'; mkdir -p '$release'"
-            rsync -az download/appcast.xml \
-              "$DEPLOY_USER@$DEPLOY_HOST:$release/appcast.xml"
+              "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming'; cp -a '$previous/.' '$incoming/'"
+            rsync -az download/appcast.xml download/release-manifest.json \
+              "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_sha'"
+              "set -eu; test -s '$incoming/index.html'; test -s '$incoming/favicon.svg'; test \"\$(sha256sum '$incoming/appcast.xml' | awk '{print \$1}')\" = '$expected_appcast'; test \"\$(sha256sum '$incoming/release-manifest.json' | awk '{print \$1}')\" = '$expected_manifest'; mv '$incoming' '$release'"
           fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
             "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
 
-          public_appcast="$(mktemp)"
-          rollback_appcast="$(mktemp)"
-          trap 'rm -f "$public_appcast" "$rollback_appcast"' EXIT
-          if ! curl --fail --silent --show-error --max-time 20 \
-            "https://updates.sanad.eaststarai.com/appcast.xml?release=$tag" \
-            -o "$public_appcast" || \
-            [[ "$(sha256sum "$public_appcast" | awk '{print $1}')" != "$expected_sha" ]]; then
-            echo "Appcast verification failed; restoring the previous selector."
+          verify_update() {
+            local name="$1" expected="$2" output="$3" marker="$4"
+            curl --fail --silent --show-error --max-time 20 \
+              "https://updates.sanad.eaststarai.com/$name?$marker" -o "$output"
+            test "$(sha256sum "$output" | awk '{print $1}')" = "$expected"
+          }
+
+          temporary="$(mktemp -d)"
+          trap 'rm -rf "$temporary"' EXIT
+          if ! verify_update appcast.xml "$expected_appcast" "$temporary/appcast.xml" "release=$tag" || \
+            ! verify_update release-manifest.json "$expected_manifest" "$temporary/release-manifest.json" "release=$tag"; then
+            echo "Updates verification failed; restoring the previous selector."
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
               "set -eu; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
-            curl --fail --silent --show-error --max-time 20 \
-              "https://updates.sanad.eaststarai.com/appcast.xml?rollback=$previous_sha" \
-              -o "$rollback_appcast"
-            test "$(sha256sum "$rollback_appcast" | awk '{print $1}')" = "$previous_sha"
+            verify_update appcast.xml "$previous_appcast" "$temporary/rollback-appcast.xml" "rollback=$previous_appcast"
+            verify_update release-manifest.json "$previous_manifest" "$temporary/rollback-manifest.json" "rollback=$previous_manifest"
             exit 1
           fi
 
@@ -285,8 +295,10 @@ jobs:
         run: |
           set -euo pipefail
           revision="$(git rev-parse HEAD)"
-          release="/opt/sanad-sites/assets/install/releases/$revision"
-          selector=/opt/sanad-sites/assets/install/current
+          root=/opt/sanad-sites/assets/install
+          release="$root/releases/$revision"
+          selector="$root/current"
+          incoming="$root/incoming-$revision-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           expected_sh="$(sha256sum scripts/install.sh | awk '{print $1}')"
           expected_ps1="$(sha256sum scripts/install.ps1 | awk '{print $1}')"
           previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
@@ -295,15 +307,15 @@ jobs:
           previous_ps1="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
             "set -eu; sha256sum '$previous/install.ps1' | awk '{print \$1}'")"
           if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"; then
-            echo "Reusing the existing immutable installer release $release."
+            "set -eu; test -s '$release/index.html'; test -s '$release/favicon.svg'; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"; then
+            echo "Reusing the existing complete immutable installer release $release."
           else
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test ! -e '$release'; mkdir -p '$release'"
+              "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming'; cp -a '$previous/.' '$incoming/'"
             rsync -az scripts/install.sh scripts/install.ps1 \
-              "$DEPLOY_USER@$DEPLOY_HOST:$release/"
+              "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
             ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"
+              "set -eu; test -s '$incoming/index.html'; test -s '$incoming/favicon.svg'; test \"\$(sha256sum '$incoming/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$incoming/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'; mv '$incoming' '$release'"
           fi
           ssh "$DEPLOY_USER@$DEPLOY_HOST" \
             "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production downloads"

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -133,12 +133,16 @@ bind mounts resolve the selected directory when the container is created; a
 symlink change alone does not update a running container.
 
 The Web handoff records its exact public commit and validates the Flutter shell,
-bootstrap, favicon, version marker, and hosted readability. Appcast activation
-verifies the attested public bytes, while installer activation verifies both
-canonical public source files. Any public mismatch restores the preceding
-selector, refreshes only the affected static container, and verifies the prior
-public bytes. Rollback never rebuilds or mutates a published release, and the
-public workflow receives neither Docker access nor general host authority.
+bootstrap, favicon, version marker, and hosted readability. Updates releases
+publish both attested Stable Appcast and manifest files; installer releases
+publish both canonical source files. Each updates or downloads candidate first
+copies the preceding selected static root into a unique incoming directory so
+server-owned `index.html` and `favicon.svg` remain present, replaces only the
+release-owned files, validates the complete root, and atomically publishes it.
+Any public mismatch restores the preceding selector, refreshes only the affected
+static container, and verifies all prior release-owned bytes. Rollback never
+rebuilds or mutates a published release, and the public workflow receives
+neither Docker access nor general host authority.
 
 Web assets use content-hashed Flutter output plus a small no-cache
 `version.json`. The server must route unknown application paths to

--- a/docs/plans/tasks/stable-production-release-deployment.md
+++ b/docs/plans/tasks/stable-production-release-deployment.md
@@ -84,3 +84,24 @@ static-container refresh after every selector change and rollback.
       gain Docker or general host authority.
 - [x] Manual and automatic Stable deployments share the same reusable workflow.
 - [x] Focused workflow contracts, documentation checks, and Graphify update pass.
+
+## Complete static-root follow-up
+
+The canonical updates and downloads containers also serve stable shell files
+such as `index.html` and `favicon.svg`. A release containing only Appcast or
+installer payloads is not a complete mount root. Each new immutable release must
+therefore copy the preceding selected static root into an incoming directory,
+replace only its verified release-owned files, validate the complete candidate,
+and atomically publish it before selection.
+
+### Completion Definition of Done
+
+- [x] Updates releases contain the attested Stable manifest and Appcast plus the
+      inherited static shell.
+- [x] Installer releases contain both canonical scripts plus the inherited
+      static shell.
+- [x] Incoming directories are unique, complete, and moved atomically; existing
+      immutable releases are reused only when every required file matches.
+- [x] Public verification and rollback compare both Appcast/manifest or both
+      installer files.
+- [x] Focused workflow contracts, documentation, and Graphify update pass.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -93,12 +93,15 @@ provisioned and protected in a separate reviewed change. Manual recovery from
 `main` remains blocked by the Environment branch policy until an operator
 explicitly authorizes that ref; tag-restricted automatic releases require no
 such exception. Each selector activation and rollback must invoke the bounded
-Production static refresh for exactly one service. Runtime acceptance requires
-the exact public Web commit and version markers, the public Appcast SHA-256, both
-public installer-source SHA-256 values, and a clean browser render. A stale bind
-mount, selector-only success, or HTTP-only shell response fails the gate. A
-failed surface must restore and publicly verify its preceding bytes without
-recreating data or application services.
+Production static refresh for exactly one service. Updates and downloads
+candidates must inherit the preceding static shell, contain `index.html` and
+`favicon.svg`, and replace only their release-owned files before atomic
+publication. Runtime acceptance requires the exact public Web commit and version
+markers, the public Appcast and Stable manifest SHA-256 values, both public
+installer-source SHA-256 values, and a clean browser render. A stale bind mount,
+incomplete static root, selector-only success, or HTTP-only shell response fails
+the gate. A failed surface must restore and publicly verify all its preceding
+release-owned bytes without recreating data or application services.
 
 ## Update failure coverage
 


### PR DESCRIPTION
## Problem / Goal

Production updates and downloads mounts also serve stable shell files. A selector release containing only Appcast or installer payloads would remove `index.html`, `favicon.svg`, and the Stable manifest. Publish complete immutable static roots before the one-time Production mount migration.

## Changes

- download and attest both Stable Appcast and release manifest
- create updates/downloads candidates by copying the preceding selected root into a unique incoming directory
- replace only release-owned files and validate the complete shell before atomic publication
- verify and roll back both Appcast/manifest or both installer-source files
- strengthen CI, architecture, QA, and plan contracts

## Verification

- parsed modified workflow YAML
- passed focused complete-static-root assertions
- passed Client redirect generator test
- verified live v1.0.1 Appcast and manifest GitHub attestations
- passed `git diff --check`
- ran `graphify update .`

## Risk / Rollback

Existing immutable releases are reused only when all required shell and release-owned files match. Otherwise a unique incoming root is built and moved atomically. Each surface retains its previous selector and exact public hashes for rollback.
