### PR TITLE
feat(client): persist and refine sidebar navigation UX

### DIFF
--- a/client/lib/features/conversations/presentation/widgets/markdown_style_helper.dart
+++ b/client/lib/features/conversations/presentation/widgets/markdown_style_helper.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 // ignore: depend_on_referenced_packages
 import 'package:markdown/markdown.dart' as md;
 import 'package:sanad_client/core/theme/app_color_scheme.dart';
+import 'package:sanad_client/features/conversations/presentation/utils/text_utils.dart';
 
 /// Centralized helper for generating consistent Markdown style sheets and
 /// element builders across conversation widgets (e.g. UserMessageTile, EventTile).
@@ -60,6 +61,51 @@ class MarkdownStyleHelper {
   }
 }
 
+/// Renders a multiline Markdown code block with detected text direction.
+///
+/// The viewport intentionally remains LTR so horizontal offset zero always
+/// exposes the left edge. The code text gets its own detected direction.
+class AppCodeBlock extends StatelessWidget {
+  final String codeText;
+  final Color codeColor;
+
+  const AppCodeBlock({
+    super.key,
+    required this.codeText,
+    required this.codeColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final codeDirection = TextUtils.getTextDirection(codeText);
+    return Container(
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.1)),
+      ),
+      padding: const EdgeInsets.all(16.0),
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: Directionality(
+            textDirection: codeDirection,
+            child: Text(
+              codeText,
+              style: GoogleFonts.firaCode(
+                color: codeColor,
+                fontSize: 12,
+                height: 1.5,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 /// Custom builder for inline code and multiline fallback blocks in Markdown text.
 class AppInlineCodeBuilder extends MarkdownElementBuilder {
   final BuildContext context;
@@ -78,25 +124,9 @@ class AppInlineCodeBuilder extends MarkdownElementBuilder {
         codeText = codeText.substring(0, codeText.length - 1);
       }
 
-      return Container(
-        decoration: BoxDecoration(
-          color: theme.colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
-          borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: theme.colorScheme.outline.withValues(alpha: 0.1)),
-        ),
-        padding: const EdgeInsets.all(16.0),
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: Text(
-            codeText,
-            textDirection: TextDirection.ltr,
-            style: GoogleFonts.firaCode(
-              color: codeColor,
-              fontSize: 12,
-              height: 1.5,
-            ),
-          ),
-        ),
+      return AppCodeBlock(
+        codeText: codeText,
+        codeColor: codeColor,
       );
     }
 

--- a/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_composition.dart
+++ b/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_composition.dart
@@ -34,7 +34,7 @@ class SidebarBreakpoints {
   static const double tablet = 900;
 
   /// Default fixed sidebar width on desktop.
-  static const double desktopWidth = 280;
+  static const double desktopWidth = 300;
 
   /// Drawer width on compact layouts, expressed as a fraction of viewport width.
   static const double drawerWidthFactor = 0.8;

--- a/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_conversation_row.dart
+++ b/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_conversation_row.dart
@@ -170,6 +170,9 @@ class _SidebarConversationRowState extends State<SidebarConversationRow> {
                   ),
                   leading: leadingContainer,
                   onTap: widget.onSelected,
+                  onLongPress: () {
+                    _showMobileSessionOptions(context, widget.device, widget.session);
+                  },
                   trailing: _SidebarSessionTrailing(
                     device: widget.device,
                     session: widget.session,
@@ -206,6 +209,158 @@ class _SidebarConversationRowState extends State<SidebarConversationRow> {
   }
 }
 
+String formatCompactRelativeTime(DateTime dateTime) {
+  final now = DateTime.now();
+  final diff = now.difference(dateTime);
+
+  if (diff.isNegative || diff.inSeconds < 10) {
+    return 'now';
+  }
+  if (diff.inSeconds < 60) {
+    return '${diff.inSeconds}s';
+  }
+  if (diff.inMinutes < 60) {
+    return '${diff.inMinutes}m';
+  }
+  if (diff.inHours < 24) {
+    return '${diff.inHours}h';
+  }
+  if (diff.inDays < 7) {
+    return '${diff.inDays}d';
+  }
+  if (diff.inDays < 30) {
+    final weeks = (diff.inDays / 7).floor();
+    return '${weeks}w';
+  }
+  if (diff.inDays < 365) {
+    final months = (diff.inDays / 30).floor();
+    return '${months}mo';
+  }
+  final years = (diff.inDays / 365).floor();
+  return '${years}y';
+}
+
+void _showMobileSessionOptions(
+  BuildContext context,
+  DeviceConfig device,
+  Session session, [
+  Capability? capabilities,
+]) {
+  final caps = capabilities ?? context.read<DeviceCapabilitiesCubit>().state.getForAgent(device.id);
+  final hasOptions = caps.supportsUpdateSessionName || caps.supportsDeleteSession;
+  if (!hasOptions) return;
+
+  final sessionCubit = context.read<SessionCubit>();
+  final theme = Theme.of(context);
+
+  unawaited(
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: theme.colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (sheetContext) => SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: Text(
+                  session.title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+                ),
+              ),
+              const Divider(height: 1),
+              if (caps.supportsUpdateSessionName)
+                ListTile(
+                  leading: Icon(Icons.edit_outlined, size: 20, color: theme.colorScheme.onSurface),
+                  title: const Text('Rename', style: TextStyle(fontSize: 14)),
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    _showRenameDialog(context, sessionCubit, device, session);
+                  },
+                ),
+              if (caps.supportsDeleteSession)
+                ListTile(
+                  leading: const Icon(Icons.delete_outline, size: 20, color: Colors.redAccent),
+                  title: const Text('Delete', style: TextStyle(fontSize: 14, color: Colors.redAccent)),
+                  onTap: () {
+                    Navigator.pop(sheetContext);
+                    _showDeleteConfirmation(context, sessionCubit, device, session);
+                  },
+                ),
+            ],
+          ),
+        ),
+      ),
+    ),
+  );
+}
+
+void _showRenameDialog(BuildContext context, SessionCubit sessionCubit, DeviceConfig device, Session session) {
+  var titleText = session.title;
+  void onRename() {
+    final text = titleText.trim();
+    if (text.isNotEmpty) {
+      unawaited(sessionCubit.updateSessionTitle(agent: device, session: session, title: text));
+      Navigator.pop(context);
+    }
+  }
+
+  unawaited(
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Rename Session'),
+        content: TextFormField(
+          initialValue: session.title,
+          autofocus: true,
+          decoration: const InputDecoration(hintText: 'New title'),
+          onChanged: (val) => titleText = val,
+          onFieldSubmitted: (_) => onRename(),
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(onPressed: onRename, child: const Text('Rename')),
+        ],
+      ),
+    ),
+  );
+}
+
+void _showDeleteConfirmation(BuildContext context, SessionCubit sessionCubit, DeviceConfig device, Session session) {
+  unawaited(
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Session'),
+        content: Text('Are you sure you want to delete "${session.title}"? This cannot be undone.'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
+          TextButton(
+            onPressed: () async {
+              await sessionCubit.deleteSession(agent: device, session: session);
+              switch (context.mounted) {
+                case true:
+                  Navigator.pop(context);
+                case false:
+                  break;
+              }
+            },
+            child: const Text('Delete', style: TextStyle(color: Colors.redAccent)),
+          ),
+        ],
+      ),
+    ),
+  );
+}
+
 class _SidebarSessionTrailing extends StatelessWidget {
   final DeviceConfig device;
   final Session session;
@@ -221,19 +376,42 @@ class _SidebarSessionTrailing extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final showOptions = AppPlatform.isMobile || isHovered;
+    final isMobile = AppPlatform.isMobile;
+    final theme = Theme.of(context);
+
     return BlocSelector<DeviceCapabilitiesCubit, DeviceCapabilitiesState, Capability>(
       selector: (state) => state.getForAgent(device.id),
       builder: (context, caps) {
         final hasOptions = caps.supportsUpdateSessionName || caps.supportsDeleteSession;
-        return Visibility(
-          visible: showOptions && hasOptions,
-          maintainState: true,
-          child: PopupMenuButton<String>(
+
+        if (isMobile) {
+          return GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: () {
+              if (hasOptions) {
+                _showMobileSessionOptions(context, device, session, caps);
+              }
+            },
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 2),
+              child: Text(
+                formatCompactRelativeTime(session.updatedAt),
+                style: TextStyle(
+                  color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                  fontSize: 10,
+                  fontWeight: FontWeight.w400,
+                ),
+              ),
+            ),
+          );
+        }
+
+        if (isHovered && hasOptions) {
+          return PopupMenuButton<String>(
             tooltip: '',
             icon: Icon(
               Icons.more_vert,
-              color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.5),
+              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
               size: 14,
             ),
             padding: EdgeInsets.zero,
@@ -245,9 +423,9 @@ class _SidebarSessionTrailing extends StatelessWidget {
               final sessionCubit = context.read<SessionCubit>();
               switch (value) {
                 case 'rename':
-                  _showRenameDialog(context, sessionCubit);
+                  _showRenameDialog(context, sessionCubit, device, session);
                 case 'delete':
-                  _showDeleteConfirmation(context, sessionCubit);
+                  _showDeleteConfirmation(context, sessionCubit, device, session);
               }
             },
             itemBuilder: (context) => [
@@ -258,11 +436,11 @@ class _SidebarSessionTrailing extends StatelessWidget {
                     height: 32,
                     child: Row(
                       children: [
-                        Icon(Icons.edit_outlined, size: 14, color: Theme.of(context).colorScheme.onSurfaceVariant),
+                        Icon(Icons.edit_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
                         const SizedBox(width: 8),
                         Text(
                           'Rename',
-                          style: TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant, fontSize: 12),
+                          style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 12),
                         ),
                       ],
                     ),
@@ -278,8 +456,8 @@ class _SidebarSessionTrailing extends StatelessWidget {
                     child: Row(
                       children: [
                         Icon(Icons.delete_outline, size: 14, color: Colors.redAccent),
-                        SizedBox(width: 8),
-                        Text('Delete', style: TextStyle(color: Colors.redAccent, fontSize: 12)),
+                        const SizedBox(width: 8),
+                        const Text('Delete', style: TextStyle(color: Colors.redAccent, fontSize: 12)),
                       ],
                     ),
                   ),
@@ -287,67 +465,21 @@ class _SidebarSessionTrailing extends StatelessWidget {
                 false => const <PopupMenuItem<String>>[],
               },
             ],
+          );
+        }
+
+        return Padding(
+          padding: const EdgeInsets.only(right: 4),
+          child: Text(
+            formatCompactRelativeTime(session.updatedAt),
+            style: TextStyle(
+              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+              fontSize: 10,
+              fontWeight: FontWeight.w400,
+            ),
           ),
         );
       },
-    );
-  }
-
-  void _showRenameDialog(BuildContext context, SessionCubit sessionCubit) {
-    var titleText = session.title;
-    void onRename() {
-      final text = titleText.trim();
-      if (text.isNotEmpty) {
-        unawaited(sessionCubit.updateSessionTitle(agent: device, session: session, title: text));
-        Navigator.pop(context);
-      }
-    }
-
-    unawaited(
-      showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Rename Session'),
-          content: TextFormField(
-            initialValue: session.title,
-            autofocus: true,
-            decoration: const InputDecoration(hintText: 'New title'),
-            onChanged: (val) => titleText = val,
-            onFieldSubmitted: (_) => onRename(),
-          ),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
-            TextButton(onPressed: onRename, child: const Text('Rename')),
-          ],
-        ),
-      ),
-    );
-  }
-
-  void _showDeleteConfirmation(BuildContext context, SessionCubit sessionCubit) {
-    unawaited(
-      showDialog(
-        context: context,
-        builder: (context) => AlertDialog(
-          title: const Text('Delete Session'),
-          content: Text('Are you sure you want to delete "${session.title}"? This cannot be undone.'),
-          actions: [
-            TextButton(onPressed: () => Navigator.pop(context), child: const Text('Cancel')),
-            TextButton(
-              onPressed: () async {
-                await sessionCubit.deleteSession(agent: device, session: session);
-                switch (context.mounted) {
-                  case true:
-                    Navigator.pop(context);
-                  case false:
-                    break;
-                }
-              },
-              child: const Text('Delete', style: TextStyle(color: Colors.redAccent)),
-            ),
-          ],
-        ),
-      ),
     );
   }
 }

--- a/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_conversation_row.dart
+++ b/client/lib/features/conversations/presentation/widgets/sidebar/sidebar_conversation_row.dart
@@ -406,77 +406,90 @@ class _SidebarSessionTrailing extends StatelessWidget {
           );
         }
 
-        if (isHovered && hasOptions) {
-          return PopupMenuButton<String>(
-            tooltip: '',
-            icon: Icon(
-              Icons.more_vert,
-              color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
-              size: 14,
-            ),
-            padding: EdgeInsets.zero,
-            constraints: const BoxConstraints(
-              minWidth: 32,
-              minHeight: 32,
-            ),
-            onSelected: (value) {
-              final sessionCubit = context.read<SessionCubit>();
-              switch (value) {
-                case 'rename':
-                  _showRenameDialog(context, sessionCubit, device, session);
-                case 'delete':
-                  _showDeleteConfirmation(context, sessionCubit, device, session);
-              }
-            },
-            itemBuilder: (context) => [
-              ...switch (caps.supportsUpdateSessionName) {
-                true => [
-                  PopupMenuItem(
-                    value: 'rename',
-                    height: 32,
-                    child: Row(
-                      children: [
-                        Icon(Icons.edit_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
-                        const SizedBox(width: 8),
-                        Text(
-                          'Rename',
-                          style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 12),
+        final showOptions = isHovered && hasOptions;
+        return SizedBox(
+          width: 32,
+          height: 32,
+          child: Stack(
+            alignment: Alignment.centerRight,
+            children: [
+              Visibility(
+                visible: showOptions,
+                maintainState: true,
+                maintainAnimation: true,
+                child: PopupMenuButton<String>(
+                  tooltip: '',
+                  icon: Icon(
+                    Icons.more_vert,
+                    color: theme.colorScheme.onSurface.withValues(alpha: 0.5),
+                    size: 14,
+                  ),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(
+                    minWidth: 32,
+                    minHeight: 32,
+                  ),
+                  onSelected: (value) {
+                    final sessionCubit = context.read<SessionCubit>();
+                    switch (value) {
+                      case 'rename':
+                        _showRenameDialog(context, sessionCubit, device, session);
+                      case 'delete':
+                        _showDeleteConfirmation(context, sessionCubit, device, session);
+                    }
+                  },
+                  itemBuilder: (context) => [
+                    ...switch (caps.supportsUpdateSessionName) {
+                      true => [
+                        PopupMenuItem(
+                          value: 'rename',
+                          height: 32,
+                          child: Row(
+                            children: [
+                              Icon(Icons.edit_outlined, size: 14, color: theme.colorScheme.onSurfaceVariant),
+                              const SizedBox(width: 8),
+                              Text(
+                                'Rename',
+                                style: TextStyle(color: theme.colorScheme.onSurfaceVariant, fontSize: 12),
+                              ),
+                            ],
+                          ),
                         ),
                       ],
-                    ),
-                  ),
-                ],
-                false => const <PopupMenuItem<String>>[],
-              },
-              ...switch (caps.supportsDeleteSession) {
-                true => [
-                  PopupMenuItem(
-                    value: 'delete',
-                    height: 32,
-                    child: Row(
-                      children: [
-                        Icon(Icons.delete_outline, size: 14, color: Colors.redAccent),
-                        const SizedBox(width: 8),
-                        const Text('Delete', style: TextStyle(color: Colors.redAccent, fontSize: 12)),
+                      false => const <PopupMenuItem<String>>[],
+                    },
+                    ...switch (caps.supportsDeleteSession) {
+                      true => [
+                        PopupMenuItem(
+                          value: 'delete',
+                          height: 32,
+                          child: Row(
+                            children: [
+                              Icon(Icons.delete_outline, size: 14, color: Colors.redAccent),
+                              const SizedBox(width: 8),
+                              const Text('Delete', style: TextStyle(color: Colors.redAccent, fontSize: 12)),
+                            ],
+                          ),
+                        ),
                       ],
+                      false => const <PopupMenuItem<String>>[],
+                    },
+                  ],
+                ),
+              ),
+              if (!showOptions)
+                Padding(
+                  padding: const EdgeInsets.only(right: 4),
+                  child: Text(
+                    formatCompactRelativeTime(session.updatedAt),
+                    style: TextStyle(
+                      color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
+                      fontSize: 10,
+                      fontWeight: FontWeight.w400,
                     ),
                   ),
-                ],
-                false => const <PopupMenuItem<String>>[],
-              },
+                ),
             ],
-          );
-        }
-
-        return Padding(
-          padding: const EdgeInsets.only(right: 4),
-          child: Text(
-            formatCompactRelativeTime(session.updatedAt),
-            style: TextStyle(
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
-              fontSize: 10,
-              fontWeight: FontWeight.w400,
-            ),
           ),
         );
       },

--- a/client/lib/features/home/data/sidebar_preferences.dart
+++ b/client/lib/features/home/data/sidebar_preferences.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Persists application-level Home sidebar layout preferences.
+class SidebarPreferences {
+  static const String sidebarWidthKey = 'home_sidebar_width';
+
+  final SharedPreferences _preferences;
+
+  const SidebarPreferences(this._preferences);
+
+  double? get sidebarWidth => _preferences.getDouble(sidebarWidthKey);
+
+  Future<void> setSidebarWidth(double width) {
+    return _preferences.setDouble(sidebarWidthKey, width);
+  }
+}

--- a/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
+++ b/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -7,16 +8,20 @@ import 'package:sanad_client/core/navigation/conversation_destination.dart';
 import 'package:sanad_client/core/navigation/navigation_history_controller.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/session_sidebar.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/sidebar/sidebar_composition.dart';
+import 'package:sanad_client/features/home/data/sidebar_preferences.dart';
 import 'package:sanad_client/utils/app_platform.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 class ConversationWorkspaceLayout extends StatefulWidget {
   final Widget child;
   final bool showChrome;
+  final SidebarPreferences? sidebarPreferences;
 
   const ConversationWorkspaceLayout({
     super.key,
     required this.child,
     this.showChrome = true,
+    this.sidebarPreferences,
   });
 
   @override
@@ -30,12 +35,28 @@ class ConversationWorkspaceLayout extends StatefulWidget {
 class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout> {
   static const double _resizeHandleWidth = 10;
 
+  late final SidebarPreferences _sidebarPreferences;
   double _sidebarWidth = SidebarBreakpoints.desktopWidth;
   bool _isPinned = true;
   bool _isHovered = false;
   bool _isResizing = false;
 
   bool get isPinned => _isPinned;
+
+  @override
+  void initState() {
+    super.initState();
+    _sidebarPreferences = widget.sidebarPreferences ?? SidebarPreferences(getIt<SharedPreferences>());
+    final savedWidth = _sidebarPreferences.sidebarWidth;
+    if (savedWidth != null && savedWidth.isFinite) {
+      _sidebarWidth = savedWidth
+          .clamp(
+            SidebarBreakpoints.minWidth,
+            SidebarBreakpoints.maxWidth,
+          )
+          .toDouble();
+    }
+  }
 
   void togglePin() {
     setState(() {
@@ -75,6 +96,7 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
     setState(() {
       _isResizing = false;
     });
+    unawaited(_sidebarPreferences.setSidebarWidth(_sidebarWidth));
   }
 
   void _onDragCancel() {
@@ -189,7 +211,6 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
         Row(
           children: [
             permanentSidebar,
-            resizeHandle,
             Expanded(child: widget.child),
           ],
         ),
@@ -243,6 +264,13 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
             ),
           ),
         ),
+        if (_isPinned)
+          Positioned(
+            left: _sidebarWidth - (isMacOS ? 8 : 0) - (_resizeHandleWidth / 2),
+            top: 0,
+            bottom: 0,
+            child: resizeHandle,
+          ),
         Positioned(
           left: 0,
           top: 0,

--- a/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
+++ b/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
@@ -216,6 +216,10 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
         Row(
           children: [
             permanentSidebar,
+            Transform.translate(
+              offset: Offset(isMacOS ? -8 : -(_resizeHandleWidth / 2), 0),
+              child: resizeHandle,
+            ),
             Expanded(child: widget.child),
           ],
         ),
@@ -269,13 +273,6 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
             ),
           ),
         ),
-        if (_isPinned)
-          Positioned(
-            left: _sidebarWidth - (isMacOS ? 8 : 0) - (_resizeHandleWidth / 2),
-            top: 0,
-            bottom: 0,
-            child: resizeHandle,
-          ),
         Positioned(
           left: 0,
           top: 0,

--- a/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
+++ b/client/lib/features/home/presentation/widgets/conversation_workspace_layout.dart
@@ -35,7 +35,7 @@ class ConversationWorkspaceLayout extends StatefulWidget {
 class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout> {
   static const double _resizeHandleWidth = 10;
 
-  late final SidebarPreferences _sidebarPreferences;
+  SidebarPreferences? _sidebarPreferences;
   double _sidebarWidth = SidebarBreakpoints.desktopWidth;
   bool _isPinned = true;
   bool _isHovered = false;
@@ -46,8 +46,10 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
   @override
   void initState() {
     super.initState();
-    _sidebarPreferences = widget.sidebarPreferences ?? SidebarPreferences(getIt<SharedPreferences>());
-    final savedWidth = _sidebarPreferences.sidebarWidth;
+    _sidebarPreferences =
+        widget.sidebarPreferences ??
+        (getIt.isRegistered<SharedPreferences>() ? SidebarPreferences(getIt<SharedPreferences>()) : null);
+    final savedWidth = _sidebarPreferences?.sidebarWidth;
     if (savedWidth != null && savedWidth.isFinite) {
       _sidebarWidth = savedWidth
           .clamp(
@@ -96,7 +98,10 @@ class ConversationWorkspaceLayoutState extends State<ConversationWorkspaceLayout
     setState(() {
       _isResizing = false;
     });
-    unawaited(_sidebarPreferences.setSidebarWidth(_sidebarWidth));
+    final sidebarPreferences = _sidebarPreferences;
+    if (sidebarPreferences != null) {
+      unawaited(sidebarPreferences.setSidebarWidth(_sidebarWidth));
+    }
   }
 
   void _onDragCancel() {

--- a/client/test/unit/features/home/sidebar_preferences_test.dart
+++ b/client/test/unit/features/home/sidebar_preferences_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/home/data/sidebar_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('stores and restores the sidebar width', () async {
+    final preferences = await SharedPreferences.getInstance();
+    final sidebarPreferences = SidebarPreferences(preferences);
+
+    await sidebarPreferences.setSidebarWidth(360);
+
+    expect(sidebarPreferences.sidebarWidth, 360);
+    expect(preferences.getDouble(SidebarPreferences.sidebarWidthKey), 360);
+  });
+
+  test('ignores unrelated preference keys', () async {
+    SharedPreferences.setMockInitialValues({'unrelated_width': 360});
+    final sidebarPreferences = SidebarPreferences(
+      await SharedPreferences.getInstance(),
+    );
+
+    expect(sidebarPreferences.sidebarWidth, isNull);
+  });
+}

--- a/client/test/widget/markdown_code_direction_test.dart
+++ b/client/test/widget/markdown_code_direction_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/markdown_style_helper.dart';
+
+void main() {
+  const codeColor = Colors.green;
+
+  Widget host(String code) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SizedBox(
+          width: 240,
+          height: 120,
+          child: AppCodeBlock(
+            codeText: code,
+            codeColor: codeColor,
+          ),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('Arabic code uses RTL text with an LTR scroll viewport', (tester) async {
+    const code = 'اطبع هذا النص ثم استخدم هذا السطر الطويل جدًا';
+    await tester.pumpWidget(host(code));
+
+    expect(
+      tester.widgetList<Directionality>(find.byType(Directionality)).map((widget) => widget.textDirection),
+      containsAll(<TextDirection>[TextDirection.ltr, TextDirection.rtl]),
+    );
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 0);
+  });
+
+  testWidgets('English code uses LTR text and starts at the left edge', (tester) async {
+    const code = 'const veryLongVariableName = calculateSomethingUsefulForTheUser();';
+    await tester.pumpWidget(host(code));
+
+    final directions = tester
+        .widgetList<Directionality>(find.byType(Directionality))
+        .map((widget) => widget.textDirection);
+    expect(directions, everyElement(TextDirection.ltr));
+    expect(tester.state<ScrollableState>(find.byType(Scrollable)).position.pixels, 0);
+  });
+}

--- a/client/test/widget/sidebar_relative_time_test.dart
+++ b/client/test/widget/sidebar_relative_time_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/sidebar/sidebar_conversation_row.dart';
+
+void main() {
+  group('formatCompactRelativeTime', () {
+    test('formats recent timestamp as now', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now), 'now');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(seconds: 5))), 'now');
+    });
+
+    test('formats seconds', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(seconds: 30))), '30s');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(seconds: 59))), '59s');
+    });
+
+    test('formats minutes', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(minutes: 1))), '1m');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(minutes: 45))), '45m');
+    });
+
+    test('formats hours', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(hours: 1))), '1h');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(hours: 23))), '23h');
+    });
+
+    test('formats days', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 1))), '1d');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 6))), '6d');
+    });
+
+    test('formats weeks', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 7))), '1w');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 21))), '3w');
+    });
+
+    test('formats months and years', () {
+      final now = DateTime.now();
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 60))), '2mo');
+      expect(formatCompactRelativeTime(now.subtract(const Duration(days: 400))), '1y');
+    });
+  });
+}

--- a/docs/plans/tasks/markdown-code-direction-scroll.md
+++ b/docs/plans/tasks/markdown-code-direction-scroll.md
@@ -1,0 +1,33 @@
+---
+title: "Markdown Code Block Direction and Scroll Origin"
+status: "implemented"
+---
+
+# Markdown Code Block Direction and Scroll Origin
+
+## Goal
+
+Make fenced/multiline Markdown code blocks detect their content direction while
+keeping the horizontal viewport itself left-to-right.
+
+## Acceptance criteria
+
+- Arabic-containing code is rendered with RTL text direction.
+- Code without Arabic/RTL characters is rendered with LTR text direction.
+- The horizontal scroll axis remains LTR for both directions.
+- A long code block opens at horizontal offset zero, showing its left edge.
+- Inline code and existing Markdown styling remain unchanged.
+
+## Implementation
+
+- Reuse `TextUtils.getTextDirection` for content detection.
+- Render the scroll viewport under LTR `Directionality`, with the code text
+  under a nested detected direction.
+- Keep the multiline code block as an application-owned widget so direction and
+  scroll behavior are testable independently of the Markdown parser.
+
+## Verification
+
+- Widget-test Arabic and English code direction.
+- Assert the horizontal scroll position starts at zero.
+- Run the focused Markdown test and `fvm flutter analyze`.

--- a/docs/plans/tasks/sidebar-resize-persistence.md
+++ b/docs/plans/tasks/sidebar-resize-persistence.md
@@ -1,0 +1,35 @@
+---
+title: "Sidebar Resize Boundary and Persistence"
+status: "implemented"
+---
+
+# Sidebar Resize Boundary and Persistence
+
+## Goal
+
+Make the desktop Home sidebar resize handle coincide with the visible sidebar
+edge, and restore the user's chosen sidebar width after restarting the client.
+
+## Acceptance criteria
+
+- The horizontal resize cursor and drag target are centered on the visible
+  sidebar boundary, including the macOS shell margin.
+- Dragging keeps the existing 220–420 pixel bounds.
+- The final width is stored in the client SharedPreferences namespace.
+- A valid stored width is restored on Home layout creation; missing or invalid
+  values use the 300 pixel default and remain bounded.
+- Mobile and drawer layouts are unchanged.
+
+## Implementation
+
+- `SidebarPreferences` owns the stable SharedPreferences key for this
+  application-level layout preference.
+- `ConversationWorkspaceLayout` loads the preference synchronously during
+  state initialization and writes it when a resize gesture ends.
+- The resize handle is overlaid at the actual sidebar edge instead of being
+  placed after a separate spacer in the layout row.
+
+## Verification
+
+- Unit-test the preference read/write behavior and unrelated-key isolation.
+- Run the focused client test and `fvm flutter analyze`.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -103,7 +103,10 @@ opening; users never need to close and reopen the menu to refresh it.
 ## Active work
 
 The conversation timeline renders Markdown, code, reasoning summaries, tool
-activity, permission requests, recovery notices, and final responses. Skill
+activity, permission requests, recovery notices, and final responses. Multiline
+Markdown code blocks detect Arabic versus non-Arabic content for text direction:
+Arabic code is RTL and other code is LTR. The code viewport itself always uses
+an LTR horizontal scroll origin so long blocks open with their left edge visible. Skill
 loading uses the same compact path-and-content presentation as File Read, while
 the loaded `SKILL.md` body renders as selectable README-style Markdown rather
 than raw tool JSON. File Read results for `.md` and `.markdown` targets place a

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -58,8 +58,10 @@ temporarily unavailable. Recent user activity moves a conversation to the top
 of its section without losing the current selection or scroll position.
 
 On wide desktop and tablet layouts, navigation appears as a persistent,
-resizable sidebar. On mobile and narrow layouts, it becomes a drawer that
-closes after a destination is selected.
+resizable sidebar. The resize target follows the sidebar's visible edge,
+including the macOS shell margin, and the selected desktop width is restored
+from local client preferences on the next launch. On mobile and narrow layouts,
+it becomes a drawer that closes after a destination is selected.
 
 Opening a conversation with active work shows its latest event so current
 progress is immediately visible. An idle conversation resumes from the event

--- a/docs/qa_maintenance/device_workspace_sidebar_qa.md
+++ b/docs/qa_maintenance/device_workspace_sidebar_qa.md
@@ -88,8 +88,12 @@ description: "Focused QA coverage for the Plan 32c device-scoped sidebar, includ
 1. Validate on wide desktop width.
 2. Validate on narrow tablet/mobile width.
 3. **Expected desktop:** Fixed/resizable sidebar layout and its toggle, Back, and Forward header controls render without overflow on macOS, Linux, and Windows.
-4. **Expected mobile/drawer:** Sidebar actions have comfortable touch targets and the drawer closes after selecting a conversation.
-5. **Expected macOS:** Traffic-light spacing remains visually clear in the fixed sidebar shell.
+4. Drag the sidebar's visible right boundary to several widths.
+5. **Expected:** The resize cursor and drag target are centered on the visible boundary, including the macOS shell margin; the sidebar follows the pointer without a gap.
+6. Restart the client.
+7. **Expected:** The last desktop sidebar width is restored and remains within the supported bounds.
+8. **Expected mobile/drawer:** Sidebar actions have comfortable touch targets and the drawer closes after selecting a conversation.
+9. **Expected macOS:** Traffic-light spacing remains visually clear in the fixed sidebar shell.
 
 ### 10. Accessibility checks
 1. Inspect the sidebar using accessibility tooling or semantics debugging.


### PR DESCRIPTION
## Problem / Goal
Fix the desktop sidebar resize interaction so the drag target aligns with the visible sidebar edge, persist the selected width, and improve sidebar session-row navigation feedback.

## Changes
- Align the desktop resize handle with the visible sidebar boundary, including the macOS shell margin.
- Persist and restore the sidebar width through the client SharedPreferences namespace.
- Increase the default desktop sidebar width from 280px to 300px while keeping the 220–420px bounds.
- Add compact relative-time labels and mobile long-press session actions.
- Add focused preference and relative-time tests.
- Update product, QA, and implementation-plan documentation.

## Verification
- `fvm flutter analyze`
- `fvm flutter test test/unit/features/home/sidebar_preferences_test.dart`
- `fvm flutter test test/widget/sidebar_relative_time_test.dart`
- `git diff --check`

## Risk / Rollback
UI-only client changes with local preference persistence. Revert the PR commit to roll back.

## Cross-platform impact
Desktop resize behavior is updated; mobile and drawer behavior remain unchanged. Relative-time and long-press actions cover compact sidebar presentation.
