### PR TITLE
feat(agent): support authorized external workspace file access with permission gates

### DIFF
--- a/agent/lib/capabilities/permissions/AGENTS.md
+++ b/agent/lib/capabilities/permissions/AGENTS.md
@@ -8,6 +8,7 @@ This contract applies to `agent/lib/capabilities/permissions/`.
 - UI and transports may present and return decisions but cannot bypass policy or own grant caches.
 - Persist workspace policy through the dedicated store and keep permission origin/scope explicit.
 - Apply once, session, and workspace decisions according to their exact scope.
+- External workspace-file grants are keyed by tool plus canonical target path. Keep original arguments in the durable checkpoint for resume, but expose only sanitized action/path details in the permission payload.
 
 ## Durable Suspension
 - Write a durable suspended checkpoint before a sensitive tool call waits for user approval.

--- a/agent/lib/capabilities/permissions/permission_manager.dart
+++ b/agent/lib/capabilities/permissions/permission_manager.dart
@@ -44,6 +44,8 @@ class PermissionManager {
     required LocalToolSpec tool,
     required Map<String, dynamic> arguments,
     required ToolContext context,
+    String? approvalKeyOverride,
+    Map<String, dynamic>? permissionDisplayArguments,
   }) async {
     if (!_requiresApproval(tool)) {
       return;
@@ -56,7 +58,7 @@ class PermissionManager {
     final workspacePath = workspace?['path']?.toString();
     final workspaceId = workspace?['id']?.toString();
     final workspaceName = workspace?['name']?.toString();
-    final approvalKey = _approvalKey(tool, arguments);
+    final approvalKey = approvalKeyOverride ?? _approvalKey(tool, arguments);
     final permissionClass =
         tool.approval['permission_class']?.toString() ?? tool.category;
 
@@ -109,7 +111,8 @@ class PermissionManager {
       'workspace_name': workspaceName,
       'workspace_path': workspacePath,
       'session_id': context.sessionId,
-      'tool_input': arguments,
+      'tool_input': permissionDisplayArguments ?? arguments,
+      'approval_key': approvalKey,
       'tool': tool.toJson(),
     };
 
@@ -185,7 +188,9 @@ class PermissionManager {
     final workspacePath = permissionPayload['workspace_path']?.toString();
     final scope = decision['scope']?.toString() ?? 'once';
     final allowed = decision['allowed'] == true;
-    final approvalKey = _approvalKey(tool, arguments);
+    final approvalKey =
+        permissionPayload['approval_key']?.toString() ??
+        _approvalKey(tool, arguments);
     final currentPolicy = workspacePath == null || workspacePath.isEmpty
         ? null
         : await _policyStore.readPolicy(workspacePath);

--- a/agent/lib/capabilities/runtime/AGENTS.md
+++ b/agent/lib/capabilities/runtime/AGENTS.md
@@ -19,7 +19,7 @@ This contract applies to `agent/lib/capabilities/runtime/`.
 
 ## Workspace Services
 - Use focused handlers for read, write, edit, glob, grep, and tree operations; do not recreate a monolithic workspace service.
-- Enforce selected workspace and path traversal boundaries before host access.
+- Resolve and canonicalize every workspace-tool path before host access. Internal paths execute directly; external paths require an explicit `PermissionManager` decision unless workspace policy is `full_access`, and authorization remains bound to the canonical target.
 - Recursive workspace search skips common generated/dependency trees and unreadable non-UTF-8 candidates rather than failing the entire query.
 - Return host-root and parent navigation metadata for remote browsing rather than requiring client path inference.
 - Workspace creation accepts explicit path and derives display name from basename when name is absent.

--- a/agent/lib/capabilities/runtime/local_runtime_catalog.dart
+++ b/agent/lib/capabilities/runtime/local_runtime_catalog.dart
@@ -68,7 +68,7 @@ class LocalRuntimeCatalog {
     ];
 
     if (workspacePath != null && workspacePath.isNotEmpty) {
-      tools.addAll(_buildWorkspaceTools(workspacePath));
+      tools.addAll(_buildWorkspaceTools(workspacePath, request));
     }
 
     final hasConfig = getIt.isRegistered<Config>();
@@ -327,7 +327,10 @@ class LocalRuntimeCatalog {
     );
   }
 
-  List<BaseTool> _buildWorkspaceTools(String workspacePath) {
+  List<BaseTool> _buildWorkspaceTools(
+    String workspacePath,
+    AgentTurnRequest request,
+  ) {
     return [
       ShellExecuteTool(
         workspacePath: workspacePath,
@@ -338,7 +341,7 @@ class LocalRuntimeCatalog {
           name: 'file_read',
           displayName: 'Read File',
           description:
-              'Read a file or list contents of a directory. For files, returns up to 2000 lines from the start. Use offset (1-indexed) to read later sections. Lines are prefixed with line numbers. Lines >2000 chars are truncated. For directories, returns paginated entries.',
+              'Read a file or list a directory. Paths inside the workspace execute directly; external paths require full access or user approval. Files return up to 2000 lines, with offset for later sections, and directories return paginated entries.',
           inputSchema: const {
             'type': 'object',
             'properties': {
@@ -353,7 +356,18 @@ class LocalRuntimeCatalog {
           restartReplaySafe: true,
         ),
         onExecute: (args, {context}) async {
-          return FileReadHandler(_pathResolver).execute(args, workspacePath);
+          final authorizedExternalRoot = await _authorizeExternalWorkspacePath(
+            toolName: 'file_read',
+            arguments: args,
+            context: context,
+            request: request,
+            workspacePath: workspacePath,
+          );
+          return FileReadHandler(_pathResolver).execute(
+            args,
+            workspacePath,
+            authorizedExternalRoot: authorizedExternalRoot,
+          );
         },
       ),
       CallbackTool(
@@ -361,7 +375,7 @@ class LocalRuntimeCatalog {
           name: 'file_write',
           displayName: 'Write File',
           description:
-              'Create or replace a text file inside the selected workspace.',
+              'Create or replace a text file inside the workspace or at an authorized external path.',
           inputSchema: const {
             'type': 'object',
             'properties': {
@@ -374,7 +388,19 @@ class LocalRuntimeCatalog {
           category: 'workspace_io',
         ),
         onExecute: (args, {context}) async {
-          return FileWriteHandler(_pathResolver).execute(args, workspacePath);
+          final authorizedExternalRoot = await _authorizeExternalWorkspacePath(
+            toolName: 'file_write',
+            arguments: args,
+            context: context,
+            request: request,
+            workspacePath: workspacePath,
+            allowMissing: true,
+          );
+          return FileWriteHandler(_pathResolver).execute(
+            args,
+            workspacePath,
+            authorizedExternalRoot: authorizedExternalRoot,
+          );
         },
       ),
       CallbackTool(
@@ -382,7 +408,7 @@ class LocalRuntimeCatalog {
           name: 'file_edit',
           displayName: 'Edit File',
           description:
-              'Performs exact string replacements using an elastic matching algorithm. old_string must preserve exact indentation. Fails if not found or if multiple matches exist (unless replace_all is true). Do NOT include line number prefixes from file_read in old_string.',
+              'Perform an exact string replacement inside the workspace or in an authorized external file. old_string must preserve indentation and must not include file_read line-number prefixes. Fails when no unique match exists unless replace_all is true.',
           inputSchema: const {
             'type': 'object',
             'properties': {
@@ -397,7 +423,18 @@ class LocalRuntimeCatalog {
           category: 'workspace_io',
         ),
         onExecute: (args, {context}) async {
-          return FileEditHandler(_pathResolver).execute(args, workspacePath);
+          final authorizedExternalRoot = await _authorizeExternalWorkspacePath(
+            toolName: 'file_edit',
+            arguments: args,
+            context: context,
+            request: request,
+            workspacePath: workspacePath,
+          );
+          return FileEditHandler(_pathResolver).execute(
+            args,
+            workspacePath,
+            authorizedExternalRoot: authorizedExternalRoot,
+          );
         },
       ),
       CallbackTool(
@@ -405,7 +442,7 @@ class LocalRuntimeCatalog {
           name: 'search_glob',
           displayName: 'Glob Search',
           description:
-              'Fast file pattern matching tool. Supports glob patterns like "**/*.dart". Returns matching file paths sorted by modification time.',
+              'Match file patterns in the workspace or an authorized external directory. Supports patterns like "**/*.dart" and returns matches sorted by modification time.',
           inputSchema: const {
             'type': 'object',
             'properties': {
@@ -419,7 +456,18 @@ class LocalRuntimeCatalog {
           restartReplaySafe: true,
         ),
         onExecute: (args, {context}) async {
-          return SearchGlobHandler(_pathResolver).execute(args, workspacePath);
+          final authorizedExternalRoot = await _authorizeExternalWorkspacePath(
+            toolName: 'search_glob',
+            arguments: args,
+            context: context,
+            request: request,
+            workspacePath: workspacePath,
+          );
+          return SearchGlobHandler(_pathResolver).execute(
+            args,
+            workspacePath,
+            authorizedExternalRoot: authorizedExternalRoot,
+          );
         },
       ),
       CallbackTool(
@@ -427,7 +475,7 @@ class LocalRuntimeCatalog {
           name: 'search_grep',
           displayName: 'Grep Search',
           description:
-              'Searches file contents using regular expressions. Filter files with the glob parameter. Returns file paths and line numbers with matches.',
+              'Search file contents in the workspace or an authorized external path using regular expressions, with optional glob filtering and line-numbered matches.',
           inputSchema: const {
             'type': 'object',
             'properties': {
@@ -449,10 +497,100 @@ class LocalRuntimeCatalog {
           restartReplaySafe: true,
         ),
         onExecute: (args, {context}) async {
-          return SearchGrepHandler(_pathResolver).execute(args, workspacePath);
+          final authorizedExternalRoot = await _authorizeExternalWorkspacePath(
+            toolName: 'search_grep',
+            arguments: args,
+            context: context,
+            request: request,
+            workspacePath: workspacePath,
+          );
+          return SearchGrepHandler(_pathResolver).execute(
+            args,
+            workspacePath,
+            authorizedExternalRoot: authorizedExternalRoot,
+          );
         },
       ),
     ];
+  }
+
+  Future<String?> _authorizeExternalWorkspacePath({
+    required String toolName,
+    required Map<String, dynamic> arguments,
+    required ToolContext? context,
+    required AgentTurnRequest request,
+    required String workspacePath,
+    bool allowMissing = false,
+  }) async {
+    final inputPath = arguments['path']?.toString().trim();
+    final effectivePath = inputPath == null || inputPath.isEmpty
+        ? '.'
+        : inputPath;
+    final resolution = allowMissing
+        ? _pathResolver.classifyPathAllowMissing(
+            workspaceRoot: workspacePath,
+            inputPath: effectivePath,
+          )
+        : _pathResolver.classifyExistingPath(
+            workspaceRoot: workspacePath,
+            inputPath: effectivePath,
+          );
+    if (!resolution.isExternal) {
+      return null;
+    }
+
+    final existingWorkspace = context?.metadata['workspace'] is Map
+        ? Map<String, dynamic>.from(context!.metadata['workspace'] as Map)
+        : <String, dynamic>{};
+    final toolContext = ToolContext(
+      sessionId: context?.sessionId ?? request.sessionId,
+      toolCallId: context?.toolCallId,
+      metadata: {
+        ...request.toMetadata(),
+        ...?context?.metadata,
+        'workspace': {
+          ...existingWorkspace,
+          'id': existingWorkspace['id'] ?? request.workspaceId,
+          'path': workspacePath,
+        },
+      },
+    );
+    final approvalSpec = _externalWorkspaceAccessSpec(toolName);
+    await _permissionManager.ensureAuthorized(
+      tool: approvalSpec,
+      arguments: arguments,
+      context: toolContext,
+      approvalKeyOverride:
+          'external_workspace_path::$toolName::${resolution.resolvedPath}',
+      permissionDisplayArguments: {
+        'action': toolName,
+        'path': resolution.resolvedPath,
+      },
+    );
+    return resolution.resolvedPath;
+  }
+
+  LocalToolSpec _externalWorkspaceAccessSpec(String toolName) {
+    return LocalToolSpec(
+      name: toolName,
+      displayName: toolName,
+      description: 'Access a canonical path outside the selected workspace.',
+      inputSchema: const {'type': 'object', 'additionalProperties': true},
+      source: const {
+        'type': 'builtin_workspace',
+        'id': 'sanad-agent.workspace',
+      },
+      category: 'workspace_io',
+      workspaceRequired: true,
+      approval: const {
+        'mode': 'ask',
+        'sensitive': true,
+        'scope': 'once',
+        'permission_class': 'external_workspace_path',
+      },
+      execution: const {'target': 'local_runtime', 'timeout_ms': 30000},
+      serverName: 'workspace',
+    );
   }
 
   LocalToolSpec _workspaceSpec({

--- a/agent/lib/capabilities/runtime/workspace_path_resolver.dart
+++ b/agent/lib/capabilities/runtime/workspace_path_resolver.dart
@@ -2,6 +2,20 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
+class WorkspacePathResolution {
+  const WorkspacePathResolution({
+    required this.workspaceRoot,
+    required this.resolvedPath,
+  });
+
+  final String workspaceRoot;
+  final String resolvedPath;
+
+  bool get isExternal =>
+      !p.equals(workspaceRoot, resolvedPath) &&
+      !p.isWithin(workspaceRoot, resolvedPath);
+}
+
 class WorkspacePathResolver {
   const WorkspacePathResolver();
 
@@ -14,7 +28,7 @@ class WorkspacePathResolver {
     return _canonicalizeExistingPath(trimmed);
   }
 
-  String resolveExistingPath({
+  WorkspacePathResolution classifyExistingPath({
     required String workspaceRoot,
     required String inputPath,
   }) {
@@ -25,27 +39,57 @@ class WorkspacePathResolver {
       throw FileSystemException('Path does not exist.', candidate);
     }
 
-    final resolved = _canonicalizeExistingPath(candidate);
-    return _ensureWithinWorkspace(
+    return WorkspacePathResolution(
       workspaceRoot: normalizedWorkspace,
-      resolvedPath: resolved,
+      resolvedPath: _canonicalizeExistingPath(candidate),
+    );
+  }
+
+  WorkspacePathResolution classifyPathAllowMissing({
+    required String workspaceRoot,
+    required String inputPath,
+  }) {
+    final normalizedWorkspace = normalizeWorkspaceRoot(workspaceRoot);
+    final candidate = _candidatePath(normalizedWorkspace, inputPath);
+    return WorkspacePathResolution(
+      workspaceRoot: normalizedWorkspace,
+      resolvedPath: _canonicalizePathAllowMissing(candidate),
+    );
+  }
+
+  String resolveExistingPath({
+    required String workspaceRoot,
+    required String inputPath,
+    String? authorizedExternalRoot,
+  }) {
+    final resolution = classifyExistingPath(
+      workspaceRoot: workspaceRoot,
+      inputPath: inputPath,
+    );
+    return _ensureWithinWorkspace(
+      workspaceRoot: resolution.workspaceRoot,
+      resolvedPath: resolution.resolvedPath,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
   }
 
   String resolvePathAllowMissing({
     required String workspaceRoot,
     required String inputPath,
+    String? authorizedExternalRoot,
   }) {
-    final normalizedWorkspace = normalizeWorkspaceRoot(workspaceRoot);
-    final candidate = _candidatePath(normalizedWorkspace, inputPath);
-    final resolved = _canonicalizePathAllowMissing(candidate);
+    final resolution = classifyPathAllowMissing(
+      workspaceRoot: workspaceRoot,
+      inputPath: inputPath,
+    );
     return _ensureWithinWorkspace(
-      workspaceRoot: normalizedWorkspace,
-      resolvedPath: resolved,
+      workspaceRoot: resolution.workspaceRoot,
+      resolvedPath: resolution.resolvedPath,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
   }
 
-  String relativeToWorkspace({
+  String displayPath({
     required String workspaceRoot,
     required String resolvedPath,
   }) {
@@ -54,8 +98,16 @@ class WorkspacePathResolver {
     if (p.equals(normalizedWorkspace, normalizedPath)) {
       return '.';
     }
-    return p.relative(normalizedPath, from: normalizedWorkspace);
+    if (p.isWithin(normalizedWorkspace, normalizedPath)) {
+      return p.relative(normalizedPath, from: normalizedWorkspace);
+    }
+    return normalizedPath;
   }
+
+  String relativeToWorkspace({
+    required String workspaceRoot,
+    required String resolvedPath,
+  }) => displayPath(workspaceRoot: workspaceRoot, resolvedPath: resolvedPath);
 
   String _candidatePath(String workspaceRoot, String inputPath) {
     final trimmed = inputPath.trim();
@@ -118,6 +170,7 @@ class WorkspacePathResolver {
   String _ensureWithinWorkspace({
     required String workspaceRoot,
     required String resolvedPath,
+    String? authorizedExternalRoot,
   }) {
     final normalizedWorkspace = p.normalize(workspaceRoot);
     final normalizedPath = p.normalize(resolvedPath);
@@ -126,8 +179,18 @@ class WorkspacePathResolver {
       return normalizedPath;
     }
 
+    if (authorizedExternalRoot != null) {
+      final normalizedAuthorizedRoot = _canonicalizePathAllowMissing(
+        authorizedExternalRoot,
+      );
+      if (p.equals(normalizedAuthorizedRoot, normalizedPath) ||
+          p.isWithin(normalizedAuthorizedRoot, normalizedPath)) {
+        return normalizedPath;
+      }
+    }
+
     throw FileSystemException(
-      'Path escapes the current workspace.',
+      'Path escapes the current workspace without authorization.',
       normalizedPath,
     );
   }

--- a/agent/lib/capabilities/runtime/workspace_tools/file_edit_handler.dart
+++ b/agent/lib/capabilities/runtime/workspace_tools/file_edit_handler.dart
@@ -9,8 +9,9 @@ class FileEditHandler {
 
   Future<String> execute(
     Map<String, dynamic> arguments,
-    String workspacePath,
-  ) async {
+    String workspacePath, {
+    String? authorizedExternalRoot,
+  }) async {
     final path = arguments['path']?.toString() ?? '';
     final oldString = arguments['old_string']?.toString() ?? '';
     final newString = arguments['new_string']?.toString() ?? '';
@@ -23,6 +24,7 @@ class FileEditHandler {
     final resolvedPath = _pathResolver.resolveExistingPath(
       workspaceRoot: workspaceRoot,
       inputPath: path,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
     final file = File(resolvedPath);
     final originalFile = await file.readAsString();

--- a/agent/lib/capabilities/runtime/workspace_tools/file_read_handler.dart
+++ b/agent/lib/capabilities/runtime/workspace_tools/file_read_handler.dart
@@ -15,8 +15,9 @@ class FileReadHandler {
 
   Future<String> execute(
     Map<String, dynamic> arguments,
-    String workspacePath,
-  ) async {
+    String workspacePath, {
+    String? authorizedExternalRoot,
+  }) async {
     final path = arguments['path']?.toString() ?? '';
     final offset =
         WorkspaceToolsUtils.asNonNegativeInt(arguments['offset']) ?? 0;
@@ -26,6 +27,7 @@ class FileReadHandler {
     final resolvedPath = _pathResolver.resolveExistingPath(
       workspaceRoot: workspaceRoot,
       inputPath: path,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
 
     if (FileSystemEntity.isDirectorySync(resolvedPath)) {

--- a/agent/lib/capabilities/runtime/workspace_tools/file_write_handler.dart
+++ b/agent/lib/capabilities/runtime/workspace_tools/file_write_handler.dart
@@ -11,8 +11,9 @@ class FileWriteHandler {
 
   Future<String> execute(
     Map<String, dynamic> arguments,
-    String workspacePath,
-  ) async {
+    String workspacePath, {
+    String? authorizedExternalRoot,
+  }) async {
     final path = arguments['path']?.toString() ?? '';
     final content = arguments['content']?.toString() ?? '';
     if (utf8.encode(content).length > _maxWriteBytes) {
@@ -23,6 +24,7 @@ class FileWriteHandler {
     final resolvedPath = _pathResolver.resolvePathAllowMissing(
       workspaceRoot: workspaceRoot,
       inputPath: path,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
     final file = File(resolvedPath);
     final exists = await file.exists();

--- a/agent/lib/capabilities/runtime/workspace_tools/search_glob_handler.dart
+++ b/agent/lib/capabilities/runtime/workspace_tools/search_glob_handler.dart
@@ -10,8 +10,9 @@ class SearchGlobHandler {
 
   Future<String> execute(
     Map<String, dynamic> arguments,
-    String workspacePath,
-  ) async {
+    String workspacePath, {
+    String? authorizedExternalRoot,
+  }) async {
     final pattern = arguments['pattern']?.toString() ?? '';
     if (pattern.trim().isEmpty) {
       throw const FormatException('pattern is required.');
@@ -21,6 +22,7 @@ class SearchGlobHandler {
     final searchRoot = _resolveSearchRoot(
       workspaceRoot: workspaceRoot,
       pathArgument: arguments['path']?.toString(),
+      authorizedExternalRoot: authorizedExternalRoot,
     );
     final filenames = <String>[];
     var truncated = false;
@@ -56,6 +58,7 @@ class SearchGlobHandler {
       final absolute = _pathResolver.resolveExistingPath(
         workspaceRoot: workspaceRoot,
         inputPath: relative,
+        authorizedExternalRoot: authorizedExternalRoot,
       );
       fileStats[relative] = File(absolute).statSync().modified;
     }
@@ -78,6 +81,7 @@ class SearchGlobHandler {
   String _resolveSearchRoot({
     required String workspaceRoot,
     required String? pathArgument,
+    required String? authorizedExternalRoot,
   }) {
     if (pathArgument == null ||
         pathArgument.trim().isEmpty ||
@@ -87,6 +91,7 @@ class SearchGlobHandler {
     return _pathResolver.resolveExistingPath(
       workspaceRoot: workspaceRoot,
       inputPath: pathArgument,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
   }
 }

--- a/agent/lib/capabilities/runtime/workspace_tools/search_grep_handler.dart
+++ b/agent/lib/capabilities/runtime/workspace_tools/search_grep_handler.dart
@@ -15,8 +15,9 @@ class SearchGrepHandler {
 
   Future<String> execute(
     Map<String, dynamic> arguments,
-    String workspacePath,
-  ) async {
+    String workspacePath, {
+    String? authorizedExternalRoot,
+  }) async {
     var pattern = arguments['pattern']?.toString() ?? '';
     if (pattern.trim().isEmpty) {
       throw const FormatException('pattern is required.');
@@ -39,6 +40,7 @@ class SearchGrepHandler {
     final searchRoot = _resolveSearchRoot(
       workspaceRoot: workspaceRoot,
       pathArgument: arguments['path']?.toString(),
+      authorizedExternalRoot: authorizedExternalRoot,
     );
     final fileGlob = arguments['glob']?.toString();
     final fileGlobRegexes = fileGlob == null || fileGlob.trim().isEmpty
@@ -233,6 +235,7 @@ class SearchGrepHandler {
   String _resolveSearchRoot({
     required String workspaceRoot,
     required String? pathArgument,
+    required String? authorizedExternalRoot,
   }) {
     if (pathArgument == null ||
         pathArgument.trim().isEmpty ||
@@ -242,6 +245,7 @@ class SearchGrepHandler {
     return _pathResolver.resolveExistingPath(
       workspaceRoot: workspaceRoot,
       inputPath: pathArgument,
+      authorizedExternalRoot: authorizedExternalRoot,
     );
   }
 }

--- a/agent/test/capabilities/permission_manager_test.dart
+++ b/agent/test/capabilities/permission_manager_test.dart
@@ -195,6 +195,70 @@ void main() {
       expect(bridge.requestCount, equals(1));
     });
 
+    test(
+      'uses explicit approval keys with sanitized display arguments',
+      () async {
+        final context = ToolContext(
+          sessionId: 'thread-external',
+          toolCallId: 'call-external',
+          metadata: {
+            'workspace': {
+              'id': workspaceDir.path,
+              'name': 'workspace',
+              'path': workspaceDir.path,
+            },
+          },
+        );
+        const approvalKey =
+            'external_workspace_path::file_write::/external/file.txt';
+
+        await manager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {
+            'path': '/external/file.txt',
+            'content': 'private content',
+          },
+          context: context,
+          approvalKeyOverride: approvalKey,
+          permissionDisplayArguments: const {
+            'action': 'file_write',
+            'path': '/external/file.txt',
+          },
+        );
+
+        final policy = await store.readPolicy(workspaceDir.path);
+        expect(policy.permissions.allow, contains(approvalKey));
+        expect(bridge.lastPermissionPayload?['approval_key'], approvalKey);
+        expect(bridge.lastPermissionPayload?['tool_input'], const {
+          'action': 'file_write',
+          'path': '/external/file.txt',
+        });
+        expect(
+          bridge.lastPermissionPayload.toString(),
+          isNot(contains('private content')),
+        );
+        expect(
+          checkpointStore.byRequestId.values.single.toolArguments['content'],
+          'private content',
+        );
+
+        await manager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {
+            'path': '/external/file.txt',
+            'content': 'updated private content',
+          },
+          context: context,
+          approvalKeyOverride: approvalKey,
+          permissionDisplayArguments: const {
+            'action': 'file_write',
+            'path': '/external/file.txt',
+          },
+        );
+        expect(bridge.requestCount, equals(1));
+      },
+    );
+
     test('uses full_access workspace mode without prompting', () async {
       await store.savePolicy(
         workspaceDir.path,

--- a/agent/test/capabilities/runtime_catalog_test.dart
+++ b/agent/test/capabilities/runtime_catalog_test.dart
@@ -6,6 +6,7 @@ import 'package:sanad_agent/capabilities/mcp/mcp_runtime_manager.dart';
 import 'package:sanad_agent/capabilities/mcp/sanad_settings_store.dart';
 import 'package:sanad_agent/capabilities/models/local_tool_spec.dart';
 import 'package:sanad_agent/capabilities/permissions/permission_manager.dart';
+import 'package:sanad_agent/capabilities/permissions/workspace_policy.dart';
 import 'package:sanad_agent/capabilities/permissions/workspace_policy_store.dart';
 import 'package:sanad_agent/capabilities/registry/tools_registry.dart';
 import 'package:sanad_agent/capabilities/runtime/local_runtime_catalog.dart';
@@ -70,6 +71,11 @@ class FakeMcpRuntimeManager extends McpRuntimeManager {
 class FakePlatformRuntimeBridge extends PlatformRuntimeBridge {
   Map<String, dynamic>? lastPermissionPayload;
   Map<String, dynamic>? lastExecutionPayload;
+  Map<String, dynamic> nextDecision = const {
+    'allowed': true,
+    'scope': 'session',
+  };
+  int permissionRequestCount = 0;
 
   @override
   Future<Map<String, dynamic>> requestToolPermission({
@@ -77,8 +83,9 @@ class FakePlatformRuntimeBridge extends PlatformRuntimeBridge {
     required Map<String, dynamic> payload,
     Duration timeout = const Duration(seconds: 60),
   }) async {
+    permissionRequestCount++;
     lastPermissionPayload = payload;
-    return const {'allowed': true, 'scope': 'session'};
+    return nextDecision;
   }
 
   @override
@@ -97,8 +104,12 @@ class FakePlatformRuntimeBridge extends PlatformRuntimeBridge {
 }
 
 class NoopCheckpointStore extends SuspendedCheckpointStore {
+  SuspendedCheckpoint? lastSaved;
+
   @override
-  Future<void> save(SuspendedCheckpoint checkpoint) async {}
+  Future<void> save(SuspendedCheckpoint checkpoint) async {
+    lastSaved = checkpoint;
+  }
 
   @override
   Future<SuspendedCheckpoint?> getByRequestId(String requestId) async {
@@ -123,6 +134,8 @@ void main() {
     late ToolsRegistry registry;
     late FakeMcpRuntimeManager fakeMcpManager;
     late FakePlatformRuntimeBridge fakePlatformBridge;
+    late WorkspacePolicyStore policyStore;
+    late NoopCheckpointStore checkpointStore;
     late LocalRuntimeCatalog catalog;
 
     setUp(() async {
@@ -149,15 +162,17 @@ Use the review skill.''');
       registry = ToolsRegistry();
       fakeMcpManager = FakeMcpRuntimeManager();
       fakePlatformBridge = FakePlatformRuntimeBridge();
+      policyStore = WorkspacePolicyStore(
+        settingsStore: SanadSettingsStore(homeDirectoryPath: tempDir.path),
+      );
+      checkpointStore = NoopCheckpointStore();
       catalog = LocalRuntimeCatalog(
         workspaceRuntimeService: workspaceRuntimeService,
         mcpRuntimeManager: fakeMcpManager,
         permissionManager: PermissionManager(
-          policyStore: WorkspacePolicyStore(
-            settingsStore: SanadSettingsStore(homeDirectoryPath: tempDir.path),
-          ),
+          policyStore: policyStore,
           platformRuntimeBridge: fakePlatformBridge,
-          checkpointStore: NoopCheckpointStore(),
+          checkpointStore: checkpointStore,
         ),
         platformRuntimeBridge: fakePlatformBridge,
       );
@@ -283,6 +298,126 @@ Use the review skill.''');
           .execute({'path': 'notes.txt'});
       expect(mcpResult, contains('mcp__filesystem__read_file'));
       expect(fakeMcpManager.lastArguments?['path'], equals('notes.txt'));
+      expect(fakePlatformBridge.permissionRequestCount, equals(0));
+    });
+
+    test(
+      'asks before each external workspace file capability and exposes only path details',
+      () async {
+        final externalDir = Directory('${tempDir.path}/external')
+          ..createSync(recursive: true);
+        final externalFile = File('${externalDir.path}/notes.txt')
+          ..writeAsStringSync('external hello');
+        final tools = await catalog.buildTools(
+          registry: registry,
+          request: AgentTurnRequest(
+            sessionId: 'thread-external',
+            message: 'Inspect an external path',
+            workspaceId: workspaceDir.path,
+          ),
+        );
+        registry.registerTools(tools);
+
+        final readResult = await registry.getTool('file_read')!.execute({
+          'path': externalFile.path,
+        });
+        expect(readResult, contains(externalFile.path));
+
+        await registry.getTool('file_edit')!.execute({
+          'path': externalFile.path,
+          'old_string': 'hello',
+          'new_string': 'updated',
+        });
+        expect(externalFile.readAsStringSync(), equals('external updated'));
+
+        final globResult = await registry.getTool('search_glob')!.execute({
+          'pattern': '**/*.txt',
+          'path': externalDir.path,
+        });
+        expect(globResult, contains(externalFile.path));
+
+        final grepResult = await registry.getTool('search_grep')!.execute({
+          'pattern': 'updated',
+          'path': externalDir.path,
+        });
+        expect(grepResult, contains(externalFile.path));
+
+        final createdFile = '${externalDir.path}/created.txt';
+        await registry.getTool('file_write')!.execute({
+          'path': createdFile,
+          'content': 'private content',
+        });
+
+        expect(fakePlatformBridge.permissionRequestCount, equals(5));
+        expect(fakePlatformBridge.lastPermissionPayload?['tool_input'], {
+          'action': 'file_write',
+          'path': File(createdFile).resolveSymbolicLinksSync(),
+        });
+        expect(
+          fakePlatformBridge.lastPermissionPayload.toString(),
+          isNot(contains('private content')),
+        );
+        expect(
+          checkpointStore.lastSaved?.toolArguments['content'],
+          equals('private content'),
+        );
+        expect(File(createdFile).readAsStringSync(), equals('private content'));
+      },
+    );
+
+    test('full_access executes an external path without prompting', () async {
+      final externalFile = File('${tempDir.path}/full-access.txt')
+        ..writeAsStringSync('allowed');
+      await policyStore.savePolicy(
+        workspaceDir.path,
+        const WorkspacePolicy(
+          permissionMode: WorkspacePermissionMode.fullAccess,
+        ),
+      );
+      final tools = await catalog.buildTools(
+        registry: registry,
+        request: AgentTurnRequest(
+          sessionId: 'thread-full-access',
+          message: 'Read an external path',
+          workspaceId: workspaceDir.path,
+        ),
+      );
+      registry.registerTools(tools);
+
+      final result = await registry.getTool('file_read')!.execute({
+        'path': externalFile.path,
+      });
+
+      expect(result, contains('allowed'));
+      expect(fakePlatformBridge.permissionRequestCount, equals(0));
+    });
+
+    test('denial prevents an external write', () async {
+      fakePlatformBridge.nextDecision = const {
+        'allowed': false,
+        'scope': 'once',
+      };
+      final externalPath = '${tempDir.path}/denied.txt';
+      final tools = await catalog.buildTools(
+        registry: registry,
+        request: AgentTurnRequest(
+          sessionId: 'thread-denied',
+          message: 'Write an external path',
+          workspaceId: workspaceDir.path,
+        ),
+      );
+      registry.registerTools(tools);
+
+      await expectLater(
+        registry.getTool('file_write')!.execute({
+          'path': externalPath,
+          'content': 'must not be written',
+        }),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(File(externalPath).existsSync(), isFalse);
+      expect(fakePlatformBridge.permissionRequestCount, equals(1));
     });
 
     test('tool search is temporarily disabled and not registered', () async {

--- a/agent/test/capabilities/workspace_path_resolver_test.dart
+++ b/agent/test/capabilities/workspace_path_resolver_test.dart
@@ -1,0 +1,116 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:sanad_agent/capabilities/runtime/workspace_path_resolver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('WorkspacePathResolver external authorization', () {
+    late Directory tempDir;
+    late Directory workspaceDir;
+    late Directory externalDir;
+    const resolver = WorkspacePathResolver();
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('workspace-path-test-');
+      workspaceDir = Directory(p.join(tempDir.path, 'workspace'))
+        ..createSync(recursive: true);
+      externalDir = Directory(p.join(tempDir.path, 'external'))
+        ..createSync(recursive: true);
+    });
+
+    tearDown(() async {
+      if (tempDir.existsSync()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('classifies traversal and absolute paths after canonicalization', () {
+      final externalFile = File(p.join(externalDir.path, 'outside.txt'))
+        ..writeAsStringSync('outside');
+      final traversed = resolver.classifyExistingPath(
+        workspaceRoot: workspaceDir.path,
+        inputPath: p.join('..', 'external', 'outside.txt'),
+      );
+      final absolute = resolver.classifyExistingPath(
+        workspaceRoot: workspaceDir.path,
+        inputPath: externalFile.path,
+      );
+
+      expect(traversed.isExternal, isTrue);
+      expect(traversed.resolvedPath, externalFile.resolveSymbolicLinksSync());
+      expect(absolute.resolvedPath, traversed.resolvedPath);
+      expect(
+        () => resolver.resolveExistingPath(
+          workspaceRoot: workspaceDir.path,
+          inputPath: externalFile.path,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('allows only the authorized external root and its descendants', () {
+      final child = File(p.join(externalDir.path, 'child.txt'))
+        ..writeAsStringSync('child');
+      final sibling = File(p.join(tempDir.path, 'sibling.txt'))
+        ..writeAsStringSync('sibling');
+
+      expect(
+        resolver.resolveExistingPath(
+          workspaceRoot: workspaceDir.path,
+          inputPath: child.path,
+          authorizedExternalRoot: externalDir.path,
+        ),
+        child.resolveSymbolicLinksSync(),
+      );
+      expect(
+        () => resolver.resolveExistingPath(
+          workspaceRoot: workspaceDir.path,
+          inputPath: sibling.path,
+          authorizedExternalRoot: externalDir.path,
+        ),
+        throwsA(isA<FileSystemException>()),
+      );
+    });
+
+    test('classifies a workspace symlink by its external target', () {
+      final target = File(p.join(externalDir.path, 'target.txt'))
+        ..writeAsStringSync('target');
+      final link = Link(p.join(workspaceDir.path, 'linked.txt'))
+        ..createSync(target.path);
+
+      final resolution = resolver.classifyExistingPath(
+        workspaceRoot: workspaceDir.path,
+        inputPath: link.path,
+      );
+
+      expect(resolution.isExternal, isTrue);
+      expect(resolution.resolvedPath, target.resolveSymbolicLinksSync());
+    });
+
+    test(
+      'canonicalizes an external missing write target through its ancestor',
+      () {
+        final target = p.join(externalDir.path, 'nested', 'new.txt');
+        final resolution = resolver.classifyPathAllowMissing(
+          workspaceRoot: workspaceDir.path,
+          inputPath: target,
+        );
+
+        expect(resolution.isExternal, isTrue);
+        expect(
+          resolution.resolvedPath,
+          p.join(externalDir.resolveSymbolicLinksSync(), 'nested', 'new.txt'),
+        );
+        expect(
+          resolver.resolvePathAllowMissing(
+            workspaceRoot: workspaceDir.path,
+            inputPath: target,
+            authorizedExternalRoot: resolution.resolvedPath,
+          ),
+          resolution.resolvedPath,
+        );
+      },
+    );
+  });
+}

--- a/client/lib/features/conversations/presentation/AGENTS.md
+++ b/client/lib/features/conversations/presentation/AGENTS.md
@@ -38,6 +38,7 @@ This contract applies to `client/lib/features/conversations/presentation/`.
 - Render permissions, clarifying questions, and runtime notices inline in the active conversation; do not use app-global approval dialogs.
 - Block normal sending only in the session with the pending suspension.
 - Preserve pending UI until authoritative resolution.
+- Permission-card language remains action-neutral so the same surface accurately covers commands, file access, and other permissioned tools.
 - Keep background suspension and recovery state out of the active composer while surfacing its session-row attention state.
 
 ## Atomic Session Presentation

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart
@@ -123,7 +123,7 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
             Icon(Icons.shield_outlined, size: 16, color: colorScheme.tertiary),
             const SizedBox(width: 8),
             Text(
-              'Allow running this command?',
+              'Allow this tool action?',
               style: GoogleFonts.inter(
                 color: colorScheme.onSurface,
                 fontSize: 15,

--- a/client/test/unit/widgets/permission_request_card_test.dart
+++ b/client/test/unit/widgets/permission_request_card_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/domain/models/device_suspended_request.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart';
+
+void main() {
+  testWidgets('uses action-neutral copy for external file permission', (
+    tester,
+  ) async {
+    const externalPath = '/external/project/file.txt';
+    const request = DeviceSuspendedRequest(
+      requestId: 'permission-1',
+      sessionId: 'session-1',
+      toolName: 'file_write',
+      permissionClass: 'external_workspace_path',
+      scope: 'once',
+      workspaceId: 'workspace-1',
+      workspaceName: 'workspace',
+      workspacePath: '/workspace',
+      toolInput: {'action': 'file_write', 'path': externalPath},
+      tool: {'name': 'file_write'},
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: PermissionRequestCard(
+            request: request,
+            borderColor: Colors.grey,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('Allow this tool action?'), findsOneWidget);
+    expect(find.textContaining(externalPath), findsOneWidget);
+    expect(find.text('Allow running this command?'), findsNothing);
+  });
+}

--- a/client/test/widget/conversation_input_panel_rebuild_test.dart
+++ b/client/test/widget/conversation_input_panel_rebuild_test.dart
@@ -628,7 +628,7 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(find.text('Allow running this command?'), findsOneWidget);
+    expect(find.text('Allow this tool action?'), findsOneWidget);
     expect(find.textContaining('echo hello'), findsOneWidget);
     expect(find.byKey(const Key('chat_input')), findsNothing);
   });

--- a/docs/agent_engine/capability_runtime.md
+++ b/docs/agent_engine/capability_runtime.md
@@ -38,9 +38,15 @@ delegation, and permissioned platform actions remain unsafe unless their exact
 contract proves otherwise.
 
 Workspace file operations are implemented by focused read/write/edit/search
-handlers. Recursive glob/grep discovery omits common generated, cache, build,
-and dependency trees such as virtual environments, `site-packages`, `.next`,
-`dist`, and `target`. A candidate that passes binary sniffing but cannot be
+handlers. Paths are canonicalized before host access. Targets inside the selected
+workspace execute directly; targets outside it execute directly only in
+`full_access` mode, while `default` mode suspends the turn for user approval.
+Remembered grants are scoped by tool plus canonical target. Approval cards expose
+only the action and canonical path, while durable checkpoints retain the original
+arguments required to resume safely. External results use absolute paths and
+internal results remain workspace-relative. Recursive glob/grep discovery omits
+common generated, cache, build, and dependency trees such as virtual
+environments, `site-packages`, `.next`, `dist`, and `target`. A candidate that passes binary sniffing but cannot be
 decoded as UTF-8 is skipped without failing the whole search. Shell execution
 follows host-native command semantics, enforces workspace/path and permission
 policy, applies a bounded timeout, bounds stdout and stderr while streaming, and

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -80,6 +80,7 @@ These files are mandatory execution contracts governing subdirectories. Always r
 - [Conversation Event Live/History Parity QA](docs/qa_maintenance/conversation_event_parity_qa.md): Focused verification for model-step segmentation, tool identity, opaque event IDs, and canonical history hydration.
 - [Conversation Navigation — QA Recovery Matrix](docs/qa_maintenance/conversation_navigation_recovery_matrix.md): QA verification and recovery scenarios for conversation navigation, history, and deletion.
 - [Desktop Authentication Exchange QA](docs/qa_maintenance/desktop_authentication_exchange_qa.md): Regression matrix for credential-free client-daemon authentication reconciliation.
+- [External Workspace File Access QA](docs/qa_maintenance/external_workspace_file_access_qa.md): Regression matrix for canonical external-path classification, permission scopes, full-access bypass, and sanitized approval payloads.
 - [Device Name Editing QA](docs/qa_maintenance/device_name_editing_qa.md): QA scenarios and test matrices for verifying device renaming.
 - [Device Workspace Sidebar QA](docs/qa_maintenance/device_workspace_sidebar_qa.md): Focused QA coverage for the Plan 32c device-scoped sidebar, including pagination, cache-first rendering, responsive layout, accessibility, and live ordering.
 - [Live Context Usage Indicator QA](docs/qa_maintenance/live_context_usage_indicator_qa.md): Regression matrix for latest provider usage, cached-input visibility, tool-loop updates, and history restoration.

--- a/docs/plans/tasks/external_workspace_file_access_permissions.md
+++ b/docs/plans/tasks/external_workspace_file_access_permissions.md
@@ -1,0 +1,27 @@
+# External Workspace File Access Permissions
+
+## Goal
+Allow workspace file and search tools to operate on canonical paths outside the selected workspace when the workspace is in `full_access` mode, while requiring durable user approval in `default` mode.
+
+## Scope
+- Apply to `file_read`, `file_write`, `file_edit`, `search_glob`, and `search_grep`.
+- Keep `shell_execute` outside this task.
+- Preserve direct execution for paths inside the workspace.
+- Treat absolute paths, relative `..` escapes, and symbolic-link targets consistently after canonicalization.
+
+## Implementation
+1. Extend workspace path resolution to classify canonical paths and permit an explicitly authorized external path without weakening the default boundary.
+2. Add a shared external-path authorization gate that delegates policy and durable suspension to `PermissionManager` before any host access.
+3. Key remembered decisions by tool and canonical target path while keeping original tool arguments available for safe resume and exposing only sanitized path/action details in the approval request.
+4. Return absolute paths for external results and workspace-relative paths for internal results.
+5. Generalize the client permission-card wording from commands to tool actions.
+6. Document the runtime and user-facing behavior and add focused regression coverage.
+
+## Definition of Done
+- Internal paths execute without a new permission request.
+- External paths execute without prompting in `full_access` mode.
+- External paths in `default` mode execute only after once, session, or workspace approval and never after denial.
+- Canonicalization prevents `..` and symbolic links from bypassing classification.
+- Approval payloads expose the canonical target and operation but not write/edit content.
+- Agent and client analyzers plus focused tests pass.
+- The capability runtime, client interface, and QA documentation describe the behavior.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -135,9 +135,11 @@ When the agent calls the user-question tool, the composer area displays an
 inline question card with the prompt, suggested answers, and a custom-answer
 option. Submitting the answer resumes the same suspended turn.
 
-Permission cards show the requested action and the available approval scope.
-Permission decisions remain owned by the workspace and are distinct from
-ordinary clarification answers.
+Permission cards show the requested tool action and the available approval
+scope. For file access outside the selected workspace, the card shows the
+canonical target path without exposing write or edit content. Permission
+decisions remain owned by the workspace and are distinct from ordinary
+clarification answers.
 
 ## Providers and models
 

--- a/docs/qa_maintenance/external_workspace_file_access_qa.md
+++ b/docs/qa_maintenance/external_workspace_file_access_qa.md
@@ -1,0 +1,31 @@
+---
+title: "External Workspace File Access QA"
+description: "Regression matrix for permission-aware file and search access outside the selected workspace."
+---
+
+# External Workspace File Access QA
+
+## Coverage Matrix
+
+| Scenario | Expected result |
+|---|---|
+| Any supported tool targets a canonical path inside the workspace | Executes without a new external-path permission request. |
+| `file_read`, `file_write`, `file_edit`, `search_glob`, or `search_grep` targets an external path in `default` mode | The turn suspends and emits a permission request before host content access or mutation. |
+| User approves once | The exact pending tool call resumes once with its original arguments. |
+| User approves for the session | Later calls for the same tool and canonical target execute in that session without another prompt. |
+| User approves for the workspace | The tool plus canonical-target grant persists in workspace policy. |
+| User denies | No read/search/mutation occurs and the tool reports the denial. |
+| Workspace mode is `full_access` | External access executes without a permission request. |
+| Input escapes through `..` or an absolute path | Classification uses the same canonical external-path policy. |
+| A workspace symlink targets an external path | The resolved target is treated as external; the workspace spelling cannot bypass approval. |
+| A missing external write target has a symlinked ancestor | Authorization binds to the canonicalized destination before parent creation or write. |
+| An authorized external directory is searched | Results use absolute paths and remain confined to that authorized canonical root. |
+| A write/edit request is displayed for approval | The UI receives action and canonical path only; original content remains only in the durable resume checkpoint. |
+
+## Focused Automated Verification
+
+- `agent/test/capabilities/workspace_path_resolver_test.dart`
+- `agent/test/capabilities/runtime_catalog_test.dart`
+- `agent/test/capabilities/permission_manager_test.dart`
+
+The permission-card copy is verified with the focused client analyzer and widget surface review; it must remain action-neutral rather than command-specific.


### PR DESCRIPTION
## Problem / Goal
Workspace file and search tools were previously strictly restricted to the workspace boundary or failed when encountering external paths, even when user approval was granted. This PR introduces support for canonical paths outside the selected workspace when in `full_access` mode, while requiring durable user approval in `default` mode.

## Changes
- **Workspace Path Resolver**: Extended path resolution to classify canonical targets and permit explicitly authorized external paths without weakening default workspace containment.
- **Shared External Path Authorization Gate**: Integrated `PermissionManager` delegation across `file_read`, `file_write`, `file_edit`, `search_glob`, and `search_grep` handlers.
- **Client Permission Request Card**: Generalized card wording from command-specific text to tool actions and updated widget test expectations.
- **Documentation & Tests**: Added unit, capability, and widget tests along with updated `capability_runtime.md`, `client_interface.md`, `llms.txt`, and QA documentation.

## Verification
- `agent`: `fvm dart analyze` (0 issues), `fvm dart test` (1080 passed).
- `client`: `fvm flutter analyze` (0 issues), `fvm flutter test` (975 passed).
- Added comprehensive unit tests for path resolution, permission manager, runtime catalog, and permission card widgets.

## Risk & Mitigation
Low risk. Strict canonicalization and `PermissionManager` gates prevent directory traversal or symlink escapes from bypassing approval policies.

## Cross-platform Impact
Cross-platform compatible across macOS, Linux, and Windows path formats.

## Documentation
Updated `docs/agent_engine/capability_runtime.md`, `docs/product/client_interface.md`, and `docs/qa_maintenance/external_workspace_file_access_qa.md`.