### PR TITLE
feat(client): align event direction and runtime metadata

### DIFF
--- a/client/lib/features/conversations/presentation/utils/tool_presentation_helper.dart
+++ b/client/lib/features/conversations/presentation/utils/tool_presentation_helper.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/session_messages_cubit.dart';
+import 'package:sanad_client/features/conversations/presentation/utils/text_utils.dart';
 
 class ToolPresentationHelper {
   static String getEventTitle(CanonicalEvent event) {
@@ -139,10 +140,16 @@ class ToolPresentationHelper {
     required BuildContext context,
     required CanonicalEvent event,
     required Color titleColor,
+    TextDirection? textDirection,
   }) {
+    final title = getEventTitle(event);
+    final resolvedDirection = textDirection ?? TextUtils.getTextDirection(title);
+
     if (event.kind != EventKind.toolCall) {
       return Text(
-        getEventTitle(event),
+        title,
+        textDirection: resolvedDirection,
+        textAlign: resolvedDirection == TextDirection.rtl ? TextAlign.right : TextAlign.left,
         style: GoogleFonts.outfit(
           color: titleColor,
           fontSize: 13,
@@ -383,6 +390,7 @@ class ToolPresentationHelper {
     return RichText(
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
+      textDirection: resolvedDirection,
       text: TextSpan(
         style: GoogleFonts.outfit(
           fontSize: 13,

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -393,50 +393,56 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
 
   Widget _buildEventHeader(bool canExpand) {
     final bool isError = widget.event.status == EventStatus.error;
+    final titleText = ToolPresentationHelper.getEventTitle(widget.event);
+    final textDirection = TextUtils.getTextDirection(titleText);
 
     final Widget header = InkWell(
       onTap: canExpand ? _toggleExpanded : null,
       borderRadius: BorderRadius.circular(8),
       child: Padding(
         padding: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 12.0),
-        child: Row(
-          children: [
-            _buildStatusIndicator(),
-            const SizedBox(width: 8),
-            Flexible(
-              child: Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Flexible(
-                    child: ToolPresentationHelper.buildTitleWidget(
-                      context: context,
-                      event: widget.event,
-                      titleColor: _getTitleColor(context),
-                    ),
-                  ),
-                  if (canExpand) ...[
-                    const SizedBox(width: 4),
-                    RotationTransition(
-                      turns: _expansionAnimation.drive(Tween<double>(begin: 0.0, end: 0.25)),
-                      child: Icon(
-                        Icons.chevron_right,
-                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                        size: 20,
+        child: Directionality(
+          textDirection: textDirection,
+          child: Row(
+            children: [
+              _buildStatusIndicator(),
+              const SizedBox(width: 8),
+              Flexible(
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Flexible(
+                      child: ToolPresentationHelper.buildTitleWidget(
+                        context: context,
+                        event: widget.event,
+                        titleColor: _getTitleColor(context),
+                        textDirection: textDirection,
                       ),
                     ),
+                    if (canExpand) ...[
+                      const SizedBox(width: 4),
+                      RotationTransition(
+                        turns: _expansionAnimation.drive(Tween<double>(begin: 0.0, end: 0.25)),
+                        child: Icon(
+                          Icons.chevron_right,
+                          color: Theme.of(context).colorScheme.onSurfaceVariant,
+                          size: 20,
+                        ),
+                      ),
+                    ],
+                    if (isError) ...[
+                      const SizedBox(width: 6),
+                      Icon(
+                        Icons.error_outline_rounded,
+                        size: 14,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                    ],
                   ],
-                  if (isError) ...[
-                    const SizedBox(width: 6),
-                    Icon(
-                      Icons.error_outline_rounded,
-                      size: 14,
-                      color: Theme.of(context).colorScheme.error,
-                    ),
-                  ],
-                ],
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/client/lib/utils/format_utils.dart
+++ b/client/lib/utils/format_utils.dart
@@ -56,7 +56,7 @@ class EventMetadataFormatter {
     if (resolvedModel.isNotEmpty) {
       parts.add(resolvedModel);
     }
-    final durationText = _formatRuntime(runtimeMs);
+    final durationText = formatRuntime(runtimeMs);
     if (durationText.isNotEmpty) {
       parts.add(durationText);
     }
@@ -70,7 +70,7 @@ class EventMetadataFormatter {
     );
   }
 
-  static String _formatRuntime(dynamic runtimeMs) {
+  static String formatRuntime(dynamic runtimeMs) {
     if (runtimeMs is! num) return '';
     final milliseconds = runtimeMs.round();
     if (milliseconds < 1000) return '${milliseconds}ms';
@@ -78,9 +78,17 @@ class EventMetadataFormatter {
     if (seconds < 60) {
       return '${seconds.toStringAsFixed(seconds >= 10 ? 0 : 1)}s';
     }
-    final minutes = (seconds / 60).floor();
-    final remainingSeconds = (seconds % 60).round();
-    return '${minutes}m ${remainingSeconds}s';
+
+    final totalSeconds = (milliseconds / 1000).round();
+    final hours = totalSeconds ~/ 3600;
+    final minutes = (totalSeconds % 3600) ~/ 60;
+    final remainingSeconds = totalSeconds % 60;
+
+    if (hours > 0) {
+      return '${hours}h ${minutes}m';
+    } else {
+      return '${minutes}m ${remainingSeconds}s';
+    }
   }
 
   static num? _readUsageNumber(dynamic usage, List<String> keys) {

--- a/client/test/unit/utils/format_utils_test.dart
+++ b/client/test/unit/utils/format_utils_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/utils/format_utils.dart';
+
+void main() {
+  group('EventMetadataFormatter.formatRuntime', () {
+    test('returns empty string when runtime is not a number', () {
+      expect(EventMetadataFormatter.formatRuntime(null), '');
+      expect(EventMetadataFormatter.formatRuntime('abc'), '');
+    });
+
+    test('formats millisecond durations under 1 second', () {
+      expect(EventMetadataFormatter.formatRuntime(250), '250ms');
+      expect(EventMetadataFormatter.formatRuntime(999), '999ms');
+    });
+
+    test('formats second durations under 1 minute', () {
+      expect(EventMetadataFormatter.formatRuntime(1500), '1.5s');
+      expect(EventMetadataFormatter.formatRuntime(12500), '13s');
+      expect(EventMetadataFormatter.formatRuntime(59000), '59s');
+    });
+
+    test('formats minutes and seconds when duration is less than 1 hour', () {
+      // 5 minutes and 12 seconds
+      expect(EventMetadataFormatter.formatRuntime((5 * 60 + 12) * 1000), '5m 12s');
+      // 59 minutes and 59 seconds
+      expect(EventMetadataFormatter.formatRuntime((59 * 60 + 59) * 1000), '59m 59s');
+    });
+
+    test('formats hours and minutes without seconds when duration is 1 hour or more', () {
+      // 3 hours and 20 minutes (200 minutes)
+      expect(EventMetadataFormatter.formatRuntime(200 * 60 * 1000), '3h 20m');
+      // 1 hour, 5 minutes, 30 seconds -> 1h 5m
+      expect(EventMetadataFormatter.formatRuntime((1 * 3600 + 5 * 60 + 30) * 1000), '1h 5m');
+    });
+  });
+}

--- a/client/test/widget/clarifying_question_rtl_test.dart
+++ b/client/test/widget/clarifying_question_rtl_test.dart
@@ -6,12 +6,54 @@ import 'package:sanad_client/features/conversations/domain/models/canonical_even
 import 'package:sanad_client/features/conversations/domain/models/device_suspended_request.dart';
 import 'package:sanad_client/features/conversations/presentation/utils/text_utils.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/clarifying_question_card.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/event_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/tools/ask_user_tool_tile.dart';
 
 void main() {
   test('detects Arabic extended Unicode blocks as RTL', () {
     expect(TextUtils.getTextDirection('\u0870'), TextDirection.rtl);
     expect(TextUtils.getTextDirection('\u08A0'), TextDirection.rtl);
+  });
+
+  testWidgets('renders EventTile header for Arabic ask_user event as RTL', (tester) async {
+    final event = CanonicalEvent(
+      id: 'event-header-rtl',
+      kind: EventKind.toolCall,
+      timestamp: DateTime(2026),
+      tool: {
+        'name': 'system_ask_user',
+        'input': {
+          'questions': [
+            {'question': 'ما هو استفسارك؟'}
+          ]
+        },
+      },
+    );
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: EventTile(event: event),
+        ),
+      ),
+    );
+
+    final headerDirectionality = tester.widget<Directionality>(
+      find.descendant(
+        of: find.byType(InkWell),
+        matching: find.byType(Directionality),
+      ).first,
+    );
+    expect(headerDirectionality.textDirection, TextDirection.rtl);
+
+    final richTexts = tester.widgetList<RichText>(
+      find.descendant(
+        of: find.byType(InkWell),
+        matching: find.byType(RichText),
+      ),
+    );
+    expect(richTexts.isNotEmpty, isTrue);
+    expect(richTexts.first.textDirection, TextDirection.rtl);
   });
 
   testWidgets('resolves every clarifying question string direction independently', (tester) async {

--- a/docs/plans/tasks/rtl_question_header_and_runtime_duration.md
+++ b/docs/plans/tasks/rtl_question_header_and_runtime_duration.md
@@ -1,0 +1,36 @@
+---
+title: "RTL Question Header and Runtime Duration"
+description: "Align dynamic Arabic event headers and present long event runtimes compactly."
+status: "completed"
+---
+
+# RTL Question Header and Runtime Duration
+
+## Goal
+
+Make dynamic ask-user event headers follow the detected title direction and keep
+event runtime metadata readable from milliseconds through multi-hour runs.
+
+## Implementation
+
+- Resolve event-title direction once and apply it to the complete header row and
+  title renderer.
+- Preserve left-to-right presentation for English event titles.
+- Expose runtime formatting for focused unit coverage and render multi-hour
+  durations as hours plus minutes.
+- Document and test both presentation behaviors.
+
+## Verification
+
+- `fvm flutter analyze` passes.
+- Focused RTL widget and runtime-format unit tests pass.
+- Live Arabic `system_ask_user` presentation is reviewed from the target
+  worktree runtime.
+- `graphify update .` completes when the local graph is available.
+
+## Definition of Done
+
+- [x] Arabic ask-user event headers render as RTL rows.
+- [x] English event headers remain LTR.
+- [x] Runtime metadata covers milliseconds, seconds, minutes, and hours.
+- [x] Product and QA documentation describe the behavior.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -92,7 +92,11 @@ opening; users never need to close and reopen the menu to refresh it.
 ## Active work
 
 The conversation timeline renders Markdown, code, reasoning summaries, tool
-activity, permission requests, recovery notices, and final responses.
+activity, permission requests, recovery notices, and final responses. Dynamic
+event titles resolve their own text direction; Arabic ask-user headers mirror
+the complete header row while English headers remain left-to-right. Event
+runtime metadata uses milliseconds below one second, seconds below one minute,
+minutes plus seconds below one hour, and hours plus minutes thereafter.
 
 While the agent is working:
 

--- a/docs/qa_maintenance/clarifying_question_rtl_qa.md
+++ b/docs/qa_maintenance/clarifying_question_rtl_qa.md
@@ -7,7 +7,7 @@ description: "Verification matrix for Arabic directionality and platform-aware m
 
 ## Scope
 
-This matrix covers text direction in the active `system_ask_user` suspension card and the completed ask-user tool result.
+This matrix covers text direction in the active `system_ask_user` suspension card, completed ask-user tool results, and conversation event headers.
 
 ## Automated Coverage
 
@@ -22,6 +22,8 @@ This matrix covers text direction in the active `system_ask_user` suspension car
 | Custom answer Android/iOS software-keyboard `Enter` | A line break is inserted and the answer remains open until the visible submit action is used. |
 | Completed Arabic question and answer | Question and answer each render RTL and right-aligned. |
 | Arabic extended Unicode characters | Direction detection classifies the text as RTL. |
+| Arabic ask-user event header | The complete header row follows RTL direction, including status, title, expansion, and error indicators. |
+| English event header | The header row retains LTR ordering and alignment. |
 
 ## Visual Review
 


### PR DESCRIPTION
## Problem / Goal

Dynamic Arabic ask-user event titles were right-to-left at the text level without aligning the complete event-header row. Event runtime metadata also lacked compact multi-hour formatting.

Tracked plan: `docs/plans/tasks/rtl_question_header_and_runtime_duration.md`

## Changes

- detect event-title direction once and apply it to the complete header row
- pass the resolved direction into plain and rich title rendering
- preserve left-to-right ordering for English event headers
- expose focused runtime formatting and render durations of one hour or more as hours plus minutes
- add RTL widget and duration-format unit coverage
- update product, QA, and implementation-plan documentation

## Verification

- `fvm flutter analyze` — no issues
- `fvm flutter test test/widget/clarifying_question_rtl_test.dart test/unit/utils/format_utils_test.dart` — 10 passed
- `git diff --check`
- `graphify update .`
- live Arabic `system_ask_user` question rendered from the target worktree runtime

## Risk and cross-platform impact

Low presentation risk. Direction is derived from the dynamic title and applies consistently across platforms. Runtime formatting is pure Dart with focused boundary coverage.

## Rollback

Revert this PR to restore the previous LTR header composition and minute/second-only long-duration formatting.
