### PR TITLE
fix(release): add compatible Linux DEB packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
 
   client-linux-web:
     needs: validate
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
@@ -270,7 +270,7 @@ jobs:
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libasound2-dev
+          sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev libasound2-dev xvfb
       - name: Build Linux and Web
         working-directory: client
         run: |
@@ -278,6 +278,7 @@ jobs:
           fvm flutter pub get
           fvm flutter analyze
           fvm flutter test test/tool/app_web_startup_contract_test.dart
+          fvm flutter test test/tool/linux_release_compatibility_contract_test.dart
           fvm flutter build linux --release --dart-define-from-file=config/prod.json
           fvm flutter build web --release --dart-define-from-file=config/prod.json
           printf '%s\n' '{"version":"${{ needs.validate.outputs.artifact_version }}","build":${{ needs.validate.outputs.build }}}' \
@@ -299,6 +300,16 @@ jobs:
           mkdir -p ../dist
           tar -C build/linux/x64/release -czf \
             "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-linux-x64.tar.gz" bundle
+          bash ../scripts/release/test_linux_release_bundle.sh \
+            "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-linux-x64.tar.gz"
+          SOURCE_DATE_EPOCH="$(git show -s --format=%ct "$GITHUB_SHA")" \
+            bash release/linux/build_linux_deb.sh \
+            build/linux/x64/release/bundle \
+            "${{ needs.validate.outputs.artifact_version }}" \
+            "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-linux-x64.deb"
+          bash ../scripts/release/test_linux_deb_package.sh \
+            "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-linux-x64.deb" \
+            --install
           tar -C build/web -czf \
             "../dist/sanad-client-${{ needs.validate.outputs.artifact_version }}-web-universal.tar.gz" .
       - uses: actions/upload-artifact@v4
@@ -715,7 +726,7 @@ jobs:
             select(.component == "client" and
               ((.platform == "macos" and .architecture == "universal" and .format == "dmg") or
                (.platform == "windows" and .architecture == "x64" and .format == "exe") or
-               (.platform == "linux" and .architecture == "x64" and .format == "tar.gz"))) |
+               (.platform == "linux" and .architecture == "x64" and .format == "deb"))) |
             .filename' download/release-manifest.json)
           test "${#client_files[@]}" -eq 3
           for file in "${client_files[@]}"; do

--- a/client/lib/infrastructure/platform/auto_update_service.dart
+++ b/client/lib/infrastructure/platform/auto_update_service.dart
@@ -264,7 +264,7 @@ class AutoUpdateService {
       component: 'client',
       platform: 'linux',
       architecture: 'x64',
-      format: 'tar.gz',
+      format: 'deb',
       publicOnly: true,
     );
     if (artifact == null) {

--- a/client/release/README.md
+++ b/client/release/README.md
@@ -9,7 +9,8 @@ The release pipeline publishes the supported client packages, including:
 
 - `sanad-client-<version>-macos-universal.dmg`
 - `sanad-client-<version>-windows-x64.exe`
-- `sanad-client-<version>-linux-x64.tar.gz`
+- `sanad-client-<version>-linux-x64.deb` (primary Ubuntu/Debian package)
+- `sanad-client-<version>-linux-x64.tar.gz` (portable advanced-user bundle)
 - `sanad-client-<version>-android-universal.apk`
 
 Store or hosted-web destinations are linked from the GitHub Release when they
@@ -20,6 +21,7 @@ apply.
 - `macos/` builds the macOS DMG and owns the macOS release helper.
 - `windows/` builds and verifies the Windows x64 installer. Its automated
   installer path uses NSIS.
+- `linux/` builds the Ubuntu/Debian x64 package from the verified Flutter bundle.
 - `ios/` owns the Internal TestFlight export policy.
 - `release/release-contract.json` and `release/contract/` at repository
   root own version validation, manifest parsing, Appcast generation, and

--- a/client/release/linux/build_linux_deb.sh
+++ b/client/release/linux/build_linux_deb.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <linux-bundle> <version> <output.deb>" >&2
+  exit 64
+fi
+
+bundle="$1"
+version="$2"
+output="$3"
+
+[[ -x "$bundle/sanad-client" ]] || {
+  echo "invalid Linux bundle: $bundle" >&2
+  exit 66
+}
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[1-9][0-9]*)?$ ]] || {
+  echo "invalid release version: $version" >&2
+  exit 65
+}
+command -v dpkg-deb >/dev/null 2>&1 || {
+  echo "dpkg-deb is required" >&2
+  exit 69
+}
+
+debian_version="${version/-rc./~rc.}"
+source_epoch="${SOURCE_DATE_EPOCH:-0}"
+[[ "$source_epoch" =~ ^[0-9]+$ ]] || {
+  echo "SOURCE_DATE_EPOCH must be an integer" >&2
+  exit 65
+}
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "$tmpdir"; }
+trap cleanup EXIT
+root="$tmpdir/root"
+
+install -d \
+  "$root/DEBIAN" \
+  "$root/opt/sanad-client" \
+  "$root/usr/bin" \
+  "$root/usr/share/applications" \
+  "$root/usr/share/icons"
+cp -a "$bundle/." "$root/opt/sanad-client/"
+install -m 0644 \
+  "$bundle/share/applications/com.eaststarai.sanad.desktop" \
+  "$root/usr/share/applications/com.eaststarai.sanad.desktop"
+cp -a "$bundle/share/icons/hicolor" "$root/usr/share/icons/"
+rm -rf "$root/opt/sanad-client/share"
+ln -s /opt/sanad-client/sanad-client "$root/usr/bin/sanad-client"
+
+find "$root/opt/sanad-client" -type d -exec chmod 0755 {} +
+find "$root/opt/sanad-client" -type f -exec chmod 0644 {} +
+chmod 0755 "$root/opt/sanad-client/sanad-client"
+find "$root/usr/share/icons" -type d -exec chmod 0755 {} +
+find "$root/usr/share/icons" -type f -exec chmod 0644 {} +
+
+installed_size="$(du -sk "$root/opt" "$root/usr" | awk '{total += $1} END {print total}')"
+cat > "$root/DEBIAN/control" <<CONTROL
+Package: sanad-client
+Version: $debian_version
+Section: utils
+Priority: optional
+Architecture: amd64
+Installed-Size: $installed_size
+Maintainer: EastStar AI <support@eaststarai.com>
+Homepage: https://sanad.eaststarai.com
+Depends: libgtk-3-0 | libgtk-3-0t64, libglib2.0-0 | libglib2.0-0t64, libstdc++6, hicolor-icon-theme
+Description: Local-first AI agent desktop client
+ Sanad Client connects to local and remote Sanad Agent runtimes from a native
+ Flutter desktop interface.
+CONTROL
+chmod 0644 "$root/DEBIAN/control"
+find "$root" -exec touch -h --date="@$source_epoch" {} +
+
+mkdir -p "$(dirname "$output")"
+dpkg-deb --root-owner-group --build "$root" "$output" >/dev/null
+echo "built Linux package: $output"

--- a/client/test/tool/linux_release_compatibility_contract_test.dart
+++ b/client/test/tool/linux_release_compatibility_contract_test.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('Linux release workflow enforces its compatibility gates', () async {
+    final workflow = File('../.github/workflows/release.yml');
+    expect(workflow.existsSync(), isTrue, reason: 'release workflow must exist');
+
+    final text = await workflow.readAsString();
+    final start = text.indexOf('\n  client-linux-web:');
+    final end = start < 0 ? -1 : text.indexOf('\n  client-android:', start);
+    expect(start, greaterThanOrEqualTo(0));
+    expect(end, greaterThan(start));
+
+    final linuxJob = text.substring(start, end);
+    expect(linuxJob, contains('runs-on: ubuntu-22.04'));
+    expect(linuxJob, isNot(contains('runs-on: ubuntu-24.04')));
+    expect(linuxJob, contains('libasound2-dev xvfb'));
+    expect(
+      linuxJob,
+      contains('scripts/release/test_linux_release_bundle.sh'),
+    );
+    expect(linuxJob, contains('release/linux/build_linux_deb.sh'));
+    expect(linuxJob, contains('scripts/release/test_linux_deb_package.sh'));
+    expect(linuxJob, contains('--install'));
+    expect(
+      linuxJob,
+      contains('fvm flutter build linux --release'),
+      reason: 'the compatibility gates must guard the actual Linux build job',
+    );
+  });
+
+  test('release contract publishes DEB as the primary Linux package', () async {
+    final contract =
+        jsonDecode(
+              await File('../release/release-contract.json').readAsString(),
+            )
+            as Map<String, dynamic>;
+    final artifacts = (contract['artifacts'] as List).cast<Map<String, dynamic>>();
+    final linuxFormats = artifacts
+        .where(
+          (artifact) =>
+              artifact['component'] == 'client' &&
+              artifact['platform'] == 'linux' &&
+              artifact['architecture'] == 'x64' &&
+              artifact['public'] == true,
+        )
+        .map((artifact) => artifact['format'])
+        .toSet();
+
+    expect(linuxFormats, containsAll(<String>{'deb', 'tar.gz'}));
+    final redirects = await File(
+      '../scripts/release/generate_client_download_redirects.sh',
+    ).readAsString();
+    expect(redirects, contains('linux\tx64\tdeb'));
+  });
+}

--- a/client/test/unit/services/verified_agent_bootstrap_installer_test.dart
+++ b/client/test/unit/services/verified_agent_bootstrap_installer_test.dart
@@ -317,6 +317,7 @@ void main() {
     await service.initialize();
     expect((await service.checkForUpdates()).status, ClientUpdateStatus.updateOpened);
     expect(opened?.host, 'github.com');
+    expect(opened?.path, endsWith('sanad-client-1.1.0-linux-x64.deb'));
   });
 }
 
@@ -333,9 +334,9 @@ Map<String, dynamic> _linuxClientManifest() => {
       'component': 'client',
       'platform': 'linux',
       'architecture': 'x64',
-      'format': 'tar.gz',
-      'filename': 'sanad-client-1.1.0-linux-x64.tar.gz',
-      'url': 'https://github.com/EastStarAI/sanad-agent/releases/download/v1.1.0/sanad-client-1.1.0-linux-x64.tar.gz',
+      'format': 'deb',
+      'filename': 'sanad-client-1.1.0-linux-x64.deb',
+      'url': 'https://github.com/EastStarAI/sanad-agent/releases/download/v1.1.0/sanad-client-1.1.0-linux-x64.deb',
       'sha256': List.filled(64, 'a').join(),
       'size': 42,
       'public': true,

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -21,7 +21,7 @@ Pull-request CI is read-only and never receives signing or deployment credential
 | Agent | Linux x64 | GitHub Release | SHA-256 plus GitHub attestation |
 | Agent | Windows x64 | GitHub Release | Temporarily unsigned Windows build for every release; canonical manifest/URL/size/SHA-256 and protected GitHub provenance |
 | Client | macOS universal | GitHub Release | Developer ID, notarization, Sparkle EdDSA |
-| Client | Linux x64 | GitHub Release | SHA-256 plus GitHub attestation |
+| Client | Linux x64 `.deb` and portable `tar.gz` | GitHub Release | SHA-256 plus GitHub attestation |
 | Client | Windows x64 | GitHub Release | Temporarily unsigned Windows build for every release; WinSparkle DSA plus canonical manifest/URL/size/SHA-256 and protected GitHub provenance |
 | Client | Android universal APK | GitHub Release | Android release signature |
 | Client | Android AAB | Private release handoff | Android release signature |

--- a/docs/operations/user_guide.md
+++ b/docs/operations/user_guide.md
@@ -57,12 +57,12 @@ After installation, launch Sanad Client from the Start menu.
 
 ### Linux
 
-1. Extract the versioned Linux x64 bundle.
-2. Open the extracted bundle.
-3. Run the Sanad Client executable.
-
-The release notes list any distribution-specific desktop integration
-requirements.
+Download the versioned Linux x64 `.deb`, open it with the Ubuntu/Debian software
+installer, and select **Install**. The package adds Sanad to the applications
+menu with its desktop icon. For terminal installation, run
+`sudo apt install ./sanad-client-<version>-linux-x64.deb` from the download
+directory. The portable `tar.gz` remains available for advanced users who do
+not want a system installation.
 
 ## Use Sanad locally
 
@@ -223,11 +223,11 @@ installer replaces the application.
 Linux Client updates are deliberately manual:
 
 1. Open **Settings → General** and select **Check for Updates**.
-2. If a newer canonical Linux x64 artifact exists, Sanad opens that exact
+2. If a newer canonical Linux x64 `.deb` exists, Sanad opens that exact
    official GitHub Release artifact in the external browser. It does not
    download, replace, elevate, or restart the application.
-3. Download and extract the newer bundle, close the current Client, replace the
-   Client bundle, and launch it again.
+3. Close the current Client and install the downloaded `.deb` with the software
+   installer or `sudo apt install ./sanad-client-<version>-linux-x64.deb`.
 4. Keep the existing Sanad Home (normally `~/.sanad`). Do not delete or replace
    it; identity, provider configuration, and Agent state remain there.
 

--- a/docs/plans/tasks/linux-client-deb-packaging.md
+++ b/docs/plans/tasks/linux-client-deb-packaging.md
@@ -1,0 +1,36 @@
+---
+title: "Linux Client DEB Packaging"
+description: "Produce an installable Ubuntu/Debian Sanad Client package with desktop integration and release verification."
+status: "Implemented and locally verified; hosted release CI pending"
+---
+
+# Linux Client DEB Packaging
+
+## Goal
+
+Make the primary Linux x64 download a directly installable `.deb` while retaining the relocatable `tar.gz` for advanced users.
+
+## Design
+
+- Build the Flutter Linux bundle on the Ubuntu 22.04 compatibility baseline.
+- Install application runtime files under `/opt/sanad-client`, expose `/usr/bin/sanad-client`, and install the existing desktop entry and hicolor icons under `/usr/share`.
+- Publish both `.deb` and `tar.gz` in the release manifest; Production `/client/linux` resolves to the `.deb`.
+- Linux user-initiated update discovery opens the canonical `.deb` artifact.
+- Package tests inspect metadata/layout, launch an extracted package in isolation, and on CI perform real install, launch, and purge verification.
+
+## Definition of Done
+
+- The `.deb` builds deterministically from the release bundle and carries the release version and `amd64` architecture.
+- Desktop launcher and all icon sizes are installed in standard system locations.
+- The package installs, launches, and uninstalls on the Ubuntu 22.04 release runner without touching an existing Sanad Home.
+- The release contract, Stable convenience redirect, update discovery, user guide, and QA matrix select the `.deb` as the primary Linux package.
+- The legacy `tar.gz` remains published and passes its compatibility smoke test.
+
+## Local verification
+
+On Ubuntu 22.04 with GLib 2.72, the rebuilt portable bundle and `.deb` launched
+successfully without the GLib 2.80-only symbol. The `.deb` passed deterministic
+rebuild comparison, metadata and icon-layout inspection, an isolated `dpkg`
+install/remove transaction, and a user-confirmed privileged install,
+eight-second launch smoke, and purge through the `--install` mode of
+`scripts/release/test_linux_deb_package.sh`.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -29,6 +29,28 @@ default rules and narrowly allows only the reviewed `generic-api-key` fixtures
 in three exact credential/redaction test files; production paths and all other
 rules remain fail-closed.
 
+Linux desktop release compatibility is a release gate. The supported binary
+baseline is Ubuntu 22.04 or newer. The `client-linux-web` job must therefore
+build the packaged Linux x64 Client on `ubuntu-22.04`, not a newer runner, so
+the produced executable and native Linux plugins do not raise the runtime
+GLib/GLIBC baseline above target systems. After packaging, CI must run
+`scripts/release/test_linux_release_bundle.sh` against the generated `tar.gz`;
+the smoke rejects any bundled executable or `.so` that imports
+`g_once_init_enter_pointer`, verifies the required runtime files exist, and
+launches the extracted `./sanad-client` under an isolated D-Bus session and
+Xvfb long enough to prove the bundle starts successfully.
+
+This gate regresses the `v1.0.1` Linux artifact built on Ubuntu 24.04. GLib
+introduced `g_once_init_enter_pointer` in 2.80; the published executable and
+five GTK plugin libraries imported it and consequently failed against Ubuntu
+23.04 GLib 2.76. Building on Ubuntu 22.04 GLib 2.72 keeps those generated native
+objects below that ABI boundary without bundling or replacing system GLib.
+The same job builds the primary `.deb` from that verified bundle, checks package
+metadata, standard `/opt`, `/usr/bin`, desktop-entry, and hicolor icon layout,
+then installs, launches, and purges it on the clean runner. The Stable Linux
+convenience link selects this `.deb`; the `tar.gz` remains a public portable
+alternative.
+
 ## Platform matrix
 
 | Target | Local evidence | Hosted or clean-machine evidence still required |
@@ -37,7 +59,7 @@ rules remain fail-closed.
 | Agent Linux x64 | contract and workflow path | hosted build, provenance, clean install, service/update/rollback |
 | Agent Windows x64 | contract and workflow path | Unsigned Windows build disclosure, SHA-256/manifest/provenance, Defender/SmartScreen and lifecycle on Windows 11, service/update/rollback |
 | Client macOS universal | universal Mach-O inspection, Developer ID-signed and notarized DMG, staple, Gatekeeper, Sparkle signature | clean update and rollback |
-| Client Linux x64 | Web/Linux workflow definition | hosted package, dependency audit, clean install/update/uninstall |
+| Client Linux x64 | Web/Linux workflow definition, compatibility-runner contract, `.deb` metadata/layout audit, portable-bundle smoke, and forbidden-symbol audit | hosted `.deb` install/launch/purge, provenance, clean update |
 | Client Windows x64 | installer and current fail-closed signing workflow definition | SANAD-12 unsigned-policy workflow adaptation, disclosure, SHA-256/manifest/provenance, Windows 11 clean installer/update/rollback and Defender/SmartScreen |
 | Client Android APK/AAB | signed local APK/AAB, package identity and keystore fingerprint | signed hosted build, clean install/upgrade |
 | Client iOS | signed IPA export for NanoSoft LY LLC; App Store Connect record and API key ready | Internal TestFlight upload |

--- a/docs/technical/update_architecture.md
+++ b/docs/technical/update_architecture.md
@@ -29,7 +29,7 @@ GitHub attestation locally.
 | Agent Linux | `github-attestation` | canonical URL, size, and SHA-256 |
 | Client macOS | `developer-id+notarization+sparkle-ed25519` | Sparkle EdDSA plus Apple package trust |
 | Client Windows | `unsigned+winsparkle-dsa` | WinSparkle DSA plus manifest/checksum/provenance release gates |
-| Client Linux | `github-attestation` | manual discovery of a canonical release artifact |
+| Client Linux | `github-attestation` | manual discovery of the canonical x64 `.deb`; portable `tar.gz` remains an alternative |
 
 Windows remains intentionally unsigned for every release until an explicit
 signed-only migration changes this centralized policy. Signed and unsigned
@@ -117,9 +117,10 @@ process name alone.
 
 Linux has no background poll, download, package replacement, privilege request,
 or rollback claim. **Settings → General → Check for Updates** performs a
-user-initiated manifest check. Only a newer canonical Linux x64 Client artifact
+user-initiated manifest check. Only a newer canonical Linux x64 Client `.deb`
 is opened in the external browser; up-to-date and discovery failures remain
-non-blocking.
+non-blocking. Installation and replacement remain user-approved system package
+manager actions.
 
 ## Isolated candidate verification
 

--- a/release/release-contract.json
+++ b/release/release-contract.json
@@ -70,6 +70,15 @@
       "component": "client",
       "platform": "linux",
       "architecture": "x64",
+      "format": "deb",
+      "filename": "sanad-client-1.0.1-linux-x64.deb",
+      "public": true,
+      "signature_type": "github-attestation"
+    },
+    {
+      "component": "client",
+      "platform": "linux",
+      "architecture": "x64",
       "format": "tar.gz",
       "filename": "sanad-client-1.0.1-linux-x64.tar.gz",
       "public": true,

--- a/scripts/release/generate_client_download_redirects.sh
+++ b/scripts/release/generate_client_download_redirects.sh
@@ -59,7 +59,7 @@ while IFS=$'\t' read -r platform architecture format; do
 done <<'PLATFORMS'
 macos	universal	dmg
 windows	x64	exe
-linux	x64	tar.gz
+linux	x64	deb
 PLATFORMS
 
 install -m 0644 "$temporary" "$OUTPUT"

--- a/scripts/release/test_generate_client_download_redirects.sh
+++ b/scripts/release/test_generate_client_download_redirects.sh
@@ -8,7 +8,8 @@ trap 'rm -rf "$ROOT"' EXIT
 mkdir "$ROOT/assets"
 printf macos > "$ROOT/assets/client-macos.dmg"
 printf windows > "$ROOT/assets/client-windows.exe"
-printf linux > "$ROOT/assets/client-linux.tar.gz"
+printf linux > "$ROOT/assets/client-linux.deb"
+printf portable > "$ROOT/assets/client-linux.tar.gz"
 
 sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'; else shasum -a 256 "$1" | awk '{print $1}'; fi; }
 for file in "$ROOT"/assets/*; do printf '%s  %s\n' "$(sha "$file")" "$(basename "$file")"; done > "$ROOT/SHA256SUMS"
@@ -16,15 +17,19 @@ for file in "$ROOT"/assets/*; do printf '%s  %s\n' "$(sha "$file")" "$(basename 
 jq -n \
   --arg mac_sha "$(sha "$ROOT/assets/client-macos.dmg")" \
   --arg win_sha "$(sha "$ROOT/assets/client-windows.exe")" \
-  --arg linux_sha "$(sha "$ROOT/assets/client-linux.tar.gz")" \
+  --arg linux_sha "$(sha "$ROOT/assets/client-linux.deb")" \
+  --arg linux_tar_sha "$(sha "$ROOT/assets/client-linux.tar.gz")" \
   '{schema_version:1,version:"9.8.7",tag:"v9.8.7",commit:"0123456789abcdef0123456789abcdef01234567",channel:"stable",repository:"EastStarAI/sanad-agent",artifacts:[
     {component:"client",platform:"macos",architecture:"universal",format:"dmg",filename:"client-macos.dmg",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-macos.dmg",sha256:$mac_sha,size:5,public:true},
     {component:"client",platform:"windows",architecture:"x64",format:"exe",filename:"client-windows.exe",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-windows.exe",sha256:$win_sha,size:7,public:true},
-    {component:"client",platform:"linux",architecture:"x64",format:"tar.gz",filename:"client-linux.tar.gz",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-linux.tar.gz",sha256:$linux_sha,size:5,public:true}
+    {component:"client",platform:"linux",architecture:"x64",format:"deb",filename:"client-linux.deb",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-linux.deb",sha256:$linux_sha,size:5,public:true},
+    {component:"client",platform:"linux",architecture:"x64",format:"tar.gz",filename:"client-linux.tar.gz",url:"https://github.com/EastStarAI/sanad-agent/releases/download/v9.8.7/client-linux.tar.gz",sha256:$linux_tar_sha,size:8,public:true}
   ]}' > "$ROOT/manifest.json"
 
 "$GENERATOR" "$ROOT/manifest.json" "$ROOT/SHA256SUMS" "$ROOT/assets" "$ROOT/redirects.conf" >/dev/null
 for platform in macos windows linux; do test "$(grep -Fc "location = /client/$platform" "$ROOT/redirects.conf")" -eq 1; done
+grep -Fq client-linux.deb "$ROOT/redirects.conf"
+! grep -Fq client-linux.tar.gz "$ROOT/redirects.conf"
 ! grep -Fq sanad-agent- "$ROOT/redirects.conf"
 
 jq '.channel = "rc"' "$ROOT/manifest.json" > "$ROOT/bad.json"

--- a/scripts/release/test_linux_deb_package.sh
+++ b/scripts/release/test_linux_deb_package.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 1 || $# -gt 2 || ( $# -eq 2 && "$2" != --install ) ]]; then
+  echo "usage: $0 <sanad-client-*.deb> [--install]" >&2
+  exit 64
+fi
+
+deb="$1"
+install_smoke="${2:-}"
+[[ -f "$deb" ]] || { echo "package not found: $deb" >&2; exit 66; }
+for command in dbus-run-session dpkg-deb objdump tar timeout; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "required command not found: $command" >&2
+    exit 69
+  }
+done
+
+[[ "$(dpkg-deb -f "$deb" Package)" == sanad-client ]]
+[[ "$(dpkg-deb -f "$deb" Architecture)" == amd64 ]]
+[[ "$(dpkg-deb -f "$deb" Version)" =~ ^[0-9]+\.[0-9]+\.[0-9]+(~rc\.[1-9][0-9]*)?$ ]]
+
+tmpdir="$(mktemp -d)"
+installed=false
+cleanup() {
+  if [[ "$installed" == true ]]; then
+    sudo dpkg --purge sanad-client >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+dpkg-deb -x "$deb" "$tmpdir/root"
+exe="$tmpdir/root/opt/sanad-client/sanad-client"
+[[ -x "$exe" ]]
+[[ "$(readlink "$tmpdir/root/usr/bin/sanad-client")" == /opt/sanad-client/sanad-client ]]
+[[ -f "$tmpdir/root/usr/share/applications/com.eaststarai.sanad.desktop" ]]
+for size in 16 24 32 48 64 128 256 512; do
+  [[ -f "$tmpdir/root/usr/share/icons/hicolor/${size}x${size}/apps/com.eaststarai.sanad.png" ]]
+done
+
+for path in "$exe" "$tmpdir/root"/opt/sanad-client/lib/*.so; do
+  symbols="$(objdump -T "$path" 2>/dev/null || true)"
+  ! grep -q g_once_init_enter_pointer <<<"$symbols"
+done
+
+run_smoke() {
+  local target="$1"
+  local runner=()
+  if command -v xvfb-run >/dev/null 2>&1; then
+    runner=(xvfb-run -a)
+  elif [[ -z "${DISPLAY:-}" ]]; then
+    echo "xvfb-run is required when no display is available" >&2
+    return 69
+  fi
+  mkdir -p "$tmpdir/home" "$tmpdir/config" "$tmpdir/cache" "$tmpdir/data"
+  set +e
+  timeout --signal=TERM --kill-after=5s 8s env \
+    HOME="$tmpdir/home" \
+    XDG_CONFIG_HOME="$tmpdir/config" \
+    XDG_CACHE_HOME="$tmpdir/cache" \
+    XDG_DATA_HOME="$tmpdir/data" \
+    dbus-run-session -- "${runner[@]}" "$target" \
+    >"$tmpdir/smoke.stdout" 2>"$tmpdir/smoke.stderr"
+  local status=$?
+  set -e
+  if [[ $status -ne 124 ]] || grep -Eq \
+    'symbol lookup error|undefined symbol|error while loading shared libraries' \
+    "$tmpdir/smoke.stderr"; then
+    cat "$tmpdir/smoke.stderr" >&2 || true
+    return 1
+  fi
+}
+
+run_smoke "$exe"
+
+if [[ "$install_smoke" == --install ]]; then
+  command -v sudo >/dev/null 2>&1 || { echo "sudo is required" >&2; exit 69; }
+  ! dpkg-query -W -f='${Status}' sanad-client 2>/dev/null | grep -q 'install ok installed'
+  sudo dpkg -i "$deb" >/dev/null
+  installed=true
+  [[ -x /usr/bin/sanad-client ]]
+  run_smoke /usr/bin/sanad-client
+  sudo dpkg --purge sanad-client >/dev/null
+  installed=false
+  [[ ! -e /usr/bin/sanad-client ]]
+  [[ ! -e /opt/sanad-client ]]
+fi
+
+echo "linux DEB smoke passed: $deb"

--- a/scripts/release/test_linux_release_bundle.sh
+++ b/scripts/release/test_linux_release_bundle.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <sanad-client-*.tar.gz>" >&2
+  exit 64
+fi
+
+archive="$1"
+if [[ ! -f "$archive" ]]; then
+  echo "archive not found: $archive" >&2
+  exit 66
+fi
+
+for command in dbus-run-session objdump tar timeout; do
+  command -v "$command" >/dev/null 2>&1 || {
+    echo "required command not found: $command" >&2
+    exit 69
+  }
+done
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+tar -xzf "$archive" -C "$tmpdir"
+bundle_dir="$tmpdir/bundle"
+exe="$bundle_dir/sanad-client"
+
+if [[ ! -x "$exe" ]]; then
+  echo "missing executable: $exe" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+binaries=("$exe" "$bundle_dir"/lib/*.so)
+for path in "${binaries[@]}"; do
+  symbols="$(objdump -T "$path" 2>/dev/null || true)"
+  if grep -q 'g_once_init_enter_pointer' <<<"$symbols"; then
+    echo "forbidden GLib symbol requirement found in $path" >&2
+    exit 1
+  fi
+done
+
+required=(
+  "$bundle_dir/lib/libflutter_linux_gtk.so"
+  "$bundle_dir/lib/libapp.so"
+  "$bundle_dir/data/icudtl.dat"
+)
+for path in "${required[@]}"; do
+  [[ -e "$path" ]] || {
+    echo "missing bundled runtime file: $path" >&2
+    exit 1
+  }
+done
+
+runner=()
+if command -v xvfb-run >/dev/null 2>&1; then
+  runner=(xvfb-run -a)
+elif [[ -z "${DISPLAY:-}" ]]; then
+  echo "xvfb-run is required when no display is available" >&2
+  exit 69
+fi
+
+mkdir -p "$tmpdir/home" "$tmpdir/config" "$tmpdir/cache" "$tmpdir/data"
+stdout="$tmpdir/smoke.stdout"
+stderr="$tmpdir/smoke.stderr"
+set +e
+timeout --signal=TERM --kill-after=5s 8s \
+  env \
+    HOME="$tmpdir/home" \
+    XDG_CONFIG_HOME="$tmpdir/config" \
+    XDG_CACHE_HOME="$tmpdir/cache" \
+    XDG_DATA_HOME="$tmpdir/data" \
+  dbus-run-session -- "${runner[@]}" "$exe" >"$stdout" 2>"$stderr"
+status=$?
+set -e
+
+if [[ $status -ne 124 ]]; then
+  echo "sanad-client did not remain alive for the release smoke window (exit $status)" >&2
+  cat "$stderr" >&2 || true
+  exit 1
+fi
+
+if grep -Eq 'symbol lookup error|undefined symbol|error while loading shared libraries' "$stderr"; then
+  echo "sanad-client reported a dynamic-linker failure" >&2
+  cat "$stderr" >&2
+  exit 1
+fi
+
+echo "linux release smoke passed: $archive"


### PR DESCRIPTION
## Problem / Goal

The published Linux 1.0.1 Client was built on Ubuntu 24.04 and its executable plus five GTK plugin libraries imported the GLib 2.80-only `g_once_init_enter_pointer` symbol. It fails to start on Ubuntu 23.04 with GLib 2.76. The public Linux download was also a portable `tar.gz`, leaving desktop installation and icon registration to the user.

## Changes

- build Linux Client artifacts on the Ubuntu 22.04 compatibility baseline;
- reject the incompatible GLib symbol and smoke the extracted portable bundle;
- produce a reproducible `amd64` `.deb` with `/opt`, `/usr/bin`, desktop-entry, and hicolor icon integration;
- install, launch, and purge the `.deb` in release CI;
- keep `tar.gz` public while selecting `.deb` for the Stable Linux convenience link and user-initiated update discovery;
- update release contracts, tests, user guidance, architecture, and QA evidence.

## Verification

- `fvm flutter analyze` — pass
- focused Flutter update/release contract tests — 14 passed
- focused Agent release-manifest tests — 20 passed, 1 platform skip
- Linux portable bundle build and launch smoke — pass
- Linux `.deb` metadata, icon layout, forbidden-symbol, and launch smoke — pass
- deterministic `.deb` rebuild comparison — byte-identical
- isolated `dpkg` install/remove transaction — pass
- privileged host install, 8-second launch, and purge — pass
- Stable Client redirect generator with both `.deb` and `tar.gz` — pass and selects `.deb`

## Risk / Rollback

The new binary baseline is Ubuntu 22.04 or newer. The portable archive remains available as a fallback. Rollback is limited to selecting the existing `tar.gz` format and removing the added `.deb` contract/build steps.

## Cross-platform impact

Linux release and update discovery only. macOS, Windows, Android, iOS, Web, and Agent artifact behavior is unchanged.

## Documentation

Updated release tooling, user installation/update guidance, release verification, update architecture, signing matrix, and the owning implementation plan.

## Publication boundary

This PR does not publish or replace any Release. The existing Production Linux convenience link remains on the immutable v1.0.1 `tar.gz` until a separately authorized future release deployment.
