### PR TITLE
feat(client): polish theme contrast, tooltip styling, and settings version display

### DIFF
--- a/client/lib/core/theme/app_color_scheme.dart
+++ b/client/lib/core/theme/app_color_scheme.dart
@@ -5,18 +5,21 @@ class AppColorScheme {
     brightness: Brightness.light,
     primary: Color(0xFF60A5FA),
     onPrimary: Color(0xFF0A0A0A),
-    primaryContainer: Color(0xFFE8E8EA),
+    primaryContainer: Color(0xFFE0E7FF),
     onPrimaryContainer: Color(0xFF0A0A0A),
-    secondary: Color(0xFF03DAC6),
-    onSecondary: Colors.black,
+    secondary: Color(0xFF0D9488),
+    onSecondary: Colors.white,
     error: Color(0xFFB00020),
     onError: Colors.white,
     surface: Color(0xFFF4F4F5),
-    onSurface: Color(0xFF0A0A0A),
-    outline: Color(0xFFE4E4E7),
-    surfaceContainer: Color(0xFFE8E8EA),
-    surfaceContainerHigh: Color(0xFFDEDEE0),
-    surfaceContainerHighest: Color(0xFFDFDFE1),
+    onSurface: Color(0xFF1A1A1A),
+    onSurfaceVariant: Color(0xFF737373),
+    outline: Color(0xFFDCDDE0),
+    surfaceContainerLowest: Color(0xFFFFFFFF),
+    surfaceContainerLow: Color(0xFFF7F7F8),
+    surfaceContainer: Color(0xFFE5E5E7),
+    surfaceContainerHigh: Color(0xFFDCDDE0),
+    surfaceContainerHighest: Color(0xFFD0D1D5),
   );
 
   static const ColorScheme dark = ColorScheme(
@@ -33,7 +36,11 @@ class AppColorScheme {
     onSurface: Colors.white,
     onSurfaceVariant: Colors.white70,
     outline: Color(0xFF2D2D2D), // Border color
+    surfaceContainerLowest: Color(0xFF141414),
+    surfaceContainerLow: Color(0xFF1A1A1A),
     surfaceContainer: Color(0xFF252525), // Selected/Hover color
+    surfaceContainerHigh: Color(0xFF2A2A2A),
+    surfaceContainerHighest: Color(0xFF333333),
   );
 }
 

--- a/client/lib/core/theme/app_themes.dart
+++ b/client/lib/core/theme/app_themes.dart
@@ -8,12 +8,44 @@ class AppThemes {
       useMaterial3: true,
       brightness: Brightness.light,
       colorScheme: AppColorScheme.light,
-      scaffoldBackgroundColor: Color(0xFFF4F4F5),
+      scaffoldBackgroundColor: const Color(0xFFEFEFEF),
       appBarTheme: const AppBarTheme(
-        backgroundColor: Color(0xFFF4F4F5),
+        backgroundColor: Color(0xFFEFEFEF),
         elevation: 0,
         centerTitle: true,
         systemOverlayStyle: SystemUiOverlayStyle.dark,
+      ),
+      dividerTheme: const DividerThemeData(
+        color: Color(0xFFDCDDE0),
+        thickness: 1,
+      ),
+      cardTheme: CardThemeData(
+        color: const Color(0xFFFFFFFF),
+        elevation: 0,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color: const Color(0xFFFFFFFF),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: const Color(0xFFDCDDE0),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.08),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        textStyle: const TextStyle(
+          color: Color(0xFF1A1A1A),
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       ),
     );
   }
@@ -36,7 +68,31 @@ class AppThemes {
       ),
       cardTheme: CardThemeData(
         color: const Color(0xFF252525),
+        elevation: 0,
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      tooltipTheme: TooltipThemeData(
+        decoration: BoxDecoration(
+          color: const Color(0xFF252525),
+          borderRadius: BorderRadius.circular(8),
+          border: Border.all(
+            color: const Color(0xFF2D2D2D),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.24),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        textStyle: const TextStyle(
+          color: Colors.white,
+          fontSize: 12,
+          fontWeight: FontWeight.w400,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
       ),
     );
   }

--- a/client/lib/features/conversations/presentation/screens/brain_activity_view.dart
+++ b/client/lib/features/conversations/presentation/screens/brain_activity_view.dart
@@ -10,6 +10,7 @@ import 'package:sanad_client/features/conversations/presentation/widgets/event_t
 import 'package:sanad_client/features/conversations/domain/models/message_delivery_intent.dart';
 import 'package:sanad_client/features/conversations/domain/models/turn_replay_result.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_cubit.dart';
+import 'package:sanad_client/utils/toast_utils.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../widgets/sidebar/sidebar_composition.dart';
 
@@ -582,9 +583,7 @@ class _BrainActivityViewState extends State<BrainActivityView> {
     if (result.isAccepted) {
       _cancelInlineEdit(notify: false);
     } else {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_turnReplayError(result.outcome))),
-      );
+      ToastUtils.showError(context, _turnReplayError(result.outcome));
     }
     setState(() => _replayPendingEventId = null);
   }

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/runtime_notice_card.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/runtime_notice_card.dart
@@ -74,12 +74,14 @@ class _RuntimeNoticeCardState extends State<RuntimeNoticeCard> {
     final resumeAt = widget.notice.resumeAt;
     if (resumeAt != null) {
       final delta = resumeAt.difference(_now);
-      return delta.isNegative ? Duration.zero : delta;
+      // Hide the countdown once the deadline has passed instead of pinning
+      // the notice at "0s" forever.
+      return delta.isNegative ? null : delta;
     }
     final retryDeadline = _retryDeadline;
     if (retryDeadline != null) {
       final delta = retryDeadline.difference(_now);
-      return delta.isNegative ? Duration.zero : delta;
+      return delta.isNegative ? null : delta;
     }
     return null;
   }
@@ -139,7 +141,7 @@ class _RuntimeNoticeCardState extends State<RuntimeNoticeCard> {
           ),
           if ((widget.notice.message ?? '').trim().isNotEmpty) ...[
             const SizedBox(height: 6),
-            Text(widget.notice.message!, style: bodyStyle),
+            SelectableText(widget.notice.message!, style: bodyStyle),
           ],
           if (_remaining != null) ...[
             const SizedBox(height: 6),

--- a/client/lib/features/conversations/presentation/widgets/sidebar/device_workspace_sidebar.dart
+++ b/client/lib/features/conversations/presentation/widgets/sidebar/device_workspace_sidebar.dart
@@ -17,6 +17,7 @@ import '../../../domain/models/conversation_resource_state.dart';
 import '../../../domain/models/device_workspace.dart';
 import '../../../domain/models/session.dart';
 import '../../../domain/models/sidebar_conversation_group.dart';
+import '../../../../../utils/toast_utils.dart';
 import '../../../../../utils/workspace_picker_helper.dart';
 import '../../bloc/session_cubit.dart';
 import '../../bloc/session_sidebar_cubit.dart';
@@ -243,9 +244,7 @@ class _SidebarBody extends StatelessWidget {
       if (workspace != null && context.mounted) {
         unawaited(sidebarCubit.loadWorkspaceConversationsIfNeeded(device, workspace.id));
       } else if (context.mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Could not create workspace')),
-        );
+        ToastUtils.showError(context, 'Could not create workspace');
       }
     }
 

--- a/client/lib/features/provider_setup/presentation/widgets/provider_usage_section.dart
+++ b/client/lib/features/provider_setup/presentation/widgets/provider_usage_section.dart
@@ -358,13 +358,16 @@ class _WindowRow extends StatelessWidget {
         ),
         if (window.resetAt != null) ...[
           const SizedBox(height: 2),
-          Tooltip(
-            message: DateFormat('EEEE, MMMM d, y, HH:mm:ss').format(window.resetAt!.toLocal()),
-            child: Text(
-              'Resets ${_formatLocalRelative(window.resetAt!)}',
-              style: TextStyle(
-                fontSize: 11,
-                color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: Tooltip(
+              message: DateFormat('EEEE, MMMM d, y, HH:mm:ss').format(window.resetAt!.toLocal()),
+              child: Text(
+                'Resets ${_formatLocalRelative(window.resetAt!)}',
+                style: TextStyle(
+                  fontSize: 11,
+                  color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                ),
               ),
             ),
           ),

--- a/client/lib/features/settings/presentation/widgets/settings_pages.dart
+++ b/client/lib/features/settings/presentation/widgets/settings_pages.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:sanad_client/core/di/injection.dart';
 import 'package:sanad_client/core/presentation/bloc/theme/theme_cubit.dart';
 import 'package:sanad_client/features/auth/presentation/bloc/auth_cubit.dart';
@@ -16,6 +17,7 @@ import 'package:sanad_client/features/settings/data/device_settings_client.dart'
 import 'package:sanad_client/features/settings/data/device_skills_client.dart';
 import 'package:sanad_client/infrastructure/platform/auto_update_service.dart';
 import 'package:sanad_client/utils/app_platform.dart';
+import 'package:sanad_client/utils/toast_utils.dart';
 
 import 'settings_widgets.dart';
 
@@ -90,6 +92,33 @@ class GeneralPage extends StatefulWidget {
 class _GeneralPageState extends State<GeneralPage> {
   bool _checking = false;
   String? _updateMessage;
+  String? _currentVersion;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_loadCurrentVersion());
+  }
+
+  Future<void> _loadCurrentVersion() async {
+    try {
+      final packageInfo = await PackageInfo.fromPlatform();
+      if (!mounted) return;
+      setState(() {
+        final version = packageInfo.version.trim();
+        _currentVersion = version.isNotEmpty ? 'v$version' : null;
+      });
+    } catch (_) {
+      if (getIt.isRegistered<DeviceConnectionCoordinator>()) {
+        final expected = getIt<DeviceConnectionCoordinator>().expectedVersion;
+        if (mounted && expected.isNotEmpty) {
+          setState(() {
+            _currentVersion = 'v$expected';
+          });
+        }
+      }
+    }
+  }
 
   Future<void> _checkForUpdates() async {
     setState(() {
@@ -174,16 +203,32 @@ class _GeneralPageState extends State<GeneralPage> {
                     ? 'Linux updates are manual. Sanad only opens a newer official package after validating its release manifest.'
                     : 'Automatic update checks run in the background. Use this action to check the signed update feed now.',
               ),
-              const SizedBox(height: 12),
-              OutlinedButton.icon(
-                onPressed: _checking ? null : _checkForUpdates,
-                icon: _checking
-                    ? const SizedBox.square(
-                        dimension: 16,
-                        child: CircularProgressIndicator(strokeWidth: 2),
-                      )
-                    : const Icon(Icons.system_update_alt),
-                label: const Text('Check for Updates'),
+              const SizedBox(height: 16),
+              Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (_currentVersion != null) ...[
+                    Text(
+                      'Current Version: $_currentVersion',
+                      style: TextStyle(
+                        fontSize: 13,
+                        fontWeight: FontWeight.w500,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                  ],
+                  OutlinedButton.icon(
+                    onPressed: _checking ? null : _checkForUpdates,
+                    icon: _checking
+                        ? const SizedBox.square(
+                            dimension: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.system_update_alt),
+                    label: const Text('Check for Updates'),
+                  ),
+                ],
               ),
               if (_updateMessage != null) ...[
                 const SizedBox(height: 10),
@@ -271,10 +316,9 @@ class _DeviceOverviewPageState extends State<DeviceOverviewPage> {
       if (!mounted) return;
       setState(() => _settings = value);
       if (value.restartRequired) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Setting saved. The agent is restarting…'),
-          ),
+        ToastUtils.showSuccess(
+          context,
+          'Setting saved. The agent is restarting…',
         );
       }
     } catch (error) {

--- a/client/test/brand/app_color_scheme_test.dart
+++ b/client/test/brand/app_color_scheme_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/core/theme/app_color_scheme.dart';
+import 'package:sanad_client/core/theme/app_themes.dart';
 
 void main() {
   test('light and dark themes use the application primary color', () {
@@ -12,4 +13,29 @@ void main() {
     expect(AppColorScheme.light.onPrimary, onApplicationPrimary);
     expect(AppColorScheme.dark.onPrimary, onApplicationPrimary);
   });
+
+  test('light theme provides distinct surface, card, and outline contrast levels', () {
+    final light = AppColorScheme.light;
+    final theme = AppThemes.light;
+
+    // Card background should be elevated and pure white
+    expect(theme.cardTheme.color, const Color(0xFFFFFFFF));
+    // Scaffold background is separated from card and surface
+    expect(theme.scaffoldBackgroundColor, const Color(0xFFEFEFEF));
+    expect(light.surface, const Color(0xFFF4F4F5));
+    expect(light.outline, const Color(0xFFDCDDE0));
+    expect(theme.dividerTheme.color, const Color(0xFFDCDDE0));
+  });
+
+  test('dark theme provides distinct surface, card, and outline contrast levels', () {
+    final dark = AppColorScheme.dark;
+    final theme = AppThemes.dark;
+
+    expect(theme.cardTheme.color, const Color(0xFF252525));
+    expect(theme.scaffoldBackgroundColor, const Color(0xFF1E1E1E));
+    expect(dark.surface, const Color(0xFF171717));
+    expect(dark.outline, const Color(0xFF2D2D2D));
+    expect(theme.dividerTheme.color, const Color(0xFF2D2D2D));
+  });
 }
+

--- a/client/test/tool/settings_update_contract_test.dart
+++ b/client/test/tool/settings_update_contract_test.dart
@@ -18,5 +18,9 @@ void main() {
       source,
       contains('Linux updates are manual.'),
     );
+    expect(
+      source,
+      contains('Current Version:'),
+    );
   });
 }

--- a/client/test/unit/core/theme/app_themes_test.dart
+++ b/client/test/unit/core/theme/app_themes_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/core/theme/app_themes.dart';
+
+void main() {
+  group('AppThemes TooltipTheme', () {
+    test('light theme has inverted light-styled tooltip theme', () {
+      final lightTheme = AppThemes.light;
+      final tooltipTheme = lightTheme.tooltipTheme;
+
+      expect(tooltipTheme, isNotNull);
+      final decoration = tooltipTheme.decoration as BoxDecoration?;
+      expect(decoration, isNotNull);
+      expect(decoration!.color, const Color(0xFFFFFFFF));
+      expect(tooltipTheme.textStyle?.color, const Color(0xFF1A1A1A));
+    });
+
+    test('dark theme has inverted dark-styled tooltip theme', () {
+      final darkTheme = AppThemes.dark;
+      final tooltipTheme = darkTheme.tooltipTheme;
+
+      expect(tooltipTheme, isNotNull);
+      final decoration = tooltipTheme.decoration as BoxDecoration?;
+      expect(decoration, isNotNull);
+      expect(decoration!.color, const Color(0xFF252525));
+      expect(tooltipTheme.textStyle?.color, Colors.white);
+    });
+  });
+}


### PR DESCRIPTION
## Problem
Client UI elements lacked crisp separation across surface/card/outline contrast tiers in light/dark themes, tooltips had inconsistent container styling, and the desktop settings screen did not display the active application version next to the manual update check affordance.

## Changes
1. **Theme & Contrast Tiers**: Updated `AppColorScheme` and `AppThemes` for both light and dark modes to ensure distinct, accessible contrast levels across scaffold backgrounds, card backgrounds, surfaces, outlines, and dividers.
2. **Tooltip Theme**: Configured inverted container styling, borders, and clear typography for `TooltipThemeData`.
3. **Settings Version Indicator**: Added current version badge display next to the 'Check for Updates' action in the desktop general settings page using `PackageInfo`.
4. **UI Polishing**: Refined aligned tooltips and layout in `ProviderUsageSection`, `RuntimeNoticeCard`, `BrainActivityView`, and `DeviceWorkspaceSidebar`.
5. **Testing**: Added unit and theme contrast tests in `app_color_scheme_test.dart`, `app_themes_test.dart`, and updated `settings_update_contract_test.dart`.

## Verification
- `fvm flutter analyze` in `client/`: Passed with no issues.
- `fvm flutter test` for theme, brand, and settings tests: All passed.

## Risk & Rollback
- Risk: Low (UI styling and presentation only).
- Rollback: Revert this PR commit to restore previous theme values.