### PR TITLE
fix(runtime): contain recovery exception on stop and recover stale switch manifests

### DIFF
--- a/agent/lib/interfaces/runtime/session_run_orchestrator.dart
+++ b/agent/lib/interfaces/runtime/session_run_orchestrator.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:sanad_agent/core/di.dart';
 import 'package:sanad_agent/core/config.dart';
 import 'package:sanad_agent/core/provider_runtime/session_queue_provider_override.dart';
+import 'package:sanad_agent/core/provider_runtime/runtime_recovery_exception.dart';
 import 'package:sanad_agent/core/provider_runtime/runtime_recovery_service.dart';
 import 'package:sanad_agent/core/provider_runtime/runtime_notice.dart';
 import 'package:sanad_agent/core/provider_runtime/runtime_failure_reason.dart';
@@ -438,7 +439,24 @@ class SessionRunOrchestrator implements SessionQueueProviderOverride {
       );
     }
     if (stopFuture != null) {
-      await stopFuture;
+      try {
+        await stopFuture;
+      } on RuntimeRecoveryCancelled catch (error) {
+        // Stop intentionally aborts an active recovery wait. The stream
+        // cancellation can surface that expected lifecycle transition through
+        // the subscription cancellation Future; durable cleanup must continue.
+        _logger.info(
+          'Runtime recovery cancelled while stopping session $sessionId: '
+          '$error',
+        );
+      } on RuntimeRecoveryRequired catch (error) {
+        // Recovery can race with Stop before stream cancellation completes.
+        // Stop is authoritative and must still transition durable state to idle.
+        _logger.info(
+          'Runtime recovery transition superseded by stop for session '
+          '$sessionId: $error',
+        );
+      }
     }
     final hasNewerDurableWork =
         persistedState

--- a/agent/test/interfaces/interfaces_test.dart
+++ b/agent/test/interfaces/interfaces_test.dart
@@ -2203,6 +2203,66 @@ Use the review skill.''',
   );
 
   test(
+    'stop completes cleanup when recovery cancellation surfaces from stream cancellation',
+    () async {
+      final orchestrator = getIt<SessionRunOrchestrator>();
+      final listening = Completer<void>();
+      final controller = StreamController<String>(
+        onListen: listening.complete,
+        onCancel: () => Future<void>.error(
+          const RuntimeRecoveryCancelled('session-stop-rate-limit'),
+        ),
+      );
+      addTearDown(() async {
+        if (!controller.isClosed) await controller.close();
+      });
+      when(
+        mockAgentRunner.streamMessage(
+          any,
+          runtimeSystemPrompt: anyNamed('runtimeSystemPrompt'),
+          providerId: anyNamed('providerId'),
+          model: anyNamed('model'),
+          thinkingMode: anyNamed('thinkingMode'),
+          receivedAt: anyNamed('receivedAt'),
+          onToolEvent: anyNamed('onToolEvent'),
+          onSteerContinuation: anyNamed('onSteerContinuation'),
+          onThoughtDelta: anyNamed('onThoughtDelta'),
+          onReasoningDelta: anyNamed('onReasoningDelta'),
+        ),
+      ).thenAnswer((_) => controller.stream);
+
+      final responses = <GatewayResponse>[];
+      final responseSubscription = orchestrator.responses.listen(responses.add);
+      addTearDown(responseSubscription.cancel);
+
+      unawaited(
+        orchestrator.handleEvent(
+          GatewayEvent(
+            sessionId: 'session-stop-rate-limit',
+            platformId: 'test-platform',
+            message: Message(role: MessageRole.user, content: 'Running'),
+          ),
+        ),
+      );
+      await listening.future;
+      expect(orchestrator.isSessionBusy('session-stop-rate-limit'), isTrue);
+
+      await orchestrator.requestStop('session-stop-rate-limit');
+      await Future<void>.delayed(Duration.zero);
+
+      expect(orchestrator.isSessionBusy('session-stop-rate-limit'), isFalse);
+      expect(orchestrator.hasSuspendedEvent('session-stop-rate-limit'), isFalse);
+      expect(
+        responses.where(
+          (response) =>
+              response.message.metadata?['canonical_event_type'] == 'stopped',
+        ),
+        hasLength(1),
+      );
+    },
+  );
+
+  test(
     'stop A preserves message B received while subscription cancellation waits',
     () async {
       final orchestrator = getIt<SessionRunOrchestrator>();

--- a/client/test/unit/scripts/sanad_dev_runtime_switch_test.dart
+++ b/client/test/unit/scripts/sanad_dev_runtime_switch_test.dart
@@ -41,6 +41,44 @@ void main() {
     expect(restored?.status, 'requested');
   });
 
+  test('active switch ownership distinguishes live and stale launchers', () {
+    final request = RuntimeSwitchRequest(
+      id: 'request-active',
+      agentPort: 58091,
+      targetRepositoryRoot: Directory.systemTemp.path,
+      targetWorkspaceHash: 'abcd1234',
+      targetWorktreeName: 'feature-a',
+      targetBranch: 'feature/a',
+      targetIsLinkedWorktree: true,
+      requestedAt: DateTime.utc(2026, 7, 28),
+      launcherId: 'launcher-old',
+      runtimeNonce: 'nonce-old',
+      status: 'starting',
+    );
+
+    expect(isActiveRuntimeSwitch(request), isTrue);
+    expect(
+      isRuntimeSwitchOwnedByLauncher(
+        request,
+        launcherId: 'launcher-old',
+        runtimeNonce: 'nonce-old',
+      ),
+      isTrue,
+    );
+    expect(
+      isRuntimeSwitchOwnedByLauncher(
+        request,
+        launcherId: 'launcher-new',
+        runtimeNonce: 'nonce-new',
+      ),
+      isFalse,
+    );
+    expect(
+      isActiveRuntimeSwitch(request.copyWith(status: 'failed')),
+      isFalse,
+    );
+  });
+
   test('switch target must contain both agent and client source roots', () {
     final request = RuntimeSwitchRequest(
       id: 'request-1',

--- a/docs/plans/tasks/66-stale-runtime-switch-manifest-recovery.md
+++ b/docs/plans/tasks/66-stale-runtime-switch-manifest-recovery.md
@@ -1,0 +1,29 @@
+---
+title: "Stale Runtime Switch Manifest Recovery"
+status: "completed"
+---
+
+# Stale Runtime Switch Manifest Recovery
+
+## Problem
+
+A runtime-switch manifest can remain in `requested`, `draining`, or `starting`
+after its owning launcher exits. A later healthy managed launcher then remains
+usable for status/reload but every source switch is blocked forever by the
+orphaned manifest.
+
+## Design
+
+- Treat an active-status switch manifest as live only when its launcher id and
+  runtime nonce match the currently validated managed launcher lease.
+- Atomically terminalize an active manifest owned by another launcher as
+  `failed` before accepting a new switch request.
+- Never discard an active manifest that still matches the live launcher.
+- Repair only the manifest; do not signal or stop any process.
+
+## Definition of Done
+
+- Unit tests cover matching-owner refusal and mismatched-owner stale recovery.
+- Existing switch-manifest and runtime ownership tests pass.
+- Analyzer passes.
+- Runtime documentation describes stale-manifest recovery.

--- a/docs/technical/agent_runtime.md
+++ b/docs/technical/agent_runtime.md
@@ -243,6 +243,10 @@ also makes the session busy. If another connection wins the active-row race,
 admission retries as queued rather than exposing a SQLite uniqueness error.
 An unexpected platform command Future is contained by `GatewayManager`, which
 returns one controlled command error while keeping the daemon event loop live.
+During Stop, an expected recovery transition surfaced by stream cancellation is
+contained inside `SessionRunOrchestrator`; Stop remains authoritative and
+continues cancelling durable work so the execution snapshot reaches `idle`
+instead of remaining at `stopping`.
 
 ### 5.1.1. Authoritative queue and pending-steer ownership (Task 36)
 

--- a/docs/technical/sanad_dev_runtime_ownership.md
+++ b/docs/technical/sanad_dev_runtime_ownership.md
@@ -89,7 +89,14 @@ inconsistent managed source and fails closed with a diagnostic. A manifest with 
 unsupported version or invalid shape remains fail-closed and is not mutated by
 the launcher. Polling reports an unchanged invalid on-disk revision only once;
 a replaced invalid revision can produce one new diagnostic, and a valid or
-absent manifest resets that suppression.
+absent manifest resets that suppression. Before submitting a new handoff, the
+CLI compares any active-status manifest with the validated live launcher id and
+runtime nonce. A matching owner remains active and blocks the new request. A
+mismatched owner proves the record belongs to a previous launcher, so the CLI
+atomically terminalizes it as `failed` without signaling any process and then
+continues normal switch preflight. `sanad-dev doctor --fix` applies the same
+identity check to repair an orphaned active-status handoff independently of a
+new switch request.
 
 For an Agent-origin command, the CLI emits a requester-bound deferred-result
 descriptor instead of treating `Switch accepted` as completion. The descriptor

--- a/scripts/sanad_dev/runtime_commands.dart
+++ b/scripts/sanad_dev/runtime_commands.dart
@@ -1077,6 +1077,40 @@ Future<void> handleRuntimeDoctor({
       '(${launcherLive ? 'live' : 'stale'})',
     );
     if (fix) {
+      final switchPath = runtimeSwitchManifestPath(
+        activeHome,
+        state.agent?.port ?? runtime.agentPort,
+      );
+      try {
+        final handoff = await readRuntimeSwitchRequest(switchPath);
+        if (handoff != null &&
+            isActiveRuntimeSwitch(handoff) &&
+            !isRuntimeSwitchOwnedByLauncher(
+              handoff,
+              launcherId: record.launcherId,
+              runtimeNonce: record.runtimeNonce,
+            )) {
+          await writeRuntimeSwitchRequest(
+            switchPath,
+            handoff.copyWith(
+              status: 'failed',
+              message:
+                  'Stale runtime handoff discarded because its owning launcher is no longer active.',
+            ),
+          );
+          print(
+            'Fixed: terminalized stale runtime handoff ${handoff.id}; '
+            'no process was signaled.',
+          );
+          return;
+        }
+      } on Object catch (error) {
+        stderr.writeln(
+          'No fix applied: runtime handoff record is invalid: $error',
+        );
+        exitCode = 1;
+        return;
+      }
       final endpointLive = agents.any(
         (agent) => agent.port == record.agentPort,
       );

--- a/scripts/sanad_dev/runtime_switch.dart
+++ b/scripts/sanad_dev/runtime_switch.dart
@@ -5,6 +5,17 @@ import 'client_launch_profile.dart';
 import 'secure_runtime_file.dart';
 
 const runtimeSwitchManifestVersion = 2;
+const activeRuntimeSwitchStatuses = {'requested', 'draining', 'starting'};
+
+bool isActiveRuntimeSwitch(RuntimeSwitchRequest request) =>
+    activeRuntimeSwitchStatuses.contains(request.status);
+
+bool isRuntimeSwitchOwnedByLauncher(
+  RuntimeSwitchRequest request, {
+  required String launcherId,
+  required String runtimeNonce,
+}) =>
+    request.launcherId == launcherId && request.runtimeNonce == runtimeNonce;
 
 class RuntimeSwitchRequest {
   const RuntimeSwitchRequest({

--- a/scripts/sanad_dev/switch_commands.dart
+++ b/scripts/sanad_dev/switch_commands.dart
@@ -160,11 +160,27 @@ Future<void> handleRuntimeSwitch({
   final manifestPath = runtimeSwitchManifestPath(sanadHome, agent.port);
   try {
     final existing = await readRuntimeSwitchRequest(manifestPath);
-    if (existing != null &&
-        const {'requested', 'draining', 'starting'}.contains(existing.status)) {
-      stderr.writeln('Switch aborted: another runtime handoff is active.');
-      exitCode = 1;
-      return;
+    if (existing != null && isActiveRuntimeSwitch(existing)) {
+      if (isRuntimeSwitchOwnedByLauncher(
+        existing,
+        launcherId: launcherRecord.launcherId,
+        runtimeNonce: launcherRecord.runtimeNonce,
+      )) {
+        stderr.writeln('Switch aborted: another runtime handoff is active.');
+        exitCode = 1;
+        return;
+      }
+      await writeRuntimeSwitchRequest(
+        manifestPath,
+        existing.copyWith(
+          status: 'failed',
+          message:
+              'Stale runtime handoff discarded because its owning launcher is no longer active.',
+        ),
+      );
+      print(
+        'Recovered stale runtime handoff ${existing.id} from a previous launcher.',
+      );
     }
   } on Object {
     stderr.writeln('Switch aborted: the existing handoff record is invalid.');


### PR DESCRIPTION
## Problem / goal

1. During `requestStop`, an active runtime recovery wait may be cancelled or race with recovery exceptions (`RuntimeRecoveryCancelled`, `RuntimeRecoveryRequired`). Previously, unhandled exceptions during stream cancellation could prevent durable cleanup from transitioning the session snapshot to `idle`, leaving it stuck in `stopping`.
2. A runtime-switch manifest could remain in `requested`, `draining`, or `starting` after its owning launcher exited. Subsequent switch requests would be blocked indefinitely by the stale manifest.

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Security or privacy
- [ ] Performance or refactor
- [x] Test or maintenance

**Components:** agent / client / docs

**Platforms:** all

## Changes

- **Agent Runtime Stop Containment:**
  - Catch `RuntimeRecoveryCancelled` and `RuntimeRecoveryRequired` during `SessionRunOrchestrator.requestStop` to allow authoritative stop cleanup to finish and set state to `idle`.
  - Added unit test in `agent/test/interfaces/interfaces_test.dart` verifying stop completes cleanup when recovery cancellation surfaces.
- **Runtime Switch Stale Recovery:**
  - Added `isActiveRuntimeSwitch` and `isRuntimeSwitchOwnedByLauncher` in `scripts/sanad_dev/runtime_switch.dart`.
  - Updated `scripts/sanad_dev/switch_commands.dart` to automatically terminalize stale active switch manifests from previous launchers before initiating a new handoff.
  - Updated `sanad-dev doctor --fix` in `scripts/sanad_dev/runtime_commands.dart` to identify and repair orphaned active-status handoffs.
  - Added unit tests in `client/test/unit/scripts/sanad_dev_runtime_switch_test.dart`.
- **Documentation & Plan:**
  - Updated `docs/technical/agent_runtime.md` and `docs/technical/sanad_dev_runtime_ownership.md`.
  - Tracked task plan in `docs/plans/tasks/66-stale-runtime-switch-manifest-recovery.md`.

## Verification

| Check | Result |
|---|---|
| `cd agent && fvm dart analyze` | Pass (0 issues) |
| `cd client && fvm flutter analyze` | Pass (0 issues) |
| `cd agent && fvm dart test test/interfaces/interfaces_test.dart` | Pass (65 tests passed) |
| `cd client && fvm flutter test test/unit/scripts/` | Pass (122 tests passed) |

## Risk and compatibility

- **Cross-platform impact:** None. Pure Dart daemon logic and cross-platform sanad-dev scripts.
- **Security/privacy impact:** None.
- **Migration/rollback:** Clean rollback by reverting the commit.

## Documentation and presentation

- [x] I reviewed the nearest `AGENTS.md` contracts.
- [x] I updated the owning `docs/` page, or this change does not alter documented behavior/design.
- [x] I updated a durable contract only if its law, ownership boundary, or invariant changed.
- [x] I added screenshots or recordings for visible changes, or this change has no visible UI.

## Contributor checks

- [x] I searched for duplicate Discussions, Issues, and pull requests.
- [x] This pull request is focused on one coherent change.
- [x] The title follows Conventional Commits and is suitable as the squash commit message.
- [x] I did not include secrets, private deployment details, personal paths, or unredacted user data.
- [x] Fork-origin verification does not require repository secrets.