### PR TITLE
fix(client): display verified user profile names

### DIFF
--- a/client/lib/features/auth/AGENTS.md
+++ b/client/lib/features/auth/AGENTS.md
@@ -8,6 +8,7 @@ This contract applies to `client/lib/features/auth/`.
 - Do not call backend `/api/auth/*` endpoints from this feature.
 - Do not mention identity-provider names, portal flow identifiers, or `{provider}` in auth feature contracts or payload construction; the portal chooses provider and flow.
 - `backendUrl` is available only for authenticated REST and Socket.IO traffic after access-token acquisition.
+- Preserve the authenticated profile's technical `username` separately from its human-facing `display_name`. Presentation prefers a non-empty display name and falls back to username for legacy accounts or servers.
 
 ## Authentication Flow
 - `AuthService.login()` sends platform and non-sensitive capabilities to `PortalAuthClient`, opens the returned portal URL, polls through the portal client, and stores tokens only after completion.

--- a/client/lib/features/auth/data/auth_repository_impl.dart
+++ b/client/lib/features/auth/data/auth_repository_impl.dart
@@ -55,6 +55,7 @@ class AuthRepositoryImpl implements IAuthRepository {
 
     return AuthSession(
       username: _authService.username ?? 'User',
+      displayName: _authService.displayName ?? _authService.username ?? 'User',
       email: _authService.email ?? '',
       userId: _authService.userId ?? '',
       accessToken: accessToken,

--- a/client/lib/features/auth/domain/auth_session.dart
+++ b/client/lib/features/auth/domain/auth_session.dart
@@ -1,5 +1,6 @@
 class AuthSession {
   final String username;
+  final String displayName;
   final String email;
   final String userId;
   final String accessToken;
@@ -8,6 +9,7 @@ class AuthSession {
 
   const AuthSession({
     required this.username,
+    required this.displayName,
     required this.email,
     required this.userId,
     required this.accessToken,

--- a/client/lib/features/auth/domain/user_display_name.dart
+++ b/client/lib/features/auth/domain/user_display_name.dart
@@ -1,0 +1,4 @@
+String resolveUserDisplayName({required String username, Object? displayName}) {
+  final normalizedDisplayName = displayName?.toString().trim() ?? '';
+  return normalizedDisplayName.isNotEmpty ? normalizedDisplayName : username;
+}

--- a/client/lib/features/auth/infrastructure/auth_service.dart
+++ b/client/lib/features/auth/infrastructure/auth_service.dart
@@ -14,6 +14,7 @@ import 'package:sanad_client/infrastructure/web_auth_popup_service_stub.dart'
     if (dart.library.html) 'package:sanad_client/infrastructure/web_auth_popup_service.dart';
 import 'package:sanad_client/features/auth/domain/auth_refresh_result.dart';
 import 'package:sanad_client/features/auth/infrastructure/portal_auth_client.dart';
+import 'package:sanad_client/features/auth/domain/user_display_name.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class AuthLoginChallenge {
@@ -52,6 +53,7 @@ class AuthService {
   String? _activeAuthSessionId;
   String? _activePollingToken;
   String? username;
+  String? displayName;
   String? email;
   String? userId;
 
@@ -277,6 +279,7 @@ class AuthService {
       await prefs.remove('backend_access_token');
       await prefs.remove('backend_refresh_token');
       username = null;
+      displayName = null;
       email = null;
       userId = null;
       userCredits = 0.0;
@@ -521,6 +524,7 @@ class AuthService {
     _backendRefreshToken = null;
     userCredits = 0.0;
     username = null;
+    displayName = null;
     email = null;
     userId = null;
 
@@ -707,10 +711,18 @@ class AuthService {
       );
       final data = response.data;
 
-      if (data['user'] != null) {
-        username = data['user']['username'];
-        email = data['user']['email'];
-        userId = data['user']['id']?.toString();
+      final user = data['user'];
+      if (user is Map) {
+        final profileUsername = user['username']?.toString().trim() ?? '';
+        if (profileUsername.isNotEmpty) {
+          username = profileUsername;
+          displayName = resolveUserDisplayName(
+            username: profileUsername,
+            displayName: user['display_name'],
+          );
+        }
+        email = user['email']?.toString();
+        userId = user['id']?.toString();
       }
 
       if (data['credits'] != null) {

--- a/client/lib/features/auth/presentation/bloc/auth_cubit.dart
+++ b/client/lib/features/auth/presentation/bloc/auth_cubit.dart
@@ -89,6 +89,7 @@ class AuthCubit extends Cubit<AuthState> {
   AuthAuthenticated _authenticated(AuthSession session) {
     return AuthAuthenticated(
       username: session.username,
+      displayName: session.displayName,
       email: session.email,
       userId: session.userId,
       accessToken: session.accessToken,

--- a/client/lib/features/auth/presentation/bloc/auth_state.dart
+++ b/client/lib/features/auth/presentation/bloc/auth_state.dart
@@ -13,6 +13,7 @@ class AuthLoading extends AuthState {}
 
 class AuthAuthenticated extends AuthState {
   final String username;
+  final String displayName;
   final String email;
   final String userId;
   final String accessToken;
@@ -21,18 +22,28 @@ class AuthAuthenticated extends AuthState {
 
   const AuthAuthenticated({
     required this.username,
+    String? displayName,
     required this.email,
     required this.userId,
     required this.accessToken,
     required this.userCredits,
     required this.totalCredits,
-  });
+  }) : displayName = displayName ?? username;
 
   @override
-  List<Object?> get props => [username, email, userId, accessToken, userCredits, totalCredits];
+  List<Object?> get props => [
+    username,
+    displayName,
+    email,
+    userId,
+    accessToken,
+    userCredits,
+    totalCredits,
+  ];
 
   AuthAuthenticated copyWith({
     String? username,
+    String? displayName,
     String? email,
     String? userId,
     String? accessToken,
@@ -41,6 +52,7 @@ class AuthAuthenticated extends AuthState {
   }) {
     return AuthAuthenticated(
       username: username ?? this.username,
+      displayName: displayName ?? this.displayName,
       email: email ?? this.email,
       userId: userId ?? this.userId,
       accessToken: accessToken ?? this.accessToken,

--- a/client/lib/features/auth/presentation/widgets/user_profile_tile.dart
+++ b/client/lib/features/auth/presentation/widgets/user_profile_tile.dart
@@ -16,7 +16,7 @@ class UserProfileTile extends StatelessWidget {
         final bool isAuthenticated = authState is AuthAuthenticated;
         final String displayName;
         if (isAuthenticated) {
-          displayName = authState.username;
+          displayName = authState.displayName;
         } else if (authState is AuthLoading) {
           displayName = 'Signing in...';
         } else {

--- a/client/lib/features/settings/presentation/widgets/settings_pages.dart
+++ b/client/lib/features/settings/presentation/widgets/settings_pages.dart
@@ -37,11 +37,13 @@ class ProfilePage extends StatelessWidget {
                 children: [
                   CircleAvatar(
                     radius: 28,
-                    child: Text(auth.username.characters.first.toUpperCase()),
+                    child: Text(
+                      auth.displayName.characters.first.toUpperCase(),
+                    ),
                   ),
                   const SizedBox(height: 16),
                   Text(
-                    auth.username,
+                    auth.displayName,
                     style: Theme.of(context).textTheme.titleLarge,
                   ),
                   Text(

--- a/client/test/unit/auth/user_display_name_test.dart
+++ b/client/test/unit/auth/user_display_name_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/auth/domain/user_display_name.dart';
+
+void main() {
+  test('prefers the human-facing profile name', () {
+    expect(
+      resolveUserDisplayName(
+        username: 'ahmedattia',
+        displayName: ' Ahmed Attia ',
+      ),
+      'Ahmed Attia',
+    );
+  });
+
+  test('falls back to username for legacy or empty profiles', () {
+    expect(resolveUserDisplayName(username: 'ahmedattia'), 'ahmedattia');
+    expect(
+      resolveUserDisplayName(username: 'ahmedattia', displayName: '  '),
+      'ahmedattia',
+    );
+  });
+}

--- a/client/test/unit/bloc/auth_cubit_flow_test.dart
+++ b/client/test/unit/bloc/auth_cubit_flow_test.dart
@@ -16,6 +16,8 @@ void main() {
     final authenticated = cubit.state as AuthAuthenticated;
     expect(authenticated.accessToken, 'access-token');
     expect(authenticated.userId, 'user-1');
+    expect(authenticated.username, 'ahmedattia');
+    expect(authenticated.displayName, 'Ahmed Attia');
 
     await cubit.logout();
     expect(cubit.state, isA<AuthUnauthenticated>());
@@ -71,7 +73,8 @@ class _FakeAuthRepository implements IAuthRepository {
 
   @override
   Future<AuthSession?> login() async => const AuthSession(
-    username: 'Test User',
+    username: 'ahmedattia',
+    displayName: 'Ahmed Attia',
     email: 'test@example.com',
     userId: 'user-1',
     accessToken: 'access-token',

--- a/docs/technical/client_authentication.md
+++ b/docs/technical/client_authentication.md
@@ -21,6 +21,11 @@ client consumes only the resulting Sanad authentication lifecycle.
 After authentication completes, the backend gateway is used only as an
 authenticated application transport.
 
+The authenticated profile keeps the unique technical `username` separate from
+the optional human-facing `display_name`. Flutter presents `display_name` when
+it is non-empty and falls back to `username` so older accounts and older hosted
+profiles remain compatible.
+
 ## Public Lifecycle
 
 1. The client sends platform identity plus non-sensitive capabilities to the


### PR DESCRIPTION
## Summary
- keep the authenticated technical username separate from the human-facing display name
- prefer display_name in the sidebar and Profile settings with a legacy username fallback
- preserve source compatibility for existing authenticated-state constructors
- document the profile projection contract

## Verification
- fvm flutter analyze: no issues
- focused authentication/navigation tests: 20 passed
- full fast Flutter suite: 968 passed, 1 skipped