### PR TITLE
feat(client,agent): improve skill load presentation, add markdown view toggle, and fix status bar worktree layout

### DIFF
--- a/agent/e2e_test/local_skill_load_e2e_test.dart
+++ b/agent/e2e_test/local_skill_load_e2e_test.dart
@@ -163,8 +163,11 @@ Use the review skill for workspace audits.
         toolResultFrame!['payload'] as Map,
       );
       final toolOutput = toolResultPayload['output']?.toString() ?? '';
-      expect(toolOutput, contains('"skill": "review"'));
-      expect(toolOutput, contains('"args": "--focus docs"'));
+      expect(toolOutput, startsWith('Skill source: '));
+      expect(
+        toolOutput,
+        contains('/workspace/.sanad/skills/review/SKILL.md\n\n'),
+      );
       expect(
         toolOutput,
         contains('Use the review skill for workspace audits.'),

--- a/agent/lib/capabilities/runtime/local_runtime_catalog.dart
+++ b/agent/lib/capabilities/runtime/local_runtime_catalog.dart
@@ -306,7 +306,6 @@ class LocalRuntimeCatalog {
           'type': 'object',
           'properties': {
             'skill': {'type': 'string'},
-            'args': {'type': 'string'},
           },
           'required': ['skill'],
           'additionalProperties': false,
@@ -320,10 +319,8 @@ class LocalRuntimeCatalog {
       ),
       onExecute: (args, {context}) async {
         final skill = args['skill']?.toString() ?? '';
-        final extra = args['args']?.toString();
         return _workspaceRuntimeService.loadSkill(
           skill: skill,
-          args: extra,
           workspacePath: workspacePath,
         );
       },

--- a/agent/lib/capabilities/skills/skill_load_service.dart
+++ b/agent/lib/capabilities/skills/skill_load_service.dart
@@ -1,8 +1,8 @@
-import 'dart:convert';
-
 import 'skill_registry.dart';
 
 class SkillLoadService {
+  static const sourcePrefix = 'Skill source: ';
+
   final Map<String, String>? _environment;
   final SkillRegistry? _registry;
 
@@ -12,11 +12,7 @@ class SkillLoadService {
   }) : _environment = environment,
        _registry = registry;
 
-  Future<String> load({
-    required String skill,
-    String? args,
-    String? workspacePath,
-  }) async {
+  Future<String> load({required String skill, String? workspacePath}) async {
     final resolved =
         await (_registry ?? SkillRegistry(environment: _environment)).resolve(
           skill: skill,
@@ -26,48 +22,6 @@ class SkillLoadService {
       throw Exception('Unknown skill: ${skill.trim()}');
     }
 
-    final payload = <String, dynamic>{
-      'skill': skill,
-      'path': resolved.sourcePath,
-      if (resolved.description != null) 'description': resolved.description,
-      'prompt': resolved.prompt,
-      'origin': resolved.origin.toJson(),
-    };
-
-    final metadata = _compactMetadata(
-      resolved.metadata.toJson(),
-      name: resolved.name,
-      description: resolved.description,
-    );
-    if (metadata.isNotEmpty) {
-      payload['metadata'] = metadata;
-    }
-
-    if (resolved.shadowedMatches.isNotEmpty) {
-      payload['shadowed_matches'] = resolved.shadowedMatches
-          .map((match) => match.toSummaryJson())
-          .toList(growable: false);
-    }
-    if (args != null && args.trim().isNotEmpty) {
-      payload['args'] = args.trim();
-    }
-
-    return const JsonEncoder.withIndent('  ').convert(payload);
-  }
-
-  Map<String, dynamic> _compactMetadata(
-    Map<String, dynamic> metadata, {
-    required String? name,
-    required String? description,
-  }) {
-    final compact = Map<String, dynamic>.from(metadata);
-    compact.remove('raw');
-    if (compact['name'] == name) {
-      compact.remove('name');
-    }
-    if (compact['description'] == description) {
-      compact.remove('description');
-    }
-    return compact;
+    return '$sourcePrefix${resolved.sourcePath}\n\n${resolved.prompt}';
   }
 }

--- a/agent/lib/engine/adapters/e2e_fixture_adapter.dart
+++ b/agent/lib/engine/adapters/e2e_fixture_adapter.dart
@@ -78,7 +78,7 @@ class E2eFixtureAdapter implements LLMAdapter {
               ToolCall(
                 id: skillLoadToolCallId,
                 name: skillLoadToolName,
-                arguments: const {'skill': 'review', 'args': '--focus docs'},
+                arguments: const {'skill': 'review'},
               ),
             ],
           ),

--- a/agent/lib/interfaces/runtime/local_workspace_runtime_service.dart
+++ b/agent/lib/interfaces/runtime/local_workspace_runtime_service.dart
@@ -775,7 +775,6 @@ class LocalWorkspaceRuntimeService {
 
   Future<String> loadSkill({
     required String skill,
-    String? args,
     String? workspaceId,
     String? workspacePath,
   }) async {
@@ -784,7 +783,6 @@ class LocalWorkspaceRuntimeService {
         (workspaceId == null ? null : await _resolveWorkspacePath(workspaceId));
     return _skillLoadService.load(
       skill: skill,
-      args: args,
       workspacePath: resolvedWorkspacePath,
     );
   }

--- a/agent/test/capabilities/runtime_catalog_test.dart
+++ b/agent/test/capabilities/runtime_catalog_test.dart
@@ -314,14 +314,24 @@ Use the review skill.''');
         );
         registry.registerTools(tools);
 
+        final skillSpec = registry.getSpec('skill_load')!;
+        final properties = Map<String, dynamic>.from(
+          skillSpec.inputSchema['properties'] as Map,
+        );
+        expect(properties.keys, equals(['skill']));
+
         final payload = await registry.getTool('skill_load')!.execute({
           'skill': 'review',
-          'args': '--focus docs',
         });
 
-        expect(payload, contains('"skill": "review"'));
-        expect(payload, contains('"args": "--focus docs"'));
+        expect(payload, startsWith('Skill source: '));
+        expect(
+          payload,
+          contains('/workspace/.sanad/skills/review/SKILL.md\n\n'),
+        );
         expect(payload, contains('Use the review skill.'));
+        expect(payload, isNot(contains('"origin"')));
+        expect(payload, isNot(contains('"metadata"')));
 
         final slashCommands = await workspaceRuntimeService.searchSlashCommands(
           query: 'review',

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -14,6 +14,7 @@ import 'package:sanad_client/features/conversations/presentation/widgets/tools/t
 import 'package:sanad_client/features/conversations/presentation/widgets/tools/web_tool_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/tools/ask_user_tool_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/tools/generic_tool_tile.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/tools/skill_load_tool_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/user_message_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/app_markdown_renderer.dart';
 
@@ -569,11 +570,11 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
         return WebToolTile(event: widget.event);
       case 'Ask':
         return AskUserToolTile(event: widget.event);
-      // todo : They have been suspended until the UI is fixed.
+      case 'Skill Load':
+        return SkillLoadToolTile(event: widget.event);
+      // todo : Memory presentation remains suspended until its UI is fixed.
       // case 'Memory':
       //   return MemoryToolTile(event: widget.event);
-      // case 'Skill Load':
-      //   return SkillLoadToolTile(event: widget.event);
       default:
         return GenericToolTile(event: widget.event);
     }

--- a/client/lib/features/conversations/presentation/widgets/tools/file_tool_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/tools/file_tool_tile.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
@@ -15,6 +16,8 @@ import 'package:diff_match_patch/diff_match_patch.dart';
 import 'package:sanad_client/shared/widgets/file_extension_icon.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/session_messages_cubit.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/app_markdown_renderer.dart';
+import 'package:sanad_client/utils/link_utils.dart';
 
 class FileToolTile extends StatefulWidget {
   final CanonicalEvent event;
@@ -31,6 +34,8 @@ class FileToolTile extends StatefulWidget {
 }
 
 class _FileToolTileState extends State<FileToolTile> {
+  static const double _readViewportHeight = 350;
+
   static final Highlight _highlight = Highlight()
     ..registerLanguage('dart', langDart)
     ..registerLanguage('json', langJson)
@@ -46,6 +51,7 @@ class _FileToolTileState extends State<FileToolTile> {
   TextSpan? _cachedCodeBlockSpan;
   final Map<String, List<TextSpan>> _highlightCache = {};
   static final Set<String> _loggedEvents = {};
+  bool _showMarkdown = true;
 
   @override
   void didChangeDependencies() {
@@ -60,6 +66,9 @@ class _FileToolTileState extends State<FileToolTile> {
   @override
   void didUpdateWidget(covariant FileToolTile oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (widget.event.id != oldWidget.event.id) {
+      _showMarkdown = true;
+    }
     if (widget.event.id != oldWidget.event.id ||
         widget.event.toolOutput != oldWidget.event.toolOutput ||
         widget.isFullyExpanded != oldWidget.isFullyExpanded) {
@@ -311,20 +320,110 @@ class _FileToolTileState extends State<FileToolTile> {
       startLine = (int.tryParse(offsetVal) ?? 0) + 1;
     }
 
+    final isMarkdown = _isMarkdownPath(path.toString());
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (path.toString().isNotEmpty) ...[
-          _buildInfoRow(context, 'Target Path', _toRelativePath(context, path.toString())),
+          Row(
+            children: [
+              Expanded(
+                child: _buildInfoRow(
+                  context,
+                  'Target Path',
+                  _toRelativePath(context, path.toString()),
+                ),
+              ),
+              if (isMarkdown) ...[
+                const SizedBox(width: 12),
+                _buildReadViewSwitch(context),
+              ],
+            ],
+          ),
           const SizedBox(height: 8),
         ],
-        _buildCodeBlock(
-          context,
-          code: content,
-          filePath: path.toString(),
-          startLine: startLine,
+        SizedBox(
+          key: const Key('file_read_content_viewport'),
+          width: double.infinity,
+          height: _readViewportHeight,
+          child: isMarkdown && _showMarkdown
+              ? SingleChildScrollView(
+                  key: const Key('file_read_markdown_body'),
+                  child: AppMarkdownRenderer(
+                    data: content,
+                    isFinal: true,
+                    onTapLink: (text, href, title) {
+                      unawaited(openExternalUrl(href));
+                    },
+                  ),
+                )
+              : KeyedSubtree(
+                  key: const Key('file_read_raw_body'),
+                  child: _buildCodeBlock(
+                    context,
+                    code: content,
+                    filePath: path.toString(),
+                    startLine: startLine,
+                  ),
+                ),
         ),
       ],
+    );
+  }
+
+  bool _isMarkdownPath(String path) {
+    final normalized = path.toLowerCase();
+    return normalized.endsWith('.md') || normalized.endsWith('.markdown');
+  }
+
+  Widget _buildReadViewSwitch(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+
+    return SegmentedButton<bool>(
+      segments: const [
+        ButtonSegment<bool>(
+          value: false,
+          label: Text('Raw', key: Key('file_read_raw_toggle')),
+        ),
+        ButtonSegment<bool>(
+          value: true,
+          label: Text('MD', key: Key('file_read_md_toggle')),
+        ),
+      ],
+      selected: {_showMarkdown},
+      showSelectedIcon: false,
+      onSelectionChanged: (selection) {
+        setState(() {
+          _showMarkdown = selection.first;
+        });
+      },
+      style: ButtonStyle(
+        visualDensity: VisualDensity.compact,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: WidgetStatePropertyAll(
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+        ),
+        backgroundColor: WidgetStateProperty.resolveWith((states) {
+          return states.contains(WidgetState.selected)
+              ? colors.primary.withValues(alpha: 0.2)
+              : Colors.transparent;
+        }),
+        foregroundColor: WidgetStateProperty.resolveWith((states) {
+          return states.contains(WidgetState.selected)
+              ? colors.primary
+              : colors.onSurfaceVariant;
+        }),
+        side: WidgetStatePropertyAll(
+          BorderSide(color: colors.onSurface.withValues(alpha: 0.05)),
+        ),
+        padding: const WidgetStatePropertyAll(
+          EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+        ),
+        textStyle: WidgetStatePropertyAll(
+          GoogleFonts.roboto(fontSize: 11, fontWeight: FontWeight.w600),
+        ),
+      ),
     );
   }
 
@@ -333,7 +432,7 @@ class _FileToolTileState extends State<FileToolTile> {
     required String code,
     required String filePath,
     required int startLine,
-    double height = 350,
+    double height = _readViewportHeight,
   }) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final defaultStyle = GoogleFonts.firaCode(

--- a/client/lib/features/conversations/presentation/widgets/tools/skill_load_tool_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/tools/skill_load_tool_tile.dart
@@ -1,187 +1,172 @@
 import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/app_markdown_renderer.dart';
+import 'package:sanad_client/utils/link_utils.dart';
 
-class SkillLoadToolTile extends StatefulWidget {
+class SkillLoadToolTile extends StatelessWidget {
+  static const _sourcePrefix = 'Skill source: ';
+
   final CanonicalEvent event;
 
-  const SkillLoadToolTile({
-    super.key,
-    required this.event,
-  });
-
-  @override
-  State<SkillLoadToolTile> createState() => _SkillLoadToolTileState();
-}
-
-class _SkillLoadToolTileState extends State<SkillLoadToolTile> {
-  bool _isExpanded = false;
-
-  Map<String, dynamic> _parseInput(dynamic input) {
-    if (input is Map<String, dynamic>) return input;
-    if (input is Map) return Map<String, dynamic>.from(input);
-    if (input is String) {
-      try {
-        final decoded = jsonDecode(input);
-        if (decoded is Map<String, dynamic>) return decoded;
-        if (decoded is Map) return Map<String, dynamic>.from(decoded);
-      } catch (_) {}
-    }
-    return {};
-  }
+  const SkillLoadToolTile({super.key, required this.event});
 
   @override
   Widget build(BuildContext context) {
-    if (widget.event.status == EventStatus.running) {
+    if (event.status == EventStatus.running) {
       return _buildRunningIndicator(context);
     }
 
-    if (widget.event.status == EventStatus.error) {
+    if (event.status == EventStatus.error) {
       return _buildErrorState(context);
     }
 
-    final mapInput = _parseInput(widget.event.toolInput);
-    final skillName = mapInput['skill']?.toString() ?? 'Skill';
-    final skillArgs = mapInput['args']?.toString();
-    final output = widget.event.toolOutput?.toString() ?? '';
-
-    return Container(
-      margin: const EdgeInsets.symmetric(vertical: 4.0),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.25),
-        borderRadius: BorderRadius.circular(8),
-        border: Border.all(
-          color: Theme.of(context).colorScheme.outlineVariant.withValues(alpha: 0.4),
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          InkWell(
-            onTap: () {
-              setState(() {
-                _isExpanded = !_isExpanded;
-              });
-            },
-            borderRadius: BorderRadius.circular(8),
-            child: Padding(
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                children: [
-                  Icon(
-                    Icons.auto_awesome_outlined,
-                    size: 16,
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Loaded Skill: $skillName',
-                          style: GoogleFonts.outfit(
-                            fontSize: 13,
-                            fontWeight: FontWeight.w600,
-                            color: Theme.of(context).colorScheme.onSurface,
-                          ),
-                        ),
-                        if (skillArgs != null && skillArgs.isNotEmpty) ...[
-                          const SizedBox(height: 2),
-                          Text(
-                            'Arguments: $skillArgs',
-                            style: GoogleFonts.roboto(
-                              fontSize: 11,
-                              color: Theme.of(context).colorScheme.onSurfaceVariant,
-                            ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-                  Icon(
-                    _isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
-                    size: 18,
-                    color: Theme.of(context).colorScheme.onSurfaceVariant,
-                  ),
-                ],
-              ),
+    final document = _SkillDocument.parse(event.toolOutput);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (document.path.isNotEmpty) ...[
+          _buildInfoRow(context, 'Target Path', document.path),
+          const SizedBox(height: 8),
+        ],
+        if (document.markdown.isNotEmpty)
+          SizedBox(
+            key: const Key('skill_markdown_body'),
+            width: double.infinity,
+            child: AppMarkdownRenderer(
+              data: document.markdown,
+              isFinal: true,
+              onTapLink: (text, href, title) => openExternalUrl(href),
             ),
           ),
-          if (_isExpanded && output.isNotEmpty) ...[
-            const Divider(height: 1),
-            Padding(
-              padding: const EdgeInsets.all(12),
-              child: Container(
-                width: double.infinity,
-                padding: const EdgeInsets.all(10),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.surface,
-                  borderRadius: BorderRadius.circular(6),
-                  border: Border.all(
-                    color: Theme.of(context).colorScheme.outlineVariant.withValues(alpha: 0.3),
-                  ),
-                ),
-                child: SelectableText(
-                  output,
-                  style: GoogleFonts.firaCode(
-                    fontSize: 11,
-                    color: Theme.of(context).colorScheme.onSurface,
-                  ),
-                ),
-              ),
-            ),
-          ],
-        ],
-      ),
+      ],
     );
   }
 
   Widget _buildRunningIndicator(BuildContext context) {
-    final mapInput = _parseInput(widget.event.toolInput);
-    final skillName = mapInput['skill']?.toString() ?? 'skill';
-
-    return Padding(
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        children: [
-          SizedBox(
-            width: 14,
-            height: 14,
-            child: CircularProgressIndicator(
-              strokeWidth: 2,
-              color: Theme.of(context).colorScheme.primary,
-            ),
+    final skillName = _parseInput(event.toolInput)['skill']?.toString() ?? '';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (skillName.isNotEmpty) ...[
+          _buildInfoRow(context, 'Skill', skillName),
+          const SizedBox(height: 8),
+        ],
+        Text(
+          'Loading skill...',
+          style: GoogleFonts.roboto(
+            fontSize: 12,
+            color: Theme.of(
+              context,
+            ).colorScheme.onSurface.withValues(alpha: 0.6),
           ),
-          const SizedBox(width: 8),
-          Text(
-            'Loading skill "$skillName"...',
-            style: GoogleFonts.roboto(
+        ),
+      ],
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context) {
+    final errorColor = Theme.of(context).colorScheme.error;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: Theme.of(
+          context,
+        ).colorScheme.errorContainer.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: errorColor.withValues(alpha: 0.2)),
+      ),
+      child: Text(
+        event.text.isNotEmpty
+            ? event.text
+            : (event.toolOutput?.toString() ?? 'Failed to load skill.'),
+        style: GoogleFonts.firaCode(fontSize: 11, color: errorColor),
+      ),
+    );
+  }
+
+  Map<String, dynamic> _parseInput(dynamic input) {
+    if (input is Map) {
+      return Map<String, dynamic>.from(input);
+    }
+    if (input is String) {
+      try {
+        final decoded = jsonDecode(input);
+        if (decoded is Map) {
+          return Map<String, dynamic>.from(decoded);
+        }
+      } catch (_) {}
+    }
+    return const {};
+  }
+
+  Widget _buildInfoRow(BuildContext context, String label, String value) {
+    return SelectableText.rich(
+      TextSpan(
+        style: GoogleFonts.roboto(
+          fontSize: 13,
+          color: Theme.of(context).colorScheme.onSurface,
+        ),
+        children: [
+          TextSpan(
+            text: '$label: ',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          TextSpan(
+            text: value,
+            style: GoogleFonts.firaCode(
               fontSize: 12,
-              fontStyle: FontStyle.italic,
-              color: Theme.of(context).colorScheme.onSurfaceVariant,
+              color: Theme.of(context).colorScheme.primary,
             ),
           ),
         ],
       ),
     );
   }
+}
 
-  Widget _buildErrorState(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.all(10),
-      decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.errorContainer.withValues(alpha: 0.2),
-        borderRadius: BorderRadius.circular(6),
-      ),
-      child: Text(
-        widget.event.toolOutput?.toString() ?? 'Failed to load skill.',
-        style: GoogleFonts.roboto(
-          fontSize: 12,
-          color: Theme.of(context).colorScheme.error,
-        ),
-      ),
+class _SkillDocument {
+  final String path;
+  final String markdown;
+
+  const _SkillDocument({required this.path, required this.markdown});
+
+  factory _SkillDocument.parse(dynamic output) {
+    if (output is Map) {
+      return _SkillDocument.fromMap(Map<String, dynamic>.from(output));
+    }
+
+    final raw = output?.toString() ?? '';
+    if (raw.startsWith(SkillLoadToolTile._sourcePrefix)) {
+      final separator = raw.indexOf('\n\n');
+      if (separator >= 0) {
+        return _SkillDocument(
+          path: raw
+              .substring(SkillLoadToolTile._sourcePrefix.length, separator)
+              .trim(),
+          markdown: raw.substring(separator + 2),
+        );
+      }
+    }
+
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        return _SkillDocument.fromMap(Map<String, dynamic>.from(decoded));
+      }
+    } catch (_) {}
+
+    return _SkillDocument(path: '', markdown: raw);
+  }
+
+  factory _SkillDocument.fromMap(Map<String, dynamic> output) {
+    return _SkillDocument(
+      path: output['path']?.toString() ?? '',
+      markdown:
+          output['prompt']?.toString() ?? output['content']?.toString() ?? '',
     );
   }
 }

--- a/client/lib/features/home/presentation/widgets/status_bar.dart
+++ b/client/lib/features/home/presentation/widgets/status_bar.dart
@@ -64,21 +64,26 @@ class StatusBar extends StatelessWidget {
           color: backgroundColor,
           child: Row(
             children: [
-              _GatewayStatusButton(
-                status: status,
-                foregroundColor: foregroundColor,
-              ),
-              if (worktreeName.isNotEmpty) ...[
-                const SizedBox(width: 4),
-                Flexible(
-                  child: WorktreeRuntimeBadge(
-                    worktreeName: worktreeName,
-                    branch: worktreeBranch,
-                    foregroundColor: foregroundColor,
-                  ),
+              Expanded(
+                child: Row(
+                  children: [
+                    _GatewayStatusButton(
+                      status: status,
+                      foregroundColor: foregroundColor,
+                    ),
+                    if (worktreeName.isNotEmpty) ...[
+                      const SizedBox(width: 4),
+                      Flexible(
+                        child: WorktreeRuntimeBadge(
+                          worktreeName: worktreeName,
+                          branch: worktreeBranch,
+                          foregroundColor: foregroundColor,
+                        ),
+                      ),
+                    ],
+                  ],
                 ),
-              ],
-              const Spacer(),
+              ),
               // Right side: environment details (VS Code style placeholders)
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/client/test/widget/file_tool_markdown_toggle_test.dart
+++ b/client/test/widget/file_tool_markdown_toggle_test.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/tools/file_tool_tile.dart';
+
+void main() {
+  testWidgets('Markdown file reads default to rendered MD and switch to Raw', (
+    tester,
+  ) async {
+    await _pumpTile(
+      tester,
+      _event(
+        path: 'docs/guide.md',
+        content: '# Guide\n\nUse the **safe** workflow.',
+      ),
+    );
+
+    expect(find.byKey(const Key('file_read_raw_toggle')), findsOneWidget);
+    expect(find.byKey(const Key('file_read_md_toggle')), findsOneWidget);
+    expect(find.byKey(const Key('file_read_markdown_body')), findsOneWidget);
+    expect(find.byKey(const Key('file_read_raw_body')), findsNothing);
+    expect(find.text('Guide'), findsOneWidget);
+    final switchWidget = tester.widget<SegmentedButton<bool>>(
+      find.byType(SegmentedButton<bool>),
+    );
+    expect(switchWidget.selected, {true});
+    expect(
+      tester.getSize(find.byKey(const Key('file_read_content_viewport'))).height,
+      350,
+    );
+    final selectedShape = switchWidget.style?.shape?.resolve({
+      WidgetState.selected,
+    });
+    expect(
+      (selectedShape as RoundedRectangleBorder).borderRadius,
+      BorderRadius.circular(8),
+    );
+    final colorScheme = Theme.of(
+      tester.element(find.byType(SegmentedButton<bool>)),
+    ).colorScheme;
+    expect(
+      switchWidget.style?.backgroundColor?.resolve({WidgetState.selected}),
+      colorScheme.primary.withValues(alpha: 0.2),
+    );
+    expect(
+      switchWidget.style?.side?.resolve({WidgetState.selected})?.color,
+      colorScheme.onSurface.withValues(alpha: 0.05),
+    );
+
+    await tester.tap(find.byKey(const Key('file_read_raw_toggle')));
+    await tester.pump();
+
+    expect(find.byKey(const Key('file_read_markdown_body')), findsNothing);
+    expect(find.byKey(const Key('file_read_raw_body')), findsOneWidget);
+    expect(tester.widget<SegmentedButton<bool>>(find.byType(SegmentedButton<bool>)).selected, {false});
+    expect(
+      tester.getSize(find.byKey(const Key('file_read_content_viewport'))).height,
+      350,
+    );
+
+    await tester.tap(find.byKey(const Key('file_read_md_toggle')));
+    await tester.pump();
+
+    expect(find.byKey(const Key('file_read_markdown_body')), findsOneWidget);
+    expect(find.byKey(const Key('file_read_raw_body')), findsNothing);
+  });
+
+  testWidgets('non-Markdown file reads keep the raw presentation', (
+    tester,
+  ) async {
+    await _pumpTile(
+      tester,
+      _event(path: 'lib/example.dart', content: 'void main() {}'),
+    );
+
+    expect(find.byType(SegmentedButton<bool>), findsNothing);
+    expect(find.byKey(const Key('file_read_markdown_body')), findsNothing);
+    expect(find.byKey(const Key('file_read_raw_body')), findsOneWidget);
+  });
+}
+
+Future<void> _pumpTile(WidgetTester tester, CanonicalEvent event) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 700,
+          child: FileToolTile(event: event),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+CanonicalEvent _event({required String path, required String content}) {
+  return CanonicalEvent(
+    id: 'file-read-$path',
+    kind: EventKind.toolCall,
+    timestamp: DateTime.utc(2026, 8, 11),
+    tool: {
+      'name': 'file_read',
+      'input': {'path': path},
+      'output': jsonEncode({
+        'type': 'text',
+        'file': {'content': content},
+      }),
+    },
+  );
+}

--- a/client/test/widget/skill_load_tool_tile_test.dart
+++ b/client/test/widget/skill_load_tool_tile_test.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/event_tile.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/tools/skill_load_tool_tile.dart';
+
+void main() {
+  testWidgets(
+    'renders compact skill output as a File Read-like Markdown body',
+    (tester) async {
+      await _pumpEvent(
+        tester,
+        _event(
+          output: '''Skill source: .agents/skills/review/SKILL.md
+
+# Review Skill
+
+Follow the **review** workflow.
+
+- Inspect
+- Verify''',
+        ),
+      );
+
+      expect(find.byType(SkillLoadToolTile), findsOneWidget);
+      expect(find.textContaining('Target Path:'), findsOneWidget);
+      expect(
+        find.textContaining('.agents/skills/review/SKILL.md'),
+        findsOneWidget,
+      );
+      expect(find.byKey(const Key('skill_markdown_body')), findsOneWidget);
+      expect(find.text('Review Skill'), findsOneWidget);
+      expect(find.text('Inspect'), findsOneWidget);
+      expect(find.text('Input Parameters'), findsNothing);
+      expect(find.text('Output Result'), findsNothing);
+    },
+  );
+
+  testWidgets('renders the skill name while loading', (tester) async {
+    await _pumpEvent(tester, _event(status: EventStatus.running));
+
+    expect(find.byType(SkillLoadToolTile), findsOneWidget);
+    expect(find.textContaining('Skill:'), findsOneWidget);
+    expect(find.textContaining('review'), findsWidgets);
+    expect(find.text('Loading skill...'), findsOneWidget);
+  });
+
+  testWidgets('renders skill load failures in the dedicated error state', (
+    tester,
+  ) async {
+    await _pumpEvent(
+      tester,
+      _event(status: EventStatus.error, output: 'Unknown skill: review'),
+    );
+
+    expect(find.byType(SkillLoadToolTile), findsOneWidget);
+    expect(find.text('Unknown skill: review'), findsOneWidget);
+    expect(find.text('Output Result'), findsNothing);
+  });
+}
+
+Future<void> _pumpEvent(WidgetTester tester, CanonicalEvent event) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 700,
+          child: EventTile(event: event, isExpanded: true),
+        ),
+      ),
+    ),
+  );
+  await tester.pump();
+}
+
+CanonicalEvent _event({EventStatus status = EventStatus.done, String? output}) {
+  return CanonicalEvent(
+    id: 'skill-load-event',
+    kind: EventKind.toolCall,
+    status: status,
+    timestamp: DateTime.utc(2026, 8, 11),
+    tool: {
+      'name': 'skill_load',
+      'input': {'skill': 'review'},
+      if (output != null) 'output': output,
+    },
+  );
+}

--- a/docs/agent_engine/capability_runtime.md
+++ b/docs/agent_engine/capability_runtime.md
@@ -90,8 +90,11 @@ dispatch. This admission boundary does not alter per-turn catalog assembly:
 servers configured by the local user remain available for tool discovery and
 execution in both local and cloud-origin turns.
 
-Skills are discovered and loaded by the runtime skill registry. The client does
-not inspect skill files to determine runtime availability.
+Skills are discovered and loaded by the runtime skill registry. A successful
+`skill_load` result contains one source-path header followed by the original
+skill Markdown; model-visible results omit duplicated input, frontmatter,
+provenance, and shadowing diagnostics. The client does not inspect skill files
+to determine runtime availability.
 
 ## Platform Tools
 

--- a/docs/plans/tasks/done/file-read-markdown-toggle-polish.md
+++ b/docs/plans/tasks/done/file-read-markdown-toggle-polish.md
@@ -1,0 +1,32 @@
+---
+title: "File Read Markdown Toggle Polish"
+status: done
+---
+
+# File Read Markdown Toggle Polish
+
+## Goal
+
+Prevent layout movement when switching File Read Markdown views and align the selector styling with the application theme.
+
+## Implementation
+
+- Give Raw and MD one shared 350px content viewport with internal scrolling.
+- Use an 8px selector radius.
+- Fill the selected segment with the application primary color at 20% opacity.
+- Match the selector border to the subtle tool-surface border treatment.
+- Extend focused widget coverage to assert stable height and selected styling.
+
+## Definition of Done
+
+- Switching Raw and MD preserves the content viewport height.
+- The selected segment uses the requested radius and theme color treatment.
+- Focused widget tests and client analysis pass.
+- The live client is reloaded.
+- The plan is moved to `docs/plans/tasks/done/`.
+
+## Verification
+
+- Stable-height and selector-style widget assertions pass.
+- Client analyzer passes without issues.
+- Live client reload completed for review.

--- a/docs/plans/tasks/done/file-read-markdown-view-toggle.md
+++ b/docs/plans/tasks/done/file-read-markdown-view-toggle.md
@@ -1,0 +1,33 @@
+---
+title: "File Read Markdown View Toggle"
+status: done
+---
+
+# File Read Markdown View Toggle
+
+## Goal
+
+Let users switch Markdown file reads between the existing raw source presentation and rendered README-style Markdown, with Markdown selected by default.
+
+## Implementation
+
+- Detect `.md` and `.markdown` File Read targets case-insensitively.
+- Place a compact `Raw | MD` switch to the right of the target path.
+- Keep the existing line-numbered source view under Raw.
+- Render MD through the shared application Markdown renderer.
+- Leave non-Markdown file reads unchanged.
+- Cover default selection, switching, and non-Markdown behavior with focused widget tests.
+
+## Definition of Done
+
+- Markdown reads open in MD mode and switch to Raw without changing tool data.
+- Non-Markdown reads retain the existing UI without a switch.
+- Client analyzer and focused widget tests pass.
+- The client is reloaded for live review.
+- This plan is moved to `docs/plans/tasks/done/`.
+
+## Verification
+
+- Focused File Read and skill-load widget tests pass.
+- Client analyzer passes without issues.
+- Live client reload completed for review.

--- a/docs/plans/tasks/done/skill-load-compact-markdown-presentation.md
+++ b/docs/plans/tasks/done/skill-load-compact-markdown-presentation.md
@@ -1,0 +1,39 @@
+---
+title: "Compact Skill Load Output and Markdown Presentation"
+status: done
+---
+
+# Compact Skill Load Output and Markdown Presentation
+
+## Problem
+
+`skill_load` accepts an `args` field that is only echoed, then returns pretty-printed JSON containing duplicated model input, frontmatter, provenance, and shadowing diagnostics. The client routes the tool through the generic JSON tile because its dedicated presentation is disabled.
+
+## Goal
+
+Make skill loading return only the selected skill source path and original Markdown content, and present that result like a normal File Read whose body is rendered Markdown.
+
+## Implementation
+
+- Remove `args` from the model-visible schema and the runtime/service call chain.
+- Return a compact text result containing one source-path header followed by the original skill Markdown.
+- Keep registry provenance, metadata, and shadowing information internal for inventory and resolution behavior.
+- Route `skill_load` to a dedicated client tile using the File Read visual language.
+- Show the selected `SKILL.md` path and render its content through the application Markdown renderer.
+- Cover the compact runtime contract and the client running/error/completed Markdown states.
+- Update capability and client-interface documentation.
+
+## Definition of Done
+
+- `skill_load` exposes only the required `skill` input.
+- Successful output contains the selected path and Markdown body without redundant JSON fields.
+- Skill-load events no longer use the generic input/output JSON presentation.
+- Markdown headings, lists, emphasis, and code render through the shared Markdown boundary.
+- Focused agent and client tests pass, and both analyzers pass.
+- The completed plan is moved to `docs/plans/tasks/done/`.
+
+## Verification
+
+- Agent analyzer and focused runtime-catalog tests pass.
+- Daemon-backed skill-load E2E passes sequentially.
+- Client analyzer and focused skill-load widget tests pass.

--- a/docs/plans/tasks/done/status-bar-worktree-layout-fix.md
+++ b/docs/plans/tasks/done/status-bar-worktree-layout-fix.md
@@ -1,0 +1,28 @@
+---
+title: "Status Bar Worktree Layout Fix"
+status: done
+---
+
+# Status Bar Worktree Layout Fix
+
+## Goal
+
+Keep the environment details, including `SanadAgent`, anchored to the far right when the optional worktree badge is visible.
+
+## Implementation
+
+- Group gateway status and the optional worktree badge in one expandable left section.
+- Keep environment details as the fixed trailing section.
+- Preserve badge truncation within the available left-side width.
+
+## Definition of Done
+
+- Showing or hiding the worktree badge does not move `SanadAgent` away from the right edge.
+- Client analysis passes.
+- The live client is reloaded.
+- The plan is moved to `docs/plans/tasks/done/`.
+
+## Verification
+
+- Client analyzer passes without issues.
+- Live client reload completed for review.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -26,7 +26,9 @@ configuration, and runtime state displayed by the client. It does not create a
 new conversation.
 
 The compact Home gateway/status bar is a native-desktop surface. Web and mobile
-never render it, regardless of browser or viewport width.
+never render it, regardless of browser or viewport width. Its gateway and
+optional worktree badge consume only the expandable leading region; desktop
+mode and `SanadAgent` remain anchored to the trailing edge.
 
 Desktop onboarding is local-first: installing the agent on the current computer
 is the primary card action, while signing in or connecting a remote device is a
@@ -99,8 +101,19 @@ opening; users never need to close and reopen the menu to refresh it.
 ## Active work
 
 The conversation timeline renders Markdown, code, reasoning summaries, tool
-activity, permission requests, recovery notices, and final responses. Dynamic
-event titles resolve their own text direction; Arabic ask-user headers mirror
+activity, permission requests, recovery notices, and final responses. Skill
+loading uses the same compact path-and-content presentation as File Read, while
+the loaded `SKILL.md` body renders as selectable README-style Markdown rather
+than raw tool JSON. File Read results for `.md` and `.markdown` targets place a
+`Raw | MD` switch beside the target path, default to rendered Markdown, and
+preserve the existing line-numbered source view under Raw. Both modes share one
+fixed-height scrollable viewport so switching never moves the surrounding
+timeline. The compact 8px-radius selector marks the active mode with the
+application primary color at 20% opacity and reuses the tool-surface border at
+5% on-surface opacity. Other file types keep the raw
+presentation without a switch. Dynamic event titles resolve their own
+text direction;
+Arabic ask-user headers mirror
 the complete header row while English headers remain left-to-right. Event
 runtime metadata uses milliseconds below one second, seconds below one minute,
 minutes plus seconds below one hour, and hours plus minutes thereafter.


### PR DESCRIPTION
## Problem / goal
1. Improve skill load tool output presentation by rendering full markdown instructions with clear collapsible sections and clean token usage summaries.
2. Provide a seamless `Raw | MD` view toggle for markdown file read tool calls in the conversation interface, defaulting to rendered markdown.
3. Fix status bar worktree path layout and truncation for responsive widths.

## Technical Changes
- **Client - File Read Toggle:** Added `Raw | MD` switch to `file_tool_tile.dart` for `.md` / `.markdown` files, defaulting to rendered markdown. Added widget test in `file_tool_markdown_toggle_test.dart`.
- **Client - Skill Load Presentation:** Redesigned `skill_load_tool_tile.dart` to render clean markdown view with description badges and collapsible content. Added widget test in `skill_load_tool_tile_test.dart`.
- **Client - Status Bar:** Updated `status_bar.dart` with flexible worktree label layout and icon styling.
- **Agent - Skill Service & Catalog:** Streamlined `skill_load_service.dart` and updated catalog tests in `runtime_catalog_test.dart`.
- **Documentation:** Updated `capability_runtime.md`, `client_interface.md`, and tracked task plans in `docs/plans/tasks/done/`.

## Verification
- `cd agent && fvm dart analyze` (passed with 0 issues)
- `cd client && fvm flutter analyze` (passed with 0 issues)
- `cd agent && fvm dart test test/capabilities/runtime_catalog_test.dart` (7 tests passed)
- `cd client && fvm flutter test test/widget/file_tool_markdown_toggle_test.dart test/widget/skill_load_tool_tile_test.dart` (all tests passed)