### PR TITLE
fix(web): align PWA theme color and splash loading with dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ doc/api/
 *.dart.js
 *.info.json
 *.js
+!client/web/*.js
 *.js_
 *.js.deps
 *.js.map

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -123,7 +123,7 @@ flutter_launcher_icons:
     generate: true
     image_path: "assets/app-logo.png"
     background_color: "#0A0A0A"
-    theme_color: "#60A5FA"
+    theme_color: "#0A0A0A"
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/client/test/brand/brand_assets_test.dart
+++ b/client/test/brand/brand_assets_test.dart
@@ -113,7 +113,7 @@ void main() {
   test('web standard and maskable icons use intentional brand colors', () {
     final manifest = jsonDecode(File('web/manifest.json').readAsStringSync()) as Map<String, dynamic>;
     expect(manifest['background_color'], '#0A0A0A');
-    expect(manifest['theme_color'], '#60A5FA');
+    expect(manifest['theme_color'], '#0A0A0A');
 
     expect((_readPng('web/icons/Icon-192.png').width, _readPng('web/icons/Icon-512.png').width), (192, 512));
     expect(

--- a/client/test/tool/app_web_startup_contract_test.dart
+++ b/client/test/tool/app_web_startup_contract_test.dart
@@ -17,6 +17,8 @@ void main() {
 
     expect(index, isNot(contains('<script>')));
     expect(index, contains('<script src="auth_popup.js"></script>'));
+    expect(index, contains('<script src="splash.js"></script>'));
+    expect(File('web/splash.js').existsSync(), isTrue);
     expect(
       index.indexOf('auth_popup.js'),
       lessThan(index.indexOf('flutter_bootstrap.js')),

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -70,15 +70,8 @@
   <div id="loading" class="loading-container">
     <div class="spinner"></div>
   </div>
-  <script>
-    window.addEventListener('flutter-first-frame', function () {
-      var loading = document.getElementById('loading');
-      if (loading) {
-        loading.remove();
-      }
-    });
-  </script>
   <script src="auth_popup.js"></script>
+  <script src="splash.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 

--- a/client/web/index.html
+++ b/client/web/index.html
@@ -32,9 +32,52 @@
 
   <title>Sanad</title>
   <link rel="manifest" href="manifest.json">
+  <style>
+    body {
+      background-color: #0A0A0A;
+      margin: 0;
+      height: 100vh;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    .loading-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .spinner {
+      width: 50px;
+      height: 50px;
+      border: 3px solid rgba(96, 165, 250, 0.1);
+      border-radius: 50%;
+      border-top-color: #60A5FA;
+      animation: spin 1s ease-in-out infinite;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
+  </style>
 </head>
 
 <body>
+  <div id="loading" class="loading-container">
+    <div class="spinner"></div>
+  </div>
+  <script>
+    window.addEventListener('flutter-first-frame', function () {
+      var loading = document.getElementById('loading');
+      if (loading) {
+        loading.remove();
+      }
+    });
+  </script>
   <script src="auth_popup.js"></script>
   <script src="flutter_bootstrap.js" async></script>
 </body>

--- a/client/web/manifest.json
+++ b/client/web/manifest.json
@@ -4,7 +4,7 @@
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0A0A0A",
-    "theme_color": "#60A5FA",
+    "theme_color": "#0A0A0A",
     "description": "An AI Companion built with Sanad",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,

--- a/client/web/splash.js
+++ b/client/web/splash.js
@@ -1,0 +1,6 @@
+window.addEventListener('flutter-first-frame', function () {
+  var loading = document.getElementById('loading');
+  if (loading) {
+    loading.remove();
+  }
+});


### PR DESCRIPTION
## Problem
In the Web / PWA build, `theme_color` in `manifest.json` and `pubspec.yaml` was hardcoded to primary blue (`#60A5FA`), causing mobile browser status bars and PWA title bars to clash with the app's dark interface. In addition, the initial web loading screen lacked dark styling.

## Changes
1. Updated `manifest.json` and `client/pubspec.yaml` web launcher icons to set `theme_color: "#0A0A0A"`.
2. Added dark background and centered spinner loading splash in `client/web/index.html` that cleanly unmounts on `flutter-first-frame`.
3. Updated brand assets test in `client/test/brand/brand_assets_test.dart` to assert `theme_color: '#0A0A0A'`.

## Verification
- `fvm flutter analyze` in `client/`: Passed with no issues.
- `fvm flutter test test/brand/brand_assets_test.dart`: Passed (5/5 tests).

## Risk & Rollback
- Risk: Low (Web presentation and manifest only).
- Rollback: Revert this PR commit to restore previous web theme color.