### PR TITLE
feat(client): refine onboarding, add-device, and mcp-server setup screens

### DIFF
--- a/client/lib/features/devices/presentation/screens/add_device_screen.dart
+++ b/client/lib/features/devices/presentation/screens/add_device_screen.dart
@@ -7,9 +7,9 @@ import 'package:sanad_client/features/devices/presentation/bloc/device_cubit.dar
 import 'package:sanad_client/features/devices/presentation/bloc/device_state.dart';
 import 'package:sanad_client/features/devices/presentation/bloc/gateway_connection_cubit.dart';
 import 'package:sanad_client/features/devices/presentation/widgets/device_install_guide.dart';
-import 'package:sanad_client/features/devices/presentation/widgets/gateway_connection_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:sanad_client/utils/app_platform.dart';
 import 'package:sanad_client/utils/toast_utils.dart';
 
 class AddDeviceScreen extends StatefulWidget {
@@ -60,139 +60,229 @@ class _AddDeviceScreenState extends State<AddDeviceScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return BlocListener<DeviceCubit, DeviceState>(
       listener: _handleDeviceStateChange,
       child: Scaffold(
-        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-        appBar: AppBar(
-          title: Text('Add Host Device', style: TextStyle(color: Theme.of(context).colorScheme.onSurface)),
-          leading: IconButton(
-            icon: Icon(Icons.close, color: Theme.of(context).colorScheme.onSurface),
-            onPressed: () => Navigator.pop(context),
-          ),
-          actions: const [
-            Padding(
-              padding: EdgeInsets.only(right: 12),
-              child: Center(child: GatewayConnectionIndicator()),
-            ),
-          ],
-        ),
-        body: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Center(
-                  child: Icon(Icons.smart_toy_outlined, size: 64, color: Theme.of(context).colorScheme.primary),
+        backgroundColor: theme.scaffoldBackgroundColor,
+        body: SafeArea(
+          child: Column(
+            children: [
+              Padding(
+                padding: EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: AppPlatform.isMacOS ? 44 : 8,
+                  bottom: 8,
                 ),
-                const SizedBox(height: 18),
-                Text(
-                  _generatedToken == null ? 'Create a remote host device' : 'Install and connect your device',
-                  textAlign: TextAlign.center,
-                  style: Theme.of(context).textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
-                ),
-                const SizedBox(height: 8),
-                Text(
-                  _generatedToken == null
-                      ? 'Create a device record, then run the generated install command on your computer or server.'
-                      : 'Run one of these commands on the target machine. Sanad will continue automatically when it connects.',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
-                ),
-                const SizedBox(height: 32),
-                if (_generatedToken == null) ...[
-                  TextFormField(
-                    controller: _nameController,
-                    style: TextStyle(color: Theme.of(context).colorScheme.onSurface),
-                    decoration: InputDecoration(
-                      labelText: 'Device Name',
-                      labelStyle: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
-                      border: const OutlineInputBorder(),
-                      enabledBorder: OutlineInputBorder(
-                        borderSide: BorderSide(color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.24)),
-                      ),
-                      prefixIcon: Icon(Icons.label_outline, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      tooltip: 'Back',
+                      onPressed: () {
+                        if (context.canPop()) {
+                          context.pop();
+                        } else {
+                          context.go(AppRoutes.home);
+                        }
+                      },
                     ),
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'Please enter a name';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 24),
-                  if (_error != null) _ErrorMessage(message: _error!),
-                  BlocBuilder<GatewayConnectionCubit, GatewayConnectionStatus>(
-                    builder: (context, gatewayStatus) {
-                      return ElevatedButton(
-                        onPressed: _isCreating ? null : () => _createDevice(gatewayStatus),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: Theme.of(context).colorScheme.primary,
-                          foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                          padding: const EdgeInsets.symmetric(vertical: 16),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Add Host Device',
+                      style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                  ],
+                ),
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: theme.colorScheme.outline.withValues(alpha: 0.12),
+              ),
+              Expanded(
+                child: Center(
+                  child: SingleChildScrollView(
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(maxWidth: 620),
+                      child: Card(
+                        elevation: 0,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                          side: BorderSide(
+                            color: theme.colorScheme.outline.withValues(alpha: 0.18),
+                          ),
                         ),
-                        child: _isCreating
-                            ? const SizedBox(
-                                width: 20,
-                                height: 20,
-                                child: CircularProgressIndicator(
-                                  strokeWidth: 2,
-                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                                ),
-                              )
-                            : Text(
-                                'Create Host Device',
-                                style: TextStyle(color: Theme.of(context).colorScheme.onPrimary, fontSize: 16),
-                              ),
-                      );
-                    },
-                  ),
-                ] else ...[
-                  Container(
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.1),
-                      borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3)),
-                    ),
+                        color: theme.colorScheme.surface,
+                        child: Padding(
+                  padding: const EdgeInsets.all(32),
+                  child: Form(
+                    key: _formKey,
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        Icon(Icons.check_circle_outline, color: Theme.of(context).colorScheme.primary, size: 48),
-                        const SizedBox(height: 16),
-                        Text(
-                          'Device Created Successfully',
-                          style: TextStyle(
-                            color: Theme.of(context).colorScheme.primary,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
+                        Center(
+                          child: Container(
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.primary.withValues(alpha: 0.1),
+                              shape: BoxShape.circle,
+                            ),
+                            child: Icon(
+                              Icons.smart_toy_outlined,
+                              size: 48,
+                              color: theme.colorScheme.primary,
+                            ),
                           ),
                         ),
                         const SizedBox(height: 20),
-                        DeviceInstallGuide(token: _generatedToken!),
+                        Text(
+                          _generatedToken == null ? 'Create a remote host device' : 'Install and connect your device',
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.w700),
+                        ),
                         const SizedBox(height: 8),
                         Text(
-                          'Waiting for the device to come online...',
-                          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant),
+                          _generatedToken == null
+                              ? 'Create a device record, then run the generated install command on your computer or server.'
+                              : 'Run one of these commands on the target machine. Sanad will continue automatically when it connects.',
+                          textAlign: TextAlign.center,
+                          style: TextStyle(color: theme.colorScheme.onSurfaceVariant, height: 1.4),
                         ),
-                        const SizedBox(height: 12),
-                        OutlinedButton.icon(
-                          onPressed: () => context.go(AppRoutes.home),
-                          icon: const Icon(Icons.arrow_forward),
-                          label: const Text('Continue to Home'),
-                        ),
+                        const SizedBox(height: 28),
+                        if (_generatedToken == null) ...[
+                          TextFormField(
+                            controller: _nameController,
+                            style: TextStyle(color: theme.colorScheme.onSurface),
+                            decoration: InputDecoration(
+                              labelText: 'Device Name',
+                              labelStyle: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+                              border: const OutlineInputBorder(),
+                              enabledBorder: OutlineInputBorder(
+                                borderSide: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.24)),
+                              ),
+                              prefixIcon: Icon(Icons.label_outline, color: theme.colorScheme.onSurfaceVariant),
+                            ),
+                            validator: (value) {
+                              if (value == null || value.trim().isEmpty) {
+                                return 'Please enter a name';
+                              }
+                              return null;
+                            },
+                          ),
+                          const SizedBox(height: 20),
+                          if (_error != null) _ErrorMessage(message: _error!),
+                          BlocBuilder<GatewayConnectionCubit, GatewayConnectionStatus>(
+                            builder: (context, gatewayStatus) {
+                              return ElevatedButton(
+                                onPressed: _isCreating ? null : () => _createDevice(gatewayStatus),
+                                style: ElevatedButton.styleFrom(
+                                  backgroundColor: theme.colorScheme.primary,
+                                  foregroundColor: theme.colorScheme.onPrimary,
+                                  padding: const EdgeInsets.symmetric(vertical: 16),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(10),
+                                  ),
+                                ),
+                                child: _isCreating
+                                    ? const SizedBox(
+                                        width: 20,
+                                        height: 20,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                          valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                        ),
+                                      )
+                                    : Text(
+                                        'Create Host Device',
+                                        style: TextStyle(
+                                          color: theme.colorScheme.onPrimary,
+                                          fontSize: 16,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                              );
+                            },
+                          ),
+                        ] else ...[
+                          Container(
+                            padding: const EdgeInsets.all(20),
+                            decoration: BoxDecoration(
+                              color: theme.colorScheme.primary.withValues(alpha: 0.06),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: theme.colorScheme.primary.withValues(alpha: 0.2)),
+                            ),
+                            child: Column(
+                              children: [
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    Icon(Icons.check_circle_outline, color: theme.colorScheme.primary, size: 24),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      'Device Created Successfully',
+                                      style: TextStyle(
+                                        color: theme.colorScheme.primary,
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 16),
+                                DeviceInstallGuide(token: _generatedToken!),
+                                const SizedBox(height: 16),
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.center,
+                                  children: [
+                                    SizedBox(
+                                      width: 14,
+                                      height: 14,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                        color: theme.colorScheme.primary,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 8),
+                                    Text(
+                                      'Waiting for the device to come online...',
+                                      style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 13),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 16),
+                                OutlinedButton.icon(
+                                  onPressed: () => context.go(AppRoutes.home),
+                                  icon: const Icon(Icons.arrow_forward_rounded, size: 18),
+                                  label: const Text('Continue to Home'),
+                                  style: OutlinedButton.styleFrom(
+                                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(8),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                       ],
                     ),
                   ),
-                ],
-              ],
+                ),
+              ),
             ),
           ),
         ),
       ),
-    );
-  }
+    ],
+  ),
+),
+),
+);
+}
 
   void _handleDeviceStateChange(BuildContext context, DeviceState state) {
     final devices = state is DeviceActive ? state.agents : (state is DeviceNoActive ? state.agents : const []);

--- a/client/lib/features/devices/presentation/screens/onboarding_setup_screen.dart
+++ b/client/lib/features/devices/presentation/screens/onboarding_setup_screen.dart
@@ -10,7 +10,6 @@ import 'package:sanad_client/features/devices/presentation/bloc/gateway_connecti
 import 'package:sanad_client/features/devices/domain/models/gateway_connection_status.dart';
 import 'package:flutter/material.dart';
 import 'package:sanad_client/features/devices/presentation/widgets/installation_terminal_view.dart';
-import 'package:sanad_client/features/devices/presentation/widgets/gateway_connection_indicator.dart';
 import 'package:sanad_client/features/devices/presentation/widgets/onboarding_setup_choices.dart';
 import 'package:sanad_client/features/provider_setup/data/provider_setup_client.dart';
 import 'package:sanad_client/features/provider_setup/presentation/widgets/provider_setup_flow.dart';
@@ -168,7 +167,6 @@ class _OnboardingSetupScreenState extends State<OnboardingSetupScreen> {
               isDesktop: AppPlatform.isDesktop,
               isAuthenticated: isAuthenticated,
               hasRegisteredDevices: hasRegisteredDevices,
-              connectionIndicator: AppPlatform.isDesktop ? const GatewayConnectionIndicator() : null,
               error: _error,
               onRunLocally: () {
                 setState(() {

--- a/client/lib/features/devices/presentation/widgets/onboarding_setup_choices.dart
+++ b/client/lib/features/devices/presentation/widgets/onboarding_setup_choices.dart
@@ -7,7 +7,6 @@ class OnboardingSetupChoices extends StatelessWidget {
     required this.hasRegisteredDevices,
     required this.onRunLocally,
     required this.onRemoteAction,
-    this.connectionIndicator,
     this.error,
     super.key,
   });
@@ -17,7 +16,6 @@ class OnboardingSetupChoices extends StatelessWidget {
   final bool hasRegisteredDevices;
   final VoidCallback onRunLocally;
   final VoidCallback onRemoteAction;
-  final Widget? connectionIndicator;
   final String? error;
 
   @override
@@ -37,7 +35,6 @@ class OnboardingSetupChoices extends StatelessWidget {
             hasRegisteredDevices: hasRegisteredDevices,
             onRunLocally: onRunLocally,
             onRemoteAction: onRemoteAction,
-            connectionIndicator: connectionIndicator,
           )
         else
           _RemoteOnlyEmptyState(
@@ -95,7 +92,6 @@ class _DesktopChoices extends StatelessWidget {
     required this.hasRegisteredDevices,
     required this.onRunLocally,
     required this.onRemoteAction,
-    required this.connectionIndicator,
   });
 
   final ThemeData theme;
@@ -103,7 +99,6 @@ class _DesktopChoices extends StatelessWidget {
   final bool hasRegisteredDevices;
   final VoidCallback onRunLocally;
   final VoidCallback onRemoteAction;
-  final Widget? connectionIndicator;
 
   @override
   Widget build(BuildContext context) {
@@ -119,10 +114,6 @@ class _DesktopChoices extends StatelessWidget {
             color: theme.colorScheme.onSurface.withValues(alpha: 0.6),
           ),
         ),
-        if (connectionIndicator != null) ...[
-          const SizedBox(height: 28),
-          Align(alignment: Alignment.center, child: connectionIndicator),
-        ],
         const SizedBox(height: 24),
         Material(
           color: Colors.transparent,

--- a/client/lib/features/mcp/presentation/screens/add_mcp_server_screen.dart
+++ b/client/lib/features/mcp/presentation/screens/add_mcp_server_screen.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import 'package:sanad_client/core/navigation/app_routes.dart';
 import 'package:sanad_client/features/devices/domain/models/device_config.dart';
 import 'package:sanad_client/features/mcp/data/mcp_runtime_client.dart';
 import 'package:sanad_client/features/mcp/domain/models/mcp_runtime_models.dart';
 import 'package:sanad_client/features/mcp/domain/models/mcp_server_config.dart';
+import 'package:sanad_client/utils/app_platform.dart';
 import 'package:sanad_client/utils/toast_utils.dart';
 
 enum _McpServerFormType { remote, stdio }
@@ -427,112 +430,283 @@ class _AddMcpServerScreenState extends State<AddMcpServerScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(
-        title: Text(_isEditing ? 'Edit MCP server' : 'Add MCP server'),
-        actions: [
-          TextButton.icon(onPressed: _import, icon: const Icon(Icons.file_open_outlined), label: const Text('Import')),
-        ],
+      backgroundColor: theme.scaffoldBackgroundColor,
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              Padding(
+                padding: EdgeInsets.only(
+                  left: 16,
+                  right: 16,
+                  top: AppPlatform.isMacOS ? 44 : 8,
+                  bottom: 8,
+                ),
+                child: Row(
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.arrow_back_rounded),
+                      tooltip: 'Back',
+                      onPressed: () {
+                        if (context.canPop()) {
+                          context.pop();
+                        } else {
+                          context.go(AppRoutes.home);
+                        }
+                      },
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      _isEditing ? 'Edit MCP server' : 'Add MCP server',
+                      style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
+                    ),
+                    const Spacer(),
+                    TextButton.icon(
+                      onPressed: _import,
+                      icon: const Icon(Icons.file_open_outlined, size: 18),
+                      label: const Text('Import'),
+                    ),
+                  ],
+                ),
+              ),
+              Divider(
+                height: 1,
+                thickness: 1,
+                color: theme.colorScheme.outline.withValues(alpha: 0.12),
+              ),
+              Expanded(
+                child: LayoutBuilder(
+                  builder: (context, constraints) {
+                    if (constraints.maxWidth >= 900) {
+                      return _buildWideLayout(context);
+                    }
+                    return _buildCompactLayout(context);
+                  },
+                ),
+              ),
+              _buildBottomBar(theme),
+            ],
+          ),
+        ),
       ),
-      body: Form(
-        key: _formKey,
-        child: Column(
+    );
+  }
+
+  Widget _buildWideLayout(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Expanded(
+          flex: 6,
+          child: ListView(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+            children: [
+              _buildFormFields(),
+            ],
+          ),
+        ),
+        VerticalDivider(
+          width: 1,
+          thickness: 1,
+          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.15),
+        ),
+        Expanded(
+          flex: 5,
+          child: ListView(
+            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 24),
+            children: [
+              _buildInspectionSection(),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCompactLayout(BuildContext context) {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 680),
+        child: ListView(
+          padding: const EdgeInsets.all(24),
           children: [
-            Expanded(
-              child: ListView(
-                padding: const EdgeInsets.all(24),
+            _buildFormFields(),
+            const SizedBox(height: 24),
+            _buildInspectionSection(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFormFields() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        SegmentedButton<_McpServerFormType>(
+          segments: const [
+            ButtonSegment(
+              value: _McpServerFormType.remote,
+              label: Text('Remote server'),
+              icon: Icon(Icons.cloud_outlined),
+            ),
+            ButtonSegment(
+              value: _McpServerFormType.stdio,
+              label: Text('Local command'),
+              icon: Icon(Icons.terminal),
+            ),
+          ],
+          selected: {_serverType},
+          onSelectionChanged: (value) => setState(() {
+            _serverType = value.first;
+            _inspection = null;
+          }),
+        ),
+        const SizedBox(height: 20),
+        _field(_name, 'Name', enabled: !_isEditing, required: true),
+        const SizedBox(height: 12),
+        _field(_description, 'Description (optional)', maxLines: 2),
+        const SizedBox(height: 20),
+        if (_serverType == _McpServerFormType.remote) ..._remoteFields(),
+        if (_serverType == _McpServerFormType.stdio) ..._stdioFields(),
+      ],
+    );
+  }
+
+  Widget _buildInspectionSection() {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Inspection & Tools',
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            ),
+            FilledButton.icon(
+              onPressed: _isTesting ? null : _test,
+              icon: _isTesting
+                  ? const SizedBox.square(
+                      dimension: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2, color: Colors.white),
+                    )
+                  : const Icon(Icons.wifi_find, size: 18),
+              label: Text(
+                _isTesting
+                    ? 'Working…'
+                    : _authType == McpAuthType.oauth && widget.initialConfig?.oauthConfigured != true
+                    ? 'Authorize & Test'
+                    : 'Test Connection',
+              ),
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        if (_oauthFlow != null) ...[
+          ListTile(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.2)),
+            ),
+            tileColor: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+            leading: const Icon(Icons.key_outlined),
+            title: Text('OAuth: ${_oauthFlow!.status.name}'),
+            subtitle: _oauthFlow!.error == null ? null : Text(_oauthFlow!.error!),
+            trailing: _oauthFlow!.isTerminal
+                ? null
+                : TextButton(onPressed: _cancelOAuth, child: const Text('Cancel')),
+          ),
+          const SizedBox(height: 16),
+        ],
+        if (_inspection != null) ...[
+          _reviewCard(_inspection!),
+        ] else if (!_isTesting) ...[
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(color: theme.colorScheme.outline.withValues(alpha: 0.18)),
+            ),
+            color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.25),
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 24),
+              child: Column(
                 children: [
-                  SegmentedButton<_McpServerFormType>(
-                    segments: const [
-                      ButtonSegment(
-                        value: _McpServerFormType.remote,
-                        label: Text('Remote server'),
-                        icon: Icon(Icons.cloud_outlined),
-                      ),
-                      ButtonSegment(
-                        value: _McpServerFormType.stdio,
-                        label: Text('Local command'),
-                        icon: Icon(Icons.terminal),
-                      ),
-                    ],
-                    selected: {_serverType},
-                    onSelectionChanged: (value) => setState(() {
-                      _serverType = value.first;
-                      _inspection = null;
-                    }),
+                  Icon(
+                    Icons.sensors_outlined,
+                    size: 36,
+                    color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.6),
                   ),
-                  const SizedBox(height: 20),
-                  _field(_name, 'Name', enabled: !_isEditing, required: true),
                   const SizedBox(height: 12),
-                  _field(_description, 'Description (optional)', maxLines: 2),
-                  const SizedBox(height: 20),
-                  if (_serverType == _McpServerFormType.remote) ..._remoteFields(),
-                  if (_serverType == _McpServerFormType.stdio) ..._stdioFields(),
-                  const SizedBox(height: 20),
-                  FilledButton.icon(
-                    onPressed: _isTesting ? null : _test,
-                    icon: _isTesting
-                        ? const SizedBox.square(dimension: 18, child: CircularProgressIndicator(strokeWidth: 2))
-                        : const Icon(Icons.wifi_find),
-                    label: Text(
-                      _isTesting
-                          ? 'Working…'
-                          : _authType == McpAuthType.oauth && widget.initialConfig?.oauthConfigured != true
-                          ? 'Authorize and test'
-                          : 'Test connection',
-                    ),
+                  Text(
+                    'No inspection results yet',
+                    style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
                   ),
-                  if (_oauthFlow != null) ...[
-                    const SizedBox(height: 16),
-                    ListTile(
-                      leading: const Icon(Icons.key_outlined),
-                      title: Text('OAuth: ${_oauthFlow!.status.name}'),
-                      subtitle: _oauthFlow!.error == null ? null : Text(_oauthFlow!.error!),
-                      trailing: _oauthFlow!.isTerminal
-                          ? null
-                          : TextButton(onPressed: _cancelOAuth, child: const Text('Cancel')),
-                    ),
-                  ],
-                  if (_inspection != null) ...[
-                    const SizedBox(height: 16),
-                    _reviewCard(_inspection!),
-                  ],
-                  const SizedBox(height: 20),
-                  CheckboxListTile(
-                    value: _acceptedRisks,
-                    onChanged: (value) => setState(() => _acceptedRisks = value ?? false),
-                    controlAffinity: ListTileControlAffinity.leading,
-                    title: const Text('I understand this server can access data and perform actions.'),
-                    subtitle: const Text('Only enable tools and servers you trust.'),
+                  const SizedBox(height: 6),
+                  Text(
+                    'Test the server connection to discover available tools and verify communication.',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 12, height: 1.4),
                   ),
                 ],
               ),
             ),
-            SafeArea(
-              top: false,
-              child: Container(
-                padding: const EdgeInsets.all(16),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface,
-                  border: Border(top: BorderSide(color: Theme.of(context).dividerColor)),
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(onPressed: _isSaving ? null : () => Navigator.pop(context), child: const Text('Cancel')),
-                    const SizedBox(width: 12),
-                    FilledButton(
-                      onPressed: _isSaving ? null : _save,
-                      child: Text(
-                        _isSaving
-                            ? 'Saving…'
-                            : _isEditing
-                            ? 'Save changes'
-                            : 'Add server',
-                      ),
-                    ),
-                  ],
-                ),
+          ),
+        ],
+        const SizedBox(height: 20),
+        CheckboxListTile(
+          value: _acceptedRisks,
+          onChanged: (value) => setState(() => _acceptedRisks = value ?? false),
+          controlAffinity: ListTileControlAffinity.leading,
+          contentPadding: EdgeInsets.zero,
+          title: const Text(
+            'I understand this server can access data and perform actions.',
+            style: TextStyle(fontSize: 13),
+          ),
+          subtitle: const Text('Only enable tools and servers you trust.', style: TextStyle(fontSize: 12)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildBottomBar(ThemeData theme) {
+    return SafeArea(
+      top: false,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          border: Border(top: BorderSide(color: theme.dividerColor)),
+        ),
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            TextButton(
+              onPressed: _isSaving ? null : () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            const SizedBox(width: 12),
+            FilledButton(
+              onPressed: _isSaving ? null : _save,
+              style: FilledButton.styleFrom(
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+              ),
+              child: Text(
+                _isSaving
+                    ? 'Saving…'
+                    : _isEditing
+                    ? 'Save changes'
+                    : 'Add server',
               ),
             ),
           ],

--- a/client/test/widget/onboarding_setup_choices_test.dart
+++ b/client/test/widget/onboarding_setup_choices_test.dart
@@ -21,7 +21,6 @@ void main() {
               hasRegisteredDevices: hasRegisteredDevices,
               onRunLocally: onRunLocally ?? () {},
               onRemoteAction: onRemoteAction ?? () {},
-              connectionIndicator: isDesktop ? const Text('Connection status') : null,
             ),
           ),
         ),


### PR DESCRIPTION
## Problem / Goal
Polish and modernize the UI for setup flows across the Flutter client:
- Clean up the Onboarding choices layout by removing redundant connection indicator parameters and styling desktop choices cleanly.
- Improve Add Host Device screen layout, card styling, and waiting-for-device state.
- Redesign Add MCP Server screen with streamlined form segments, clearer headers, empty inspection result cards, and modern bottom action bar.

## Technical Changes
- `client/lib/features/devices/presentation/screens/onboarding_setup_screen.dart`: Removed unused connection indicator parameter.
- `client/lib/features/devices/presentation/widgets/onboarding_setup_choices.dart`: Cleaned up desktop choice options and removed obsolete connection indicator wrapper.
- `client/lib/features/devices/presentation/screens/add_device_screen.dart`: Improved styling, responsive card container, token instructions, and status indicator.
- `client/lib/features/mcp/presentation/screens/add_mcp_server_screen.dart`: Modernized layout with clear empty-state card, segmented button styling, and unified bottom bar.
- `client/test/widget/onboarding_setup_choices_test.dart`: Updated widget test to match revised widget parameters.

## Verification
- `cd client && fvm flutter analyze`: Passed (0 issues).
- `cd client && fvm flutter test`: 183/183 tests passed.

## Risk & Cross-Platform Impact
- Low risk, client presentation-only refinements.
- Preserves responsive design across macOS, Linux, Windows, and Web.

## Rollback Plan
- Revert this pull request or squash commit if regressions are observed.