### PR TITLE
feat(client): make onboarding local-first

### DIFF
--- a/client/lib/features/devices/presentation/screens/onboarding_setup_screen.dart
+++ b/client/lib/features/devices/presentation/screens/onboarding_setup_screen.dart
@@ -11,11 +11,13 @@ import 'package:sanad_client/features/devices/domain/models/gateway_connection_s
 import 'package:flutter/material.dart';
 import 'package:sanad_client/features/devices/presentation/widgets/installation_terminal_view.dart';
 import 'package:sanad_client/features/devices/presentation/widgets/gateway_connection_indicator.dart';
+import 'package:sanad_client/features/devices/presentation/widgets/onboarding_setup_choices.dart';
 import 'package:sanad_client/features/provider_setup/data/provider_setup_client.dart';
 import 'package:sanad_client/features/provider_setup/presentation/widgets/provider_setup_flow.dart';
 import 'package:sanad_client/core/di/injection.dart';
 import 'package:sanad_client/features/devices/data/device_connection_coordinator.dart';
 import 'package:sanad_client/features/devices/data/device_inventory_source.dart';
+import 'package:sanad_client/utils/app_platform.dart';
 import 'package:go_router/go_router.dart';
 
 class OnboardingSetupScreen extends StatefulWidget {
@@ -146,7 +148,7 @@ class _OnboardingSetupScreenState extends State<OnboardingSetupScreen> {
                       onComplete: _onInstallSuccess,
                       onFailure: _onInstallFailure,
                     )
-                  : _buildSelectionView(theme),
+                  : _buildSelectionView(),
             ),
           ),
         ),
@@ -154,109 +156,41 @@ class _OnboardingSetupScreenState extends State<OnboardingSetupScreen> {
     );
   }
 
-  Widget _buildSelectionView(ThemeData theme) {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        // Brand Header
-        Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Icon(
-              Icons.rocket_launch_outlined,
-              size: 44,
-              color: theme.colorScheme.primary,
-            ),
-            const SizedBox(width: 12),
-            Text(
-              'Sanad Agent',
-              style: TextStyle(
-                fontSize: 36,
-                fontWeight: FontWeight.bold,
-                letterSpacing: -1.0,
-                color: theme.colorScheme.onSurface,
-              ),
-            ),
-          ],
-        ),
-        const SizedBox(height: 12),
-        Text(
-          'The local agent is currently inactive. Please select your preferred setup mode to start.',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 16,
-            height: 1.5,
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
-          ),
-        ),
-        const SizedBox(height: 36),
-        const Align(
-          alignment: Alignment.center,
-          child: GatewayConnectionIndicator(),
-        ),
-        const SizedBox(height: 24),
+  Widget _buildSelectionView() {
+    return BlocBuilder<AuthCubit, AuthState>(
+      builder: (context, authState) {
+        return BlocBuilder<DeviceCubit, DeviceState>(
+          builder: (context, deviceState) {
+            final isAuthenticated = authState is AuthAuthenticated;
+            final hasRegisteredDevices = _registeredDevicesFromState(deviceState).isNotEmpty;
 
-        // Option A: Local offline mode
-        _buildOptionCard(
-          theme: theme,
-          icon: Icons.computer_outlined,
-          title: 'Run Locally (Offline Mode)',
-          description: 'Download the local agent and install it as a background service running on your machine.',
-          onTap: () {
-            setState(() {
-              _showTerminal = true;
-              _error = null;
-            });
-          },
-        ),
-        const SizedBox(height: 16),
-
-        BlocBuilder<AuthCubit, AuthState>(
-          builder: (context, authState) {
-            return BlocBuilder<DeviceCubit, DeviceState>(
-              builder: (context, deviceState) {
-                final isAuthenticated = authState is AuthAuthenticated;
-                final registeredDevices = _registeredDevicesFromState(deviceState);
-                final hasRegisteredDevices = registeredDevices.isNotEmpty;
-
-                return _buildOptionCard(
-                  theme: theme,
-                  icon: Icons.cloud_outlined,
-                  title: isAuthenticated
-                      ? (hasRegisteredDevices ? 'Use Existing Cloud Devices' : 'Add Remote Device')
-                      : 'Sign in to Connect Remote',
-                  description: isAuthenticated
-                      ? (hasRegisteredDevices
-                            ? 'Continue to your linked computers and servers through SanadGateway.'
-                            : 'Create a remote device record, then install Sanad Agent on that machine.')
-                      : 'Sign in first, then add or choose a remote computer or server.',
-                  onTap: () {
-                    if (!isAuthenticated) {
-                      unawaited(context.read<AuthCubit>().login());
-                      return;
-                    }
-                    if (hasRegisteredDevices) {
-                      context.go(AppRoutes.home);
-                    } else {
-                      unawaited(context.push(AppRoutes.addAgent));
-                    }
-                  },
-                );
+            return OnboardingSetupChoices(
+              isDesktop: AppPlatform.isDesktop,
+              isAuthenticated: isAuthenticated,
+              hasRegisteredDevices: hasRegisteredDevices,
+              connectionIndicator: AppPlatform.isDesktop ? const GatewayConnectionIndicator() : null,
+              error: _error,
+              onRunLocally: () {
+                setState(() {
+                  _showTerminal = true;
+                  _error = null;
+                });
+              },
+              onRemoteAction: () {
+                if (!isAuthenticated) {
+                  unawaited(context.read<AuthCubit>().login());
+                  return;
+                }
+                if (hasRegisteredDevices) {
+                  context.go(AppRoutes.home);
+                } else {
+                  unawaited(context.push(AppRoutes.addAgent));
+                }
               },
             );
           },
-        ),
-
-        if (_error != null) ...[
-          const SizedBox(height: 24),
-          Text(
-            _error!,
-            style: const TextStyle(color: Colors.redAccent, fontSize: 13),
-            textAlign: TextAlign.center,
-          ),
-        ],
-      ],
+        );
+      },
     );
   }
 
@@ -281,67 +215,5 @@ class _OnboardingSetupScreenState extends State<OnboardingSetupScreen> {
         ? state.agents
         : (state is DeviceNoActive ? state.agents : const <DeviceConfig>[]);
     return devices.where((device) => device.id != DeviceInventoryIds.localDevice).toList();
-  }
-
-  Widget _buildOptionCard({
-    required ThemeData theme,
-    required IconData icon,
-    required String title,
-    required String description,
-    required VoidCallback onTap,
-  }) {
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        onTap: onTap,
-        borderRadius: BorderRadius.circular(16),
-        child: Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.1),
-            ),
-            borderRadius: BorderRadius.circular(16),
-            color: theme.colorScheme.onSurface.withValues(alpha: 0.02),
-          ),
-          child: Row(
-            children: [
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.primary.withValues(alpha: 0.1),
-                  shape: BoxShape.circle,
-                ),
-                child: Icon(icon, color: theme.colorScheme.primary, size: 28),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                      title,
-                      style: const TextStyle(
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    const SizedBox(height: 6),
-                    Text(
-                      description,
-                      style: TextStyle(
-                        fontSize: 13,
-                        color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-                        height: 1.4,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
   }
 }

--- a/client/lib/features/devices/presentation/widgets/onboarding_setup_choices.dart
+++ b/client/lib/features/devices/presentation/widgets/onboarding_setup_choices.dart
@@ -1,0 +1,277 @@
+import 'package:flutter/material.dart';
+
+class OnboardingSetupChoices extends StatelessWidget {
+  const OnboardingSetupChoices({
+    required this.isDesktop,
+    required this.isAuthenticated,
+    required this.hasRegisteredDevices,
+    required this.onRunLocally,
+    required this.onRemoteAction,
+    this.connectionIndicator,
+    this.error,
+    super.key,
+  });
+
+  final bool isDesktop;
+  final bool isAuthenticated;
+  final bool hasRegisteredDevices;
+  final VoidCallback onRunLocally;
+  final VoidCallback onRemoteAction;
+  final Widget? connectionIndicator;
+  final String? error;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _BrandHeader(theme: theme),
+        const SizedBox(height: 24),
+        if (isDesktop)
+          _DesktopChoices(
+            theme: theme,
+            isAuthenticated: isAuthenticated,
+            hasRegisteredDevices: hasRegisteredDevices,
+            onRunLocally: onRunLocally,
+            onRemoteAction: onRemoteAction,
+            connectionIndicator: connectionIndicator,
+          )
+        else
+          _RemoteOnlyEmptyState(
+            theme: theme,
+            isAuthenticated: isAuthenticated,
+            onRemoteAction: onRemoteAction,
+          ),
+        if (error != null) ...[
+          const SizedBox(height: 24),
+          Text(
+            error!,
+            style: const TextStyle(color: Colors.redAccent, fontSize: 13),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _BrandHeader extends StatelessWidget {
+  const _BrandHeader({required this.theme});
+
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Icon(
+          Icons.rocket_launch_outlined,
+          size: 44,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(width: 12),
+        Text(
+          'Sanad Agent',
+          style: TextStyle(
+            fontSize: 36,
+            fontWeight: FontWeight.bold,
+            letterSpacing: -1,
+            color: theme.colorScheme.onSurface,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DesktopChoices extends StatelessWidget {
+  const _DesktopChoices({
+    required this.theme,
+    required this.isAuthenticated,
+    required this.hasRegisteredDevices,
+    required this.onRunLocally,
+    required this.onRemoteAction,
+    required this.connectionIndicator,
+  });
+
+  final ThemeData theme;
+  final bool isAuthenticated;
+  final bool hasRegisteredDevices;
+  final VoidCallback onRunLocally;
+  final VoidCallback onRemoteAction;
+  final Widget? connectionIndicator;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Text(
+          'Set up Sanad Agent on this computer. No account is required.',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 16,
+            height: 1.5,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+        if (connectionIndicator != null) ...[
+          const SizedBox(height: 28),
+          Align(alignment: Alignment.center, child: connectionIndicator),
+        ],
+        const SizedBox(height: 24),
+        Material(
+          color: Colors.transparent,
+          child: InkWell(
+            key: const Key('onboarding_run_locally'),
+            onTap: onRunLocally,
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                border: Border.all(
+                  color: theme.colorScheme.primary.withValues(alpha: 0.45),
+                ),
+                borderRadius: BorderRadius.circular(16),
+                color: theme.colorScheme.primary.withValues(alpha: 0.08),
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: theme.colorScheme.primary.withValues(alpha: 0.14),
+                      shape: BoxShape.circle,
+                    ),
+                    child: Icon(
+                      Icons.computer_outlined,
+                      color: theme.colorScheme.primary,
+                      size: 28,
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  const Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Run Sanad Locally',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        SizedBox(height: 6),
+                        Text(
+                          'Install Sanad Agent as a background service on this computer.',
+                          style: TextStyle(fontSize: 13, height: 1.4),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Icon(
+                    Icons.arrow_forward_rounded,
+                    color: theme.colorScheme.primary,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(height: 18),
+        Text(
+          'or',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 13,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.45),
+          ),
+        ),
+        const SizedBox(height: 4),
+        Align(
+          alignment: Alignment.center,
+          child: TextButton(
+            key: const Key('onboarding_remote_action'),
+            onPressed: onRemoteAction,
+            style: TextButton.styleFrom(
+              foregroundColor: theme.colorScheme.onSurface.withValues(alpha: 0.72),
+              textStyle: const TextStyle(
+                fontSize: 14,
+                decoration: TextDecoration.underline,
+              ),
+            ),
+            child: Text(_remoteActionLabel()),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _remoteActionLabel() {
+    if (!isAuthenticated) return 'Sign in to connect a remote device';
+    if (hasRegisteredDevices) return 'Continue with connected devices';
+    return 'Add a remote device';
+  }
+}
+
+class _RemoteOnlyEmptyState extends StatelessWidget {
+  const _RemoteOnlyEmptyState({
+    required this.theme,
+    required this.isAuthenticated,
+    required this.onRemoteAction,
+  });
+
+  final ThemeData theme;
+  final bool isAuthenticated;
+  final VoidCallback onRemoteAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Icon(
+          Icons.devices_outlined,
+          size: 52,
+          color: theme.colorScheme.primary,
+        ),
+        const SizedBox(height: 18),
+        Text(
+          isAuthenticated ? 'No devices connected' : 'Connect to Sanad Agent',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 22,
+            fontWeight: FontWeight.w600,
+            color: theme.colorScheme.onSurface,
+          ),
+        ),
+        const SizedBox(height: 10),
+        Text(
+          isAuthenticated
+              ? 'Install Sanad Agent on a computer or server to access it from this device.'
+              : 'Sign in to access Sanad Agent on your computers and servers.',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 15,
+            height: 1.5,
+            color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
+          ),
+        ),
+        const SizedBox(height: 28),
+        FilledButton.icon(
+          key: const Key('onboarding_remote_action'),
+          onPressed: onRemoteAction,
+          icon: Icon(isAuthenticated ? Icons.add_rounded : Icons.login_rounded),
+          label: Text(isAuthenticated ? 'Add a Remote Device' : 'Sign In'),
+          style: FilledButton.styleFrom(
+            padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/client/test/widget/onboarding_setup_choices_test.dart
+++ b/client/test/widget/onboarding_setup_choices_test.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/devices/presentation/widgets/onboarding_setup_choices.dart';
+
+void main() {
+  Widget buildSubject({
+    required bool isDesktop,
+    required bool isAuthenticated,
+    bool hasRegisteredDevices = false,
+    VoidCallback? onRunLocally,
+    VoidCallback? onRemoteAction,
+  }) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: SizedBox(
+            width: 650,
+            child: OnboardingSetupChoices(
+              isDesktop: isDesktop,
+              isAuthenticated: isAuthenticated,
+              hasRegisteredDevices: hasRegisteredDevices,
+              onRunLocally: onRunLocally ?? () {},
+              onRemoteAction: onRemoteAction ?? () {},
+              connectionIndicator: isDesktop ? const Text('Connection status') : null,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('desktop makes local setup primary and remote setup secondary', (
+    tester,
+  ) async {
+    var localTaps = 0;
+    var remoteTaps = 0;
+
+    await tester.pumpWidget(
+      buildSubject(
+        isDesktop: true,
+        isAuthenticated: false,
+        onRunLocally: () => localTaps++,
+        onRemoteAction: () => remoteTaps++,
+      ),
+    );
+
+    expect(find.text('Run Sanad Locally'), findsOneWidget);
+    expect(find.byKey(const Key('onboarding_run_locally')), findsOneWidget);
+    expect(
+      find.text('Sign in to connect a remote device'),
+      findsOneWidget,
+    );
+    expect(
+      tester.widget<TextButton>(
+        find.byKey(const Key('onboarding_remote_action')),
+      ),
+      isA<TextButton>(),
+    );
+
+    await tester.tap(find.byKey(const Key('onboarding_run_locally')));
+    await tester.tap(find.byKey(const Key('onboarding_remote_action')));
+
+    expect(localTaps, 1);
+    expect(remoteTaps, 1);
+  });
+
+  testWidgets('non-desktop authenticated empty state only offers remote setup', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildSubject(isDesktop: false, isAuthenticated: true),
+    );
+
+    expect(find.text('No devices connected'), findsOneWidget);
+    expect(find.text('Add a Remote Device'), findsOneWidget);
+    expect(find.text('Run Sanad Locally'), findsNothing);
+    expect(find.byKey(const Key('onboarding_run_locally')), findsNothing);
+    expect(
+      tester.widget<FilledButton>(
+        find.byKey(const Key('onboarding_remote_action')),
+      ),
+      isA<FilledButton>(),
+    );
+  });
+}

--- a/docs/plans/tasks/local_first_onboarding_hierarchy.md
+++ b/docs/plans/tasks/local_first_onboarding_hierarchy.md
@@ -1,0 +1,31 @@
+# Local-First Onboarding Hierarchy
+
+## Goal
+
+Make desktop onboarding visibly local-first without presenting an unsupported local-agent action on mobile or web.
+
+## UX Contract
+
+- Desktop presents local installation as the primary large action and remote-device connection as a secondary underlined action.
+- Mobile and web never present local installation. An authenticated user with no devices receives a focused empty state whose primary action adds a remote device.
+- Unauthenticated non-desktop users remain routed to sign-in.
+- Remote action labels continue to reflect authentication and registered-device state.
+
+## Implementation
+
+1. Extract the onboarding choice presentation into a platform-aware widget.
+2. Preserve the existing local installation, authentication, existing-device, and add-device callbacks.
+3. Update the product interface documentation.
+4. Add widget coverage for desktop hierarchy and the non-desktop empty state.
+
+## Definition of Done
+
+- Desktop local setup is the only card-style primary choice.
+- Desktop remote setup is rendered as an underlined secondary action.
+- Non-desktop onboarding contains no local setup control and offers `Add a Remote Device` when authenticated without devices.
+- Focused widget tests and `fvm flutter analyze` pass.
+
+## Verification
+
+- [x] `fvm flutter test test/widget/onboarding_setup_choices_test.dart`
+- [x] `fvm flutter analyze`

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -28,6 +28,13 @@ new conversation.
 The compact Home gateway/status bar is a native-desktop surface. Web and mobile
 never render it, regardless of browser or viewport width.
 
+Desktop onboarding is local-first: installing the agent on the current computer
+is the primary card action, while signing in or connecting a remote device is a
+secondary text action. Mobile and web never offer local installation. When an
+authenticated mobile or web user has no registered devices, onboarding presents
+a `No devices connected` empty state with `Add a Remote Device` as its primary
+action.
+
 When an empty device inventory is still being requested, the sidebar identifies
 that request as loading rather than claiming that no devices exist. If the
 request settles successfully, times out, or fails without returning a device,


### PR DESCRIPTION
## Problem / Goal

Desktop onboarding currently gives local installation and cloud connection equal visual weight, while mobile and web can surface an unsupported local-install choice when an authenticated account has no devices.

## Changes

- make local installation the primary desktop onboarding card
- render remote connection as an underlined secondary desktop action
- remove the misleading `Offline Mode` wording
- show a remote-only `No devices connected` empty state on mobile and web
- preserve authentication, existing-device, add-device, and local-install callbacks
- extract the platform-aware choice presentation into a focused widget
- document the UX contract and implementation plan

## Verification

- `fvm flutter test test/widget/onboarding_setup_choices_test.dart`
- `fvm flutter analyze`
- manual Linux review with a separately launched client using disabled cloud access and an unreachable local gateway

## Risk / Cross-platform impact

Low, presentation-focused risk. Desktop action hierarchy changes intentionally. Mobile and web no longer expose local installation. Existing routing and connection ownership are unchanged.

## Documentation

- `docs/product/client_interface.md`
- `docs/plans/tasks/local_first_onboarding_hierarchy.md`

## Rollback

Revert this pull request to restore the two equal desktop option cards and previous shared onboarding presentation.
