### PR TITLE
docs(skills): require authorization for protected labels

### DIFF
--- a/.agents/skills/sanad-pull-request-lifecycle/SKILL.md
+++ b/.agents/skills/sanad-pull-request-lifecycle/SKILL.md
@@ -22,6 +22,7 @@ Use this skill after work is accepted and scoped. It may prepare local changes a
 4. Update the owning task checklist and evidence only after verification.
 5. Use a Conventional Commits pull-request title. The human PR will be squash merged, so the title must describe the final commit.
 6. Write the pull request with Problem/Goal, linked `Closes #...`, Changes, Verification, risk, cross-platform impact, documentation, and rollback.
+7. Map all modified paths against the repository label taxonomy before creating the pull request. Apply appropriate non-protected category labels such as `type/*` and `comp/*` only when the taxonomy calls for them. For any required protected positive-review label (`maintainer-reviewed`, `security-reviewed`, or `release-reviewed`), report why it is required and ask the responsible maintainer for explicit authorization after presenting the review evidence; never add a protected label merely to make CI pass. If authorization is withheld or unavailable, leave the label absent and report the merge blocker.
 
 ## CI Repair Loop
 


### PR DESCRIPTION
## Problem / Goal

The pull-request lifecycle skill identified protected-review labels during preparation but did not explicitly define how agents must distinguish ordinary categorization from protected positive review or obtain authorization before applying sensitive labels.

## Changes

- map modified paths against the repository label taxonomy before PR creation
- allow appropriate non-protected `type/*` and `comp/*` categorization when the taxonomy calls for it
- require the agent to present review evidence and ask the responsible maintainer for explicit authorization before applying protected positive-review labels
- leave unauthorized protected labels absent and report the resulting merge blocker
- explicitly prohibit adding protected labels merely to make CI pass

## Verification

- `git diff --check origin/main...HEAD`
- confirmed the skill contains no `gh run watch` instruction
- confirmed protected-label authorization wording is present

## Risk and cross-platform impact

Documentation/SOP-only change. No runtime or platform behavior changes.

## Documentation

The skill remains aligned with `docs/operations/community_governance.md` and the pull-request review mutation boundary.

## Rollback

Revert this PR to restore the previous lifecycle skill wording.
