### PR TITLE
docs(release): record stable asset deployment evidence

### DIFF
--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -155,6 +155,12 @@ Local verification proves the release contract, manifest/checksum generation,
 macOS universal packaging and Developer ID signatures, iOS signed export,
 Sparkle signatures, Web packaging, analyzers, and updater tests.
 
+Production rehearsal run `31346940281` completed the reusable Stable asset
+handoff from `v1.0.1` release run `31296207510`. Web, Appcast, Stable manifest,
+and both installer sources matched their immutable source identities; clean
+Flutter rendering and all three environment regressions passed. The same
+workflow is called automatically after every future approved Stable publication.
+
 The protected validation-only run at public `main` commit `c2bd6b3b` passed the
 complete hosted Agent and Client matrix. It exercised the protected signing
 Environments, generated the assembled manifest, checksums, Appcast, SBOM, and

--- a/docs/plans/tasks/stable-production-release-deployment.md
+++ b/docs/plans/tasks/stable-production-release-deployment.md
@@ -1,7 +1,7 @@
 ---
 title: "Stable Production Release Deployment Handoff"
 description: "Connect approved Stable publication to Production Web, Appcast, and installer deployment without weakening protected release or rollback boundaries."
-status: "in_review"
+status: "done"
 priority: "critical"
 design_contract: "docs/operations/release_and_signing.md"
 qa_contract: "docs/qa_maintenance/release_verification.md"
@@ -105,3 +105,16 @@ and atomically publish it before selection.
 - [x] Public verification and rollback compare both Appcast/manifest or both
       installer files.
 - [x] Focused workflow contracts, documentation, and Graphify update pass.
+
+## Live closure — 2026-08-10
+
+Private host control commit `61a7c846` and public workflow commits `2f8dbe33`
+and `4273491c` were merged after protected review and complete CI. The one-time
+Production mount migration preserved an owner-only rollback copy and activated
+the canonical static roots. Public rehearsal run `31346940281`, sourced from
+Stable release run `31296207510`, passed Web, updates, and installers. Web serves
+version `1.0.1`, build `2`, and public commit
+`7bbb88a874011490ee8b0f94dd78f4640e4f718d`; all release-owned public bytes,
+clean-browser rendering, and Production/Development/Staging regressions passed.
+Future Stable publication invokes the same reusable workflow automatically with
+all three surfaces enabled.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -103,6 +103,24 @@ incomplete static root, selector-only success, or HTTP-only shell response fails
 the gate. A failed surface must restore and publicly verify all its preceding
 release-owned bytes without recreating data or application services.
 
+### Live Stable asset rehearsal — 2026-08-10
+
+After the one-time Production static-root migration, public workflow run
+`31346940281` deployed all three surfaces from `v1.0.1` release run
+`31296207510`. Web serves version `1.0.1`, build `2`, and commit
+`7bbb88a874011490ee8b0f94dd78f4640e4f718d`. Public Appcast and Stable manifest
+bytes matched their GitHub Release SHA-256 values, and both public installer
+sources matched the tagged source bytes. The selected updates and downloads
+roots also contain their inherited `index.html` and `favicon.svg` files.
+
+A fresh isolated browser reached `/login`, created a full-size Flutter view with
+glass pane and semantics host, loaded CanvasKit/Wasm, `main.dart.js`, fonts, and
+brand assets with successful responses, and reported no uncaught exception or
+console error. The Production, Development, and Staging public verifiers passed;
+Production PostgreSQL and Redis volumes remained present. The rehearsal used the
+same reusable workflow that every future approved Stable publication calls
+automatically.
+
 ## Update failure coverage
 
 Automated tests cover contract parsing, invalid tag rejection, deterministic


### PR DESCRIPTION
## Summary

Close the Stable Production asset plan with live v1.0.1 rehearsal evidence.

## Evidence

- reusable asset run `31346940281` succeeded for Web, updates, and installers
- Web serves v1.0.1 build 2 and commit `7bbb88a8`
- Appcast, Stable manifest, and installer-source hashes matched
- isolated Chrome rendered Flutter `/login` without console or uncaught errors
- Production/Development/Staging regressions passed
- future Stable publication calls the same reusable workflow automatically

Documentation only; no runtime mutation.
