### PR TITLE
security(release): restrict production deployment credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,28 +245,27 @@ jobs:
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/appcast.xml' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/release-manifest.json' .github/workflows/deploy.yml
-          test "$(grep -Fc 'sanad-sites-control refresh-static production' .github/workflows/deploy.yml)" -eq 6
+          test "$(grep -Fc 'scripts/release/deploy_production_asset.sh' .github/workflows/deploy.yml)" -ge 12
+          ! grep -Eq '(^|[[:space:]])rsync[[:space:]]|ln -sfn|sudo /usr/local/sbin|/opt/sanad-sites/' .github/workflows/deploy.yml
           grep -F 'name: Activate, verify, and roll back updates on failure' .github/workflows/deploy.yml
           grep -F 'https://updates.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
-          test "$(grep -Fc 'cp -a' .github/workflows/deploy.yml)" -eq 2
-          test "$(grep -Fc 'incoming/index.html' .github/workflows/deploy.yml)" -eq 3
-          test "$(grep -Fc 'incoming/favicon.svg' .github/workflows/deploy.yml)" -eq 2
           grep -F 'name: Activate, verify, and roll back installer sources on failure' .github/workflows/deploy.yml
           grep -F 'https://downloads.sanad.eaststarai.com/$name' .github/workflows/deploy.yml
           grep -F 'restoring the previous selector' .github/workflows/deploy.yml
           test "$(grep -Fc 'environment: client-downloads-production' .github/workflows/deploy.yml)" -eq 3
           ! grep -Eq 'environment: (web|updates|installers)-production' .github/workflows/deploy.yml
           grep -F 'environment: client-downloads-production' .github/workflows/release.yml
-          grep -F 'sanad-client-downloads-control deploy' .github/workflows/release.yml
+          grep -F 'deploy_production_asset.sh deploy-client-aliases' .github/workflows/release.yml
+          ! grep -Fq 'sudo /usr/local/sbin/sanad-client-downloads-control' .github/workflows/release.yml
           grep -F 'name: Deploy Stable Production assets' .github/workflows/release.yml
           grep -F 'uses: ./.github/workflows/deploy.yml' .github/workflows/release.yml
           grep -F 'release_run_id:' .github/workflows/release.yml
           grep -F 'github.run_id' .github/workflows/release.yml
-          ! grep -Fq '/srv/sanad/' .github/workflows/deploy.yml
-          grep -Fq '/opt/sanad-sites/assets/web' .github/workflows/deploy.yml
-          grep -Fq '/opt/sanad-sites/assets/updates' .github/workflows/deploy.yml
-          grep -Fq '/opt/sanad-sites/assets/install' .github/workflows/deploy.yml
+          bash -n scripts/release/deploy_production_asset.sh
+          grep -Fq 'broker "upload $kind' scripts/release/deploy_production_asset.sh
+          grep -Fq 'upload-client-aliases' scripts/release/deploy_production_asset.sh
           scripts/release/test_generate_client_download_redirects.sh
+          scripts/release/test_deploy_production_asset.sh
           grep -F -- '--draft' .github/workflows/release.yml
           grep -F 'release-manifest-rc.json' release/release-contract.json
           grep -F 'appcast-rc.xml' release/release-contract.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,28 +102,17 @@ jobs:
           find web -type d -exec chmod 755 {} +
           find web -type f -exec chmod 644 {} +
           test -z "$(find web -type f ! -perm -004 -print -quit)"
-      - name: Publish immutable Production Web release
+      - id: publish_asset
+        name: Publish immutable Production Web release
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
           DEPLOY_USER: ${{ secrets.DEPLOY_SSH_USER }}
-          RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          tag="$RELEASE_TAG"
           expected_sha="$(git rev-parse HEAD)"
-          incoming="/opt/sanad-sites/assets/web/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          release="/opt/sanad-sites/assets/web/releases/$tag"
-          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'"; then
-            echo "Reusing the existing immutable Production Web release $release."
-            exit 0
-          fi
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming' /opt/sanad-sites/assets/web/releases"
-          rsync -az --delete --delay-updates web/ \
-            "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; find '$incoming' -type d -exec chmod 755 {} +; find '$incoming' -type f -exec chmod 644 {} +; test -z \"\$(find '$incoming' -type f ! -perm -004 -print -quit)\"; test -s '$incoming/index.html'; grep -Fq flutter_bootstrap.js '$incoming/index.html'; test \"\$(cat '$incoming/sanad-public-sha.txt')\" = '$expected_sha'; test ! -e '$release'; mv '$incoming' '$release'"
+          digest="$(scripts/release/deploy_production_asset.sh \
+            publish static-web "$expected_sha" web)"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
       - name: Activate, verify, and roll back Production Web on failure
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_SSH_HOST }}
@@ -131,16 +120,11 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
-          release="/opt/sanad-sites/assets/web/releases/$RELEASE_TAG"
-          selector=/opt/sanad-sites/assets/web/current
           expected_sha="$(git rev-parse HEAD)"
-          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
-          test -n "$previous"
-          previous_index_sha="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; sha256sum '$previous/index.html' | cut -d ' ' -f 1")"
-          test -n "$previous_index_sha"
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/index.html'; test \"\$(cat '$release/sanad-public-sha.txt')\" = '$expected_sha'; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production web"
+          read -r previous_identity previous_digest \
+            <<<"$(scripts/release/deploy_production_asset.sh previous static-web)"
+          scripts/release/deploy_production_asset.sh activate static-web \
+            "$expected_sha" "${{ steps.publish_asset.outputs.digest }}"
 
           verify_web() {
             body="$(mktemp)"
@@ -167,20 +151,16 @@ jobs:
           done
           if [[ "$activated" != true ]]; then
             echo "Production Web verification failed; restoring the previous selector."
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test -s '$previous/index.html'; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production web"
+            scripts/release/deploy_production_asset.sh rollback static-web \
+              "$previous_identity" "$previous_digest"
             rollback_verified=false
             for attempt in $(seq 1 12); do
-              rolled_back_index="$(mktemp)"
-              if curl --fail --silent --show-error --location --max-time 20 \
-                --output "$rolled_back_index" \
-                "https://app.sanad.eaststarai.com/?rollback=$previous_index_sha" && \
-                [[ "$(sha256sum "$rolled_back_index" | cut -d ' ' -f 1)" == "$previous_index_sha" ]]; then
+              served_previous="$(curl --fail --silent --show-error --max-time 20 \
+                "https://app.sanad.eaststarai.com/sanad-public-sha.txt?rollback=$previous_identity" || true)"
+              if [[ "$served_previous" == "$previous_identity" ]]; then
                 rollback_verified=true
-                rm -f "$rolled_back_index"
                 break
               fi
-              rm -f "$rolled_back_index"
               sleep 5
             done
             if [[ "$rollback_verified" != true ]]; then
@@ -227,30 +207,16 @@ jobs:
         run: |
           set -euo pipefail
           tag="${{ inputs.release_tag }}"
-          root=/opt/sanad-sites/assets/updates
-          release="$root/releases/$tag"
-          selector="$root/current"
-          incoming="$root/incoming-$tag-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          revision="$(git rev-parse HEAD)"
           expected_appcast="$(sha256sum download/appcast.xml | awk '{print $1}')"
           expected_manifest="$(sha256sum download/release-manifest.json | awk '{print $1}')"
-          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
-          previous_appcast="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; sha256sum '$previous/appcast.xml' | awk '{print \$1}'")"
-          previous_manifest="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; sha256sum '$previous/release-manifest.json' | awk '{print \$1}'")"
-          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/index.html'; test -s '$release/favicon.svg'; test \"\$(sha256sum '$release/appcast.xml' | awk '{print \$1}')\" = '$expected_appcast'; test \"\$(sha256sum '$release/release-manifest.json' | awk '{print \$1}')\" = '$expected_manifest'"; then
-            echo "Reusing the existing complete immutable updates release $release."
-          else
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming'; cp -a '$previous/.' '$incoming/'"
-            rsync -az download/appcast.xml download/release-manifest.json \
-              "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test -s '$incoming/index.html'; test -s '$incoming/favicon.svg'; test \"\$(sha256sum '$incoming/appcast.xml' | awk '{print \$1}')\" = '$expected_appcast'; test \"\$(sha256sum '$incoming/release-manifest.json' | awk '{print \$1}')\" = '$expected_manifest'; mv '$incoming' '$release'"
-          fi
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
+          read -r previous_identity previous_digest \
+            <<<"$(scripts/release/deploy_production_asset.sh previous static-updates)"
+          previous_appcast="$(scripts/release/deploy_production_asset.sh hash static-updates appcast.xml)"
+          previous_manifest="$(scripts/release/deploy_production_asset.sh hash static-updates release-manifest.json)"
+          digest="$(scripts/release/deploy_production_asset.sh \
+            publish static-updates "$revision" download)"
+          scripts/release/deploy_production_asset.sh activate static-updates "$revision" "$digest"
 
           verify_update() {
             local name="$1" expected="$2" output="$3" marker="$4"
@@ -264,8 +230,8 @@ jobs:
           if ! verify_update appcast.xml "$expected_appcast" "$temporary/appcast.xml" "release=$tag" || \
             ! verify_update release-manifest.json "$expected_manifest" "$temporary/release-manifest.json" "release=$tag"; then
             echo "Updates verification failed; restoring the previous selector."
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production updates"
+            scripts/release/deploy_production_asset.sh rollback static-updates \
+              "$previous_identity" "$previous_digest"
             verify_update appcast.xml "$previous_appcast" "$temporary/rollback-appcast.xml" "rollback=$previous_appcast"
             verify_update release-manifest.json "$previous_manifest" "$temporary/rollback-manifest.json" "rollback=$previous_manifest"
             exit 1
@@ -295,30 +261,15 @@ jobs:
         run: |
           set -euo pipefail
           revision="$(git rev-parse HEAD)"
-          root=/opt/sanad-sites/assets/install
-          release="$root/releases/$revision"
-          selector="$root/current"
-          incoming="$root/incoming-$revision-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
           expected_sh="$(sha256sum scripts/install.sh | awk '{print $1}')"
           expected_ps1="$(sha256sum scripts/install.ps1 | awk '{print $1}')"
-          previous="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" "set -eu; readlink -f '$selector'")"
-          previous_sh="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; sha256sum '$previous/install.sh' | awk '{print \$1}'")"
-          previous_ps1="$(ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; sha256sum '$previous/install.ps1' | awk '{print \$1}'")"
-          if ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; test -s '$release/index.html'; test -s '$release/favicon.svg'; test \"\$(sha256sum '$release/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$release/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'"; then
-            echo "Reusing the existing complete immutable installer release $release."
-          else
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test ! -e '$incoming'; test ! -e '$release'; mkdir -p '$incoming'; cp -a '$previous/.' '$incoming/'"
-            rsync -az scripts/install.sh scripts/install.ps1 \
-              "$DEPLOY_USER@$DEPLOY_HOST:$incoming/"
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; test -s '$incoming/index.html'; test -s '$incoming/favicon.svg'; test \"\$(sha256sum '$incoming/install.sh' | awk '{print \$1}')\" = '$expected_sh'; test \"\$(sha256sum '$incoming/install.ps1' | awk '{print \$1}')\" = '$expected_ps1'; mv '$incoming' '$release'"
-          fi
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "set -eu; ln -sfn '$release' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production downloads"
+          read -r previous_identity previous_digest \
+            <<<"$(scripts/release/deploy_production_asset.sh previous static-downloads)"
+          previous_sh="$(scripts/release/deploy_production_asset.sh hash static-downloads install.sh)"
+          previous_ps1="$(scripts/release/deploy_production_asset.sh hash static-downloads install.ps1)"
+          digest="$(scripts/release/deploy_production_asset.sh \
+            publish static-downloads "$revision" scripts)"
+          scripts/release/deploy_production_asset.sh activate static-downloads "$revision" "$digest"
 
           verify_installer() {
             local name="$1" expected="$2" output="$3" marker="$4"
@@ -332,8 +283,8 @@ jobs:
           if ! verify_installer install.sh "$expected_sh" "$temporary/install.sh" "release=$revision" || \
             ! verify_installer install.ps1 "$expected_ps1" "$temporary/install.ps1" "release=$revision"; then
             echo "Installer verification failed; restoring the previous selector."
-            ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-              "set -eu; ln -sfn '$previous' '$selector'; sudo /usr/local/sbin/sanad-sites-control refresh-static production downloads"
+            scripts/release/deploy_production_asset.sh rollback static-downloads \
+              "$previous_identity" "$previous_digest"
             verify_installer install.sh "$previous_sh" "$temporary/rollback.sh" "rollback=$previous_sh"
             verify_installer install.ps1 "$previous_ps1" "$temporary/rollback.ps1" "rollback=$previous_ps1"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -750,9 +750,8 @@ jobs:
         run: |
           set -euo pipefail
           manifest_sha="$(sha256sum download/release-manifest.json | awk '{print $1}')"
-          ssh "$DEPLOY_USER@$DEPLOY_HOST" \
-            "sudo /usr/local/sbin/sanad-client-downloads-control deploy '$RELEASE_TAG' '$manifest_sha'" \
-            < generated/sanad-client-download-redirects.conf
+          scripts/release/deploy_production_asset.sh deploy-client-aliases \
+            "$RELEASE_TAG" "$manifest_sha" generated/sanad-client-download-redirects.conf
 
   production-assets:
     name: Deploy Stable Production assets

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -118,31 +118,36 @@ It requires an exact public `main` commit, inventories existing `v1` tags and
 Releases before the gate, has no write permission, and never creates a candidate.
 Probe approval is not Release publication approval.
 
-The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. After an approved Stable publication, the protected Client-download job downloads the public manifest, checksum file, and three desktop Client artifacts; verifies canonical URLs, byte sizes, SHA-256 values, and GitHub attestations; generates a deterministic Nginx redirect include; and sends only that include to the server's restricted control command. The Stable release then calls the reusable Production asset workflow with Web, Appcast, and installers enabled and its own release run ID. This ordering serializes the redirect deployment before the remaining Production assets and prevents an asset handoff when publication or redirect verification fails. RC and validation-only runs never enter either Production path. The server remains a redirector rather than an artifact mirror and owns candidate validation, atomic activation, public regression verification, and automatic rollback.
+The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. After an approved Stable publication, the protected Client-download job downloads the public manifest, checksum file, and three desktop Client artifacts; verifies canonical URLs, byte sizes, SHA-256 values, and GitHub attestations; generates a deterministic Nginx redirect include; and uploads only that bounded include through the Production forced-command deployment broker. The broker verifies the exact byte count and digest, and the root-owned controller invokes the fixed alias validator with the verified payload. The Stable release then calls the reusable Production asset workflow with Web, Appcast, and installers enabled and its own release run ID. This ordering serializes the redirect deployment before the remaining Production assets and prevents an asset handoff when publication or redirect verification fails. RC and validation-only runs never enter either Production path. The server remains a redirector rather than an artifact mirror and owns candidate validation, atomic activation, public regression verification, and automatic rollback.
 
 A manual `Deploy prepared release assets` dispatch is recovery-only. It must identify an existing immutable Stable tag and its successful producing release run. Because a default-branch dispatch has `main` as its deployment ref, the `client-downloads-production` Environment must explicitly allow the reviewed `main` recovery ref before credentials are available; normal automatic deployment remains tag-restricted. Changing that policy is a repository-setting mutation and is not implied by a workflow edit.
 
-Production Web, Appcast, and installer releases use `/opt/sanad-sites/assets/web`, `/opt/sanad-sites/assets/updates`, and `/opt/sanad-sites/assets/install`; the obsolete `/srv/sanad/*` workflow roots are not valid deployment targets. The private Web handoff
-is downloaded from the explicitly selected successful release-workflow run and
-verified against its GitHub build attestation. Server deployment writes an
-immutable versioned directory, changes the owning `current` symlink only after
-the transfer succeeds, and invokes the private host-owned
-`sanad-sites-control refresh-static production` action for exactly the affected
-Web, updates, or downloads container. This refresh is required because Docker
-bind mounts resolve the selected directory when the container is created; a
-symlink change alone does not update a running container.
+The public workflow never names, creates, reads, or selects a live-host release
+directory. The private Web handoff is downloaded from the explicitly selected
+successful release-workflow run and verified against its GitHub build
+attestation. It is packaged with its exact public commit identity and sent to
+the Production forced-command broker. The root-owned controller safely extracts
+the bounded archive, rejects links, traversal, secret-shaped paths, unexpected
+static-overlay files, changed manifests, or non-root-writable promoted content,
+and creates the immutable release and selector. Activation recreates exactly
+the affected Web, updates, or downloads container because Docker bind mounts
+resolve the selected directory when the container is created; selector change
+alone does not update a running container.
 
 The Web handoff records its exact public commit and validates the Flutter shell,
 bootstrap, favicon, version marker, and hosted readability. Updates releases
 publish both attested Stable Appcast and manifest files; installer releases
-publish both canonical source files. Each updates or downloads candidate first
-copies the preceding selected static root into a unique incoming directory so
-server-owned `index.html` and `favicon.svg` remain present, replaces only the
-release-owned files, validates the complete root, and atomically publishes it.
-Any public mismatch restores the preceding selector, refreshes only the affected
-static container, and verifies all prior release-owned bytes. Rollback never
-rebuilds or mutates a published release, and the public workflow receives
-neither Docker access nor general host authority.
+publish both canonical source files. For each updates or downloads candidate,
+the root-owned controller first reverifies and copies the preceding immutable
+static release so `index.html` and `favicon.svg` remain present, then overlays
+exactly the two allowlisted release-owned files. The workflow cannot request any
+other overlay path. The controller manifests and reverifies the complete
+candidate before atomic publication. Any public mismatch restores the preceding
+selector, refreshes only the affected static container, and verifies all prior
+release-owned bytes against hashes read through a filename allowlist. Rollback
+never rebuilds or mutates a published release, and the public workflow receives
+neither Docker access, filesystem traversal, an interactive shell, nor general
+host authority.
 
 Web assets use content-hashed Flutter output plus a small no-cache
 `version.json`. The server must route unknown application paths to

--- a/docs/plans/tasks/stable-production-release-deployment.md
+++ b/docs/plans/tasks/stable-production-release-deployment.md
@@ -118,3 +118,28 @@ version `1.0.1`, build `2`, and public commit
 clean-browser rendering, and Production/Development/Staging regressions passed.
 Future Stable publication invokes the same reusable workflow automatically with
 all three surfaces enabled.
+
+## Deployment credential privilege-boundary follow-up
+
+The original bounded command still allowed the deployment account to write live
+release trees and exposed wildcard root entrypoints. The release handoff now
+uses only a forced-command broker protocol: bounded uploads enter an untrusted
+incoming namespace, while a root-owned controller validates, manifests,
+promotes, selects, refreshes, and rolls back immutable releases. Static overlay
+archives contain exactly the two owned Appcast/manifest or installer files; the
+controller inherits the remaining shell from the preceding verified release.
+Stable Client aliases use the same bounded upload protocol.
+
+### Follow-up Definition of Done
+
+- [x] Public workflows contain no direct live path, remote `rsync`, selector
+      mutation, Docker command, or `sudo` command.
+- [x] Production Web, updates, installers, and Client aliases use the common
+      forced-command deployment protocol.
+- [x] Rollback captures the previous immutable identity and digest and reads
+      comparison hashes only for an exact static filename allowlist.
+- [x] Release architecture and QA contracts describe the root-owned promotion
+      boundary and two-file overlay contract.
+- [x] Focused workflow and YAML validation pass on the final branch.
+- [ ] The public PR is merged before the private repository pins the resulting
+      public commit and performs the live credential cutover.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -98,7 +98,7 @@ approval for RC1 or any later publication.
 
 ## Stable Client convenience-link gate
 
-Only an approved, published Stable Release may update the Production convenience links. The post-publication job must reject Drafts, prereleases, non-canonical repositories or URLs, missing or duplicate desktop Client entries, Agent artifacts, and any size, SHA-256, checksum-file, or attestation mismatch. Its generated include contains exactly macOS, Windows, and Linux redirects and is retained as workflow evidence. The restricted server command must pass a loopback candidate before atomic activation, verify Production plus Development and Staging regressions, and restore the preceding include on any reload or verification failure. Development and Staging never expose equivalent aliases, and Client bytes continue to download directly from GitHub Releases.
+Only an approved, published Stable Release may update the Production convenience links. The post-publication job must reject Drafts, prereleases, non-canonical repositories or URLs, missing or duplicate desktop Client entries, Agent artifacts, and any size, SHA-256, checksum-file, or attestation mismatch. Its generated include contains exactly macOS, Windows, and Linux redirects and is retained as workflow evidence. The Production forced-command broker accepts that file only with an exact bounded length and SHA-256, and the root-owned restricted server command must pass a loopback candidate before atomic activation, verify Production plus Development and Staging regressions, and restore the preceding include on any reload or verification failure. Development and Staging never expose equivalent aliases, and Client bytes continue to download directly from GitHub Releases.
 
 ## Stable Production asset handoff gate
 
@@ -114,11 +114,14 @@ Static verification rejects separate `web-production`, `updates-production`, or
 provisioned and protected in a separate reviewed change. Manual recovery from
 `main` remains blocked by the Environment branch policy until an operator
 explicitly authorizes that ref; tag-restricted automatic releases require no
-such exception. Each selector activation and rollback must invoke the bounded
-Production static refresh for exactly one service. Updates and downloads
-candidates must inherit the preceding static shell, contain `index.html` and
-`favicon.svg`, and replace only their release-owned files before atomic
-publication. Runtime acceptance requires the exact public Web commit and version
+such exception. Each selector activation and rollback must pass through the
+forced-command broker and root-owned controller, which refresh exactly one
+Production static service. The workflow must contain no direct remote `rsync`,
+selector mutation, live-host path, Docker command, or `sudo` command. Updates
+and downloads candidates must inherit the preceding verified static shell
+inside the trusted controller, contain `index.html` and `favicon.svg`, and
+accept only their exact two-file overlay allowlist before atomic publication.
+Runtime acceptance requires the exact public Web commit and version
 markers, the public Appcast and Stable manifest SHA-256 values, both public
 installer-source SHA-256 values, and a clean browser render. A stale bind mount,
 incomplete static root, selector-only success, or HTTP-only shell response fails

--- a/scripts/release/deploy_production_asset.sh
+++ b/scripts/release/deploy_production_asset.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ACTION="${1:-}"
+test -n "${DEPLOY_HOST:-}" && test -n "${DEPLOY_USER:-}" || {
+  echo "DEPLOY_HOST and DEPLOY_USER are required." >&2
+  exit 64
+}
+
+sha256_file() { sha256sum "$1" | awk '{print $1}'; }
+file_size() {
+  if stat -c '%s' "$1" >/dev/null 2>&1; then stat -c '%s' "$1"; else stat -f '%z' "$1"; fi
+}
+broker() { ssh "$DEPLOY_USER@$DEPLOY_HOST" "$@"; }
+
+create_archive() {
+  local source="$1" archive="$2"
+  shift 2
+  local -a tar_command=(tar)
+  if tar --version 2>/dev/null | grep -Fq 'GNU tar'; then
+    tar_command+=(--sort=name --mtime=@0 --owner=0 --group=0 --numeric-owner)
+  fi
+  COPYFILE_DISABLE=1 "${tar_command[@]}" -C "$source" -czf "$archive" "$@"
+}
+
+valid_kind() {
+  case "$1" in static-web|static-updates|static-downloads) return 0 ;; *) return 1 ;; esac
+}
+
+publish() {
+  local kind="$1" identity="$2" source="$3" archive digest bytes
+  valid_kind "$kind" && [[ "$identity" =~ ^[0-9a-f]{40}$ ]] || exit 64
+  source="$(realpath "$source")"
+  test -d "$source" || exit 66
+  archive="$(mktemp "${RUNNER_TEMP:-/tmp}/sanad-production-asset.XXXXXX")"
+  cleanup() { rm -f "$archive"; }
+  trap cleanup EXIT HUP INT TERM
+  case "$kind" in
+    static-web)
+      test -s "$source/index.html" && test -s "$source/flutter_bootstrap.js" && \
+        test -s "$source/favicon.svg" && test "$(tr -d '\r\n' < "$source/sanad-public-sha.txt")" = "$identity"
+      create_archive "$source" "$archive" .
+      ;;
+    static-updates)
+      test -s "$source/appcast.xml" && test -s "$source/release-manifest.json"
+      create_archive "$source" "$archive" appcast.xml release-manifest.json
+      ;;
+    static-downloads)
+      test -s "$source/install.sh" && test -s "$source/install.ps1"
+      create_archive "$source" "$archive" install.sh install.ps1
+      ;;
+  esac
+  digest="$(sha256_file "$archive")"
+  bytes="$(file_size "$archive")"
+  broker "upload $kind $identity $digest $bytes" < "$archive" >&2
+  broker "install $kind $identity $digest" >&2
+  rm -f "$archive"
+  trap - EXIT HUP INT TERM
+  printf '%s\n' "$digest"
+}
+
+deploy_aliases() {
+  local tag="$1" manifest_digest="$2" config="$3" payload_digest bytes
+  [[ "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && "$manifest_digest" =~ ^[0-9a-f]{64}$ ]] || exit 64
+  test -s "$config" || exit 66
+  payload_digest="$(sha256_file "$config")"
+  bytes="$(file_size "$config")"
+  broker "upload-client-aliases $tag $manifest_digest $payload_digest $bytes" < "$config" >&2
+  broker "deploy-client-aliases $tag $manifest_digest $payload_digest"
+}
+
+case "$ACTION" in
+  publish)
+    test "$#" -eq 4 || exit 64
+    publish "$2" "$3" "$4"
+    ;;
+  previous)
+    test "$#" -eq 2 && valid_kind "$2" || exit 64
+    broker "previous $2"
+    ;;
+  hash)
+    test "$#" -eq 3 && valid_kind "$2" || exit 64
+    case "$2:$3" in
+      static-web:index.html|static-updates:appcast.xml|static-updates:release-manifest.json|static-downloads:install.sh|static-downloads:install.ps1) ;;
+      *) exit 64 ;;
+    esac
+    broker "hash $2 $3"
+    ;;
+  activate|rollback)
+    test "$#" -eq 4 && valid_kind "$2" || exit 64
+    [[ "$3" =~ ^[0-9a-f]{40}$ && "$4" =~ ^[0-9a-f]{64}$ ]] || exit 64
+    broker "$ACTION $2 $3 $4"
+    ;;
+  deploy-client-aliases)
+    test "$#" -eq 4 || exit 64
+    deploy_aliases "$2" "$3" "$4"
+    ;;
+  *) exit 64 ;;
+esac

--- a/scripts/release/test_deploy_production_asset.sh
+++ b/scripts/release/test_deploy_production_asset.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+temporary="$(mktemp -d)"
+cleanup() { rm -rf "$temporary"; }
+trap cleanup EXIT HUP INT TERM
+
+cat > "$temporary/ssh" <<'SSH'
+#!/usr/bin/env bash
+printf '%s\n' "$2" >> "$SANAD_DEPLOY_TEST_LOG"
+case "$2" in
+  upload\ *) cat > "$SANAD_DEPLOY_TEST_UPLOAD" ;;
+  upload-client-aliases\ *) cat > "$SANAD_DEPLOY_TEST_ALIAS" ;;
+  previous\ *) printf '%040d %064d\n' 2 3 ;;
+  hash\ *) printf '%064d\n' 4 ;;
+esac
+SSH
+chmod 0755 "$temporary/ssh"
+export PATH="$temporary:$PATH"
+export DEPLOY_HOST=example.invalid
+export DEPLOY_USER=sanad-deploy-production
+export SANAD_DEPLOY_TEST_LOG="$temporary/commands.log"
+export SANAD_DEPLOY_TEST_UPLOAD="$temporary/upload.tar.gz"
+export SANAD_DEPLOY_TEST_ALIAS="$temporary/aliases.conf"
+
+identity=1111111111111111111111111111111111111111
+mkdir "$temporary/updates"
+printf '<rss/>\n' > "$temporary/updates/appcast.xml"
+printf '{}\n' > "$temporary/updates/release-manifest.json"
+digest="$($SCRIPT_DIR/deploy_production_asset.sh publish static-updates "$identity" "$temporary/updates")"
+[[ "$digest" =~ ^[0-9a-f]{64}$ ]]
+test "$($SCRIPT_DIR/deploy_production_asset.sh publish static-updates "$identity" "$temporary/updates")" = "$digest"
+archived="$(tar -tzf "$temporary/upload.tar.gz" | sort | tr '\n' ' ' | sed 's/ $//')"
+test "$archived" = 'appcast.xml release-manifest.json'
+grep -Eq '^upload static-updates [0-9a-f]{40} [0-9a-f]{64} [1-9][0-9]*$' "$temporary/commands.log"
+grep -Eq '^install static-updates [0-9a-f]{40} [0-9a-f]{64}$' "$temporary/commands.log"
+
+read -r previous_identity previous_digest \
+  <<<"$($SCRIPT_DIR/deploy_production_asset.sh previous static-updates)"
+test "$previous_identity" = 0000000000000000000000000000000000000002
+test "$previous_digest" = 0000000000000000000000000000000000000000000000000000000000000003
+test "$($SCRIPT_DIR/deploy_production_asset.sh hash static-updates appcast.xml)" = \
+  0000000000000000000000000000000000000000000000000000000000000004
+
+manifest_digest="$(printf manifest | sha256sum | awk '{print $1}')"
+printf '# release-manifest.json sha256: %s\n' "$manifest_digest" > "$temporary/source-aliases.conf"
+$SCRIPT_DIR/deploy_production_asset.sh deploy-client-aliases \
+  v9.8.7 "$manifest_digest" "$temporary/source-aliases.conf" >/dev/null
+cmp -s "$temporary/source-aliases.conf" "$temporary/aliases.conf"
+grep -Eq '^upload-client-aliases v9\.8\.7 [0-9a-f]{64} [0-9a-f]{64} [1-9][0-9]*$' "$temporary/commands.log"
+grep -Eq '^deploy-client-aliases v9\.8\.7 [0-9a-f]{64} [0-9a-f]{64}$' "$temporary/commands.log"
+
+if $SCRIPT_DIR/deploy_production_asset.sh hash static-updates install.sh >/dev/null 2>&1; then
+  echo "Unexpected static hash target passed the client allowlist." >&2
+  exit 1
+fi
+
+echo "production-deployment-client=pass"


### PR DESCRIPTION
## Summary
- route Production Web, Appcast, installer, and Client-alias publication through a forced-command broker
- remove direct remote rsync, selector mutation, and sudo from public workflows
- retain exact rollback verification through constrained immutable identities and filename hash allowlists
- document and test the root-owned promotion boundary

## Verification
- `scripts/release/test_deploy_production_asset.sh`
- `scripts/release/test_generate_client_download_redirects.sh`
- YAML parse for deploy, release, and CI workflows
- static CI privilege-boundary assertions
- `graphify update .`
