### PR TITLE
fix(release): roll back failed asset activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,7 +248,12 @@ jobs:
           grep -F 'https://app.sanad.eaststarai.com/sanad-public-sha.txt' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/appcast.xml' .github/workflows/deploy.yml
           grep -F 'gh attestation verify download/release-manifest.json' .github/workflows/deploy.yml
+          grep -Fq "'') test \"\$RELEASE_RUN_ID\" = \"\$GITHUB_RUN_ID\" ;;" .github/workflows/deploy.yml
           test "$(grep -Fc 'scripts/release/deploy_production_asset.sh' .github/workflows/deploy.yml)" -ge 12
+          test "$(grep -Fc 'if ! scripts/release/deploy_production_asset.sh activate static-' .github/workflows/deploy.yml)" -eq 3
+          test "$(grep -Fc 'if ! rollback_web' .github/workflows/deploy.yml)" -eq 2
+          test "$(grep -Fc 'if ! rollback_updates' .github/workflows/deploy.yml)" -eq 2
+          test "$(grep -Fc 'if ! rollback_installers' .github/workflows/deploy.yml)" -eq 2
           ! grep -Eq '(^|[[:space:]])rsync[[:space:]]|ln -sfn|sudo /usr/local/sbin|/opt/sanad-sites/' .github/workflows/deploy.yml
           grep -F 'name: Activate, verify, and roll back updates on failure' .github/workflows/deploy.yml
           grep -F 'https://updates.sanad.eaststarai.com/$name' .github/workflows/deploy.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       release_run_id:
-        description: Successful release workflow run containing private Web handoff artifacts
+        description: Producing release workflow run containing private Web handoff artifacts
         required: true
         type: string
       deploy_web:
@@ -27,7 +27,7 @@ on:
         required: true
         default: v1.0.1
       release_run_id:
-        description: Successful release workflow run containing private Web handoff artifacts
+        description: Completed producing release workflow run containing private Web handoff artifacts
         required: true
       deploy_web:
         type: boolean
@@ -78,7 +78,11 @@ jobs:
           expected_sha="$(git rev-parse HEAD)"
           run_metadata="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RELEASE_RUN_ID")"
           run_conclusion="$(jq -r '.conclusion // empty' <<<"$run_metadata")"
-          test "$run_conclusion" = "success" || test "$run_conclusion" = "failure" || test -z "$run_conclusion"
+          case "$run_conclusion" in
+            success|failure) ;;
+            '') test "$RELEASE_RUN_ID" = "$GITHUB_RUN_ID" ;;
+            *) echo "The producing release run is not deployable: $run_conclusion" >&2; exit 1 ;;
+          esac
           test "$(jq -r '.path' <<<"$run_metadata")" = .github/workflows/release.yml
           test "$(jq -r '.head_sha' <<<"$run_metadata")" = "$expected_sha"
           gh release view "$RELEASE_TAG" --json isDraft --jq '.isDraft == false' | grep -Fxq true
@@ -124,8 +128,6 @@ jobs:
           expected_sha="$(git rev-parse HEAD)"
           read -r previous_identity previous_digest \
             <<<"$(scripts/release/deploy_production_asset.sh previous static-web)"
-          scripts/release/deploy_production_asset.sh activate static-web \
-            "$expected_sha" "${{ steps.publish_asset.outputs.digest }}"
 
           verify_web() {
             body="$(mktemp)"
@@ -142,6 +144,33 @@ jobs:
             test "$served_sha" = "$expected_sha"
           }
 
+          rollback_web() {
+            if ! scripts/release/deploy_production_asset.sh rollback static-web \
+              "$previous_identity" "$previous_digest"; then
+              echo "Production Web rollback command failed." >&2
+              return 1
+            fi
+            for attempt in $(seq 1 12); do
+              served_previous="$(curl --fail --silent --show-error --max-time 20 \
+                "https://app.sanad.eaststarai.com/sanad-public-sha.txt?rollback=$previous_identity" || true)"
+              if [[ "$served_previous" == "$previous_identity" ]]; then
+                return 0
+              fi
+              sleep 5
+            done
+            echo "Production Web rollback verification failed." >&2
+            return 1
+          }
+
+          if ! scripts/release/deploy_production_asset.sh activate static-web \
+            "$expected_sha" "${{ steps.publish_asset.outputs.digest }}"; then
+            echo "Production Web activation failed; restoring the previous selector."
+            if ! rollback_web; then
+              echo "Production Web rollback did not complete." >&2
+            fi
+            exit 1
+          fi
+
           activated=false
           for attempt in $(seq 1 12); do
             if verify_web; then
@@ -152,20 +181,8 @@ jobs:
           done
           if [[ "$activated" != true ]]; then
             echo "Production Web verification failed; restoring the previous selector."
-            scripts/release/deploy_production_asset.sh rollback static-web \
-              "$previous_identity" "$previous_digest"
-            rollback_verified=false
-            for attempt in $(seq 1 12); do
-              served_previous="$(curl --fail --silent --show-error --max-time 20 \
-                "https://app.sanad.eaststarai.com/sanad-public-sha.txt?rollback=$previous_identity" || true)"
-              if [[ "$served_previous" == "$previous_identity" ]]; then
-                rollback_verified=true
-                break
-              fi
-              sleep 5
-            done
-            if [[ "$rollback_verified" != true ]]; then
-              echo "Production Web rollback verification failed." >&2
+            if ! rollback_web; then
+              echo "Production Web rollback did not complete." >&2
             fi
             exit 1
           fi
@@ -217,7 +234,6 @@ jobs:
           previous_manifest="$(scripts/release/deploy_production_asset.sh hash static-updates release-manifest.json)"
           digest="$(scripts/release/deploy_production_asset.sh \
             publish static-updates "$revision" download)"
-          scripts/release/deploy_production_asset.sh activate static-updates "$revision" "$digest"
 
           verify_update() {
             local name="$1" expected="$2" output="$3" marker="$4"
@@ -228,13 +244,33 @@ jobs:
 
           temporary="$(mktemp -d)"
           trap 'rm -rf "$temporary"' EXIT
+          rollback_updates() {
+            if ! scripts/release/deploy_production_asset.sh rollback static-updates \
+              "$previous_identity" "$previous_digest"; then
+              echo "Updates rollback command failed." >&2
+              return 1
+            fi
+            if ! verify_update appcast.xml "$previous_appcast" "$temporary/rollback-appcast.xml" "rollback=$previous_appcast" || \
+              ! verify_update release-manifest.json "$previous_manifest" "$temporary/rollback-manifest.json" "rollback=$previous_manifest"; then
+              echo "Updates rollback verification failed." >&2
+              return 1
+            fi
+          }
+
+          if ! scripts/release/deploy_production_asset.sh activate static-updates "$revision" "$digest"; then
+            echo "Updates activation failed; restoring the previous selector."
+            if ! rollback_updates; then
+              echo "Updates rollback did not complete." >&2
+            fi
+            exit 1
+          fi
+
           if ! verify_update appcast.xml "$expected_appcast" "$temporary/appcast.xml" "release=$tag" || \
             ! verify_update release-manifest.json "$expected_manifest" "$temporary/release-manifest.json" "release=$tag"; then
             echo "Updates verification failed; restoring the previous selector."
-            scripts/release/deploy_production_asset.sh rollback static-updates \
-              "$previous_identity" "$previous_digest"
-            verify_update appcast.xml "$previous_appcast" "$temporary/rollback-appcast.xml" "rollback=$previous_appcast"
-            verify_update release-manifest.json "$previous_manifest" "$temporary/rollback-manifest.json" "rollback=$previous_manifest"
+            if ! rollback_updates; then
+              echo "Updates rollback did not complete." >&2
+            fi
             exit 1
           fi
 
@@ -270,7 +306,6 @@ jobs:
           previous_ps1="$(scripts/release/deploy_production_asset.sh hash static-downloads install.ps1)"
           digest="$(scripts/release/deploy_production_asset.sh \
             publish static-downloads "$revision" scripts)"
-          scripts/release/deploy_production_asset.sh activate static-downloads "$revision" "$digest"
 
           verify_installer() {
             local name="$1" expected="$2" output="$3" marker="$4"
@@ -281,12 +316,32 @@ jobs:
 
           temporary="$(mktemp -d)"
           trap 'rm -rf "$temporary"' EXIT
+          rollback_installers() {
+            if ! scripts/release/deploy_production_asset.sh rollback static-downloads \
+              "$previous_identity" "$previous_digest"; then
+              echo "Installer rollback command failed." >&2
+              return 1
+            fi
+            if ! verify_installer install.sh "$previous_sh" "$temporary/rollback.sh" "rollback=$previous_sh" || \
+              ! verify_installer install.ps1 "$previous_ps1" "$temporary/rollback.ps1" "rollback=$previous_ps1"; then
+              echo "Installer rollback verification failed." >&2
+              return 1
+            fi
+          }
+
+          if ! scripts/release/deploy_production_asset.sh activate static-downloads "$revision" "$digest"; then
+            echo "Installer activation failed; restoring the previous selector."
+            if ! rollback_installers; then
+              echo "Installer rollback did not complete." >&2
+            fi
+            exit 1
+          fi
+
           if ! verify_installer install.sh "$expected_sh" "$temporary/install.sh" "release=$revision" || \
             ! verify_installer install.ps1 "$expected_ps1" "$temporary/install.ps1" "release=$revision"; then
             echo "Installer verification failed; restoring the previous selector."
-            scripts/release/deploy_production_asset.sh rollback static-downloads \
-              "$previous_identity" "$previous_digest"
-            verify_installer install.sh "$previous_sh" "$temporary/rollback.sh" "rollback=$previous_sh"
-            verify_installer install.ps1 "$previous_ps1" "$temporary/rollback.ps1" "rollback=$previous_ps1"
+            if ! rollback_installers; then
+              echo "Installer rollback did not complete." >&2
+            fi
             exit 1
           fi

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -120,11 +120,24 @@ Probe approval is not Release publication approval.
 
 The candidate workflow creates a private Draft and fails if the tag already owns any Draft or published Release. A separate least-privilege publication job can make that reviewed Draft public only after the required owner approval on `release-publication`. Rejected or cancelled approval leaves no partial public Release. Public release files use published checksums. After an approved Stable publication, the protected Client-download job downloads the public manifest, checksum file, and three desktop Client artifacts; verifies canonical URLs, byte sizes, SHA-256 values, and GitHub attestations; generates a deterministic Nginx redirect include; and uploads only that bounded include through the Production forced-command deployment broker. The broker verifies the exact byte count and digest, and the root-owned controller invokes the fixed alias validator with the verified payload. The Stable release then calls the reusable Production asset workflow with Web, Appcast, and installers enabled and its own release run ID. This ordering serializes the redirect deployment before the remaining Production assets and prevents an asset handoff when publication or redirect verification fails. RC and validation-only runs never enter either Production path. The server remains a redirector rather than an artifact mirror and owns candidate validation, atomic activation, public regression verification, and automatic rollback.
 
-A manual `Deploy prepared release assets` dispatch is recovery-only. It must identify an existing immutable Stable tag and its successful producing release run. Because a default-branch dispatch has `main` as its deployment ref, the `client-downloads-production` Environment must explicitly allow the reviewed `main` recovery ref before credentials are available; normal automatic deployment remains tag-restricted. Changing that policy is a repository-setting mutation and is not implied by a workflow edit.
+Every static-surface job captures the preceding identity before activation and
+must enter the same verified rollback path when the controller activation
+command itself returns nonzero or when later public-byte verification fails.
+Shell fail-fast behavior must not exit between a selector-changing activation
+and rollback. Rollback command failure is reported separately from rollback
+verification failure, and the release job remains failed in either case.
+
+A manual `Deploy prepared release assets` dispatch is recovery-only. It must identify an existing immutable Stable tag and its completed producing release run. Because a default-branch dispatch has `main` as its deployment ref, the `client-downloads-production` Environment must explicitly allow the reviewed `main` recovery ref before credentials are available; normal automatic deployment remains tag-restricted. Changing that policy is a repository-setting mutation and is not implied by a workflow edit.
+
+The producing release run may be completed with `success` or `failure`, because
+an asset deployment failure can make the parent release run fail after the
+immutable Release and attested Web handoff already exist. A run with no final
+conclusion is accepted only when its ID is the current reusable-workflow run;
+manual recovery cannot consume an unrelated queued or in-progress run.
 
 The public workflow never names, creates, reads, or selects a live-host release
 directory. The private Web handoff is downloaded from the explicitly selected
-successful release-workflow run and verified against its GitHub build
+producing release-workflow run and verified against its GitHub build
 attestation. It is packaged with its exact public commit identity and sent to
 the Production forced-command broker. The root-owned controller safely extracts
 the bounded archive, rejects links, traversal, secret-shaped paths, unexpected

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -126,7 +126,11 @@ markers, the public Appcast and Stable manifest SHA-256 values, both public
 installer-source SHA-256 values, and a clean browser render. A stale bind mount,
 incomplete static root, selector-only success, or HTTP-only shell response fails
 the gate. A failed surface must restore and publicly verify all its preceding
-release-owned bytes without recreating data or application services.
+release-owned bytes without recreating data or application services. This
+includes a controller activation that returns nonzero after changing the
+selector: Web, updates, and installer jobs must catch that command result,
+invoke rollback, verify the preceding public bytes, and only then report the
+failed deployment.
 
 ### Live Stable asset rehearsal — 2026-08-10
 
@@ -145,6 +149,23 @@ console error. The Production, Development, and Staging public verifiers passed;
 Production PostgreSQL and Redis volumes remained present. The rehearsal used the
 same reusable workflow that every future approved Stable publication calls
 automatically.
+
+### Stable Web `v1.0.2` promotion failure — 2026-08-10
+
+Run `31422198524` published and verified the signed Stable packages, update
+feed, installer sources, and Client aliases, but its Web job exposed two
+deployment-contract defects. The root-owned promotion directory retained
+`mktemp -d` mode `0700`, so the unprivileged Nginx worker returned `403` despite
+healthy container state and readable files. Controller activation returned
+nonzero from its internal smoke after changing the selector; step-level
+`set -e` then exited before the external-verification rollback block.
+
+The bounded live recovery changed only the verified `v1.0.2` Web release root
+to `0755`; its exact source marker and Flutter bootstrap immediately returned
+success. The permanent gate normalizes promoted release roots in the private
+controller and requires activation-command failure rollback for all three
+public static jobs. A successful Web-only rerun and clean-browser evidence are
+required before this incident is closed.
 
 ## Update failure coverage
 


### PR DESCRIPTION
## Summary
- catch controller activation failures for Web, updates, and installer surfaces
- restore and verify the captured previous selector before reporting failure
- strengthen CI workflow contracts so shell fail-fast cannot bypass rollback
- document the v1.0.2 promotion incident and recovery gate

## Validation
- `scripts/release/test_deploy_production_asset.sh`
- workflow YAML parse
- focused activation/rollback contract assertions

## Incident
Run 31422198524 left the v1.0.2 Web selector active after controller smoke failed on an unreadable release root. The private controller fix is reviewed separately.