### PR TITLE
feat(client): add file drag and drop support to message input panel

### DIFF
--- a/client/lib/features/conversations/presentation/widgets/conversation_input_panel.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input_panel.dart
@@ -25,6 +25,7 @@ import 'package:sanad_client/features/voice/presentation/bloc/voice_stream_state
 import 'package:sanad_client/features/voice/presentation/widgets/voice_stream_panel.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/conversation_context_chips.dart';
 import 'package:sanad_client/utils/toast_utils.dart';
+import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:sanad_client/features/conversations/domain/models/message_delivery_intent.dart';
@@ -75,6 +76,7 @@ class _ConversationInputPanelState extends State<ConversationInputPanel> {
   bool _isRestoringDraftContext = false;
   String? _boundDeviceId;
   String? _observedPendingRequestId;
+  bool _isDragging = false;
 
   @override
   void initState() {
@@ -581,29 +583,61 @@ class _ConversationInputPanelState extends State<ConversationInputPanel> {
 
     final isBlurEnabled = widget.showBlur;
     final decoration = BoxDecoration(
-      color: isBlurEnabled ? theme.colorScheme.surface.withValues(alpha: 0.35) : theme.colorScheme.surface,
+      color: _isDragging
+          ? theme.colorScheme.primary.withValues(alpha: 0.1)
+          : (isBlurEnabled ? theme.colorScheme.surface.withValues(alpha: 0.35) : theme.colorScheme.surface),
       borderRadius: BorderRadius.circular(12),
       border: Border.all(
-        color: theme.colorScheme.outline.withValues(alpha: 0.30),
+        color: _isDragging
+            ? theme.colorScheme.primary
+            : theme.colorScheme.outline.withValues(alpha: 0.30),
+        width: 1.0,
       ),
     );
 
-    final borderCard = Container(
-      margin: const EdgeInsets.only(left: 8, right: 8, bottom: 8),
-      child: ClipRRect(
-        borderRadius: BorderRadius.circular(12),
-        child: isBlurEnabled
-            ? BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
-                child: Container(
+    final borderCard = DropTarget(
+      onDragEntered: (details) {
+        setState(() {
+          _isDragging = true;
+        });
+      },
+      onDragExited: (details) {
+        setState(() {
+          _isDragging = false;
+        });
+      },
+      onDragDone: (details) {
+        setState(() {
+          _isDragging = false;
+        });
+        if (details.files.isNotEmpty) {
+          final droppedPaths = details.files.map((file) => file.path).join(' ');
+          final currentText = _chatController.text;
+          if (currentText.isEmpty) {
+            _chatController.text = '$droppedPaths ';
+          } else {
+            final separator = currentText.endsWith(' ') ? '' : ' ';
+            _chatController.text = '$currentText$separator$droppedPaths ';
+          }
+        }
+      },
+      child: Container(
+        margin: const EdgeInsets.only(left: 8, right: 8, bottom: 8),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(12),
+          child: isBlurEnabled
+              ? BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
+                  child: Container(
+                    decoration: decoration,
+                    child: mainContent,
+                  ),
+                )
+              : Container(
                   decoration: decoration,
                   child: mainContent,
                 ),
-              )
-            : Container(
-                decoration: decoration,
-                child: mainContent,
-              ),
+        ),
       ),
     );
 

--- a/client/macos/Podfile.lock
+++ b/client/macos/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
   - auto_updater_macos (0.0.1):
     - FlutterMacOS
     - Sparkle
+  - desktop_drop (0.0.1):
+    - FlutterMacOS
   - file_selector_macos (0.0.1):
     - FlutterMacOS
   - FlutterMacOS (1.0.0)
@@ -32,6 +34,7 @@ DEPENDENCIES:
   - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
   - audio_session (from `Flutter/ephemeral/.symlinks/plugins/audio_session/macos`)
   - auto_updater_macos (from `Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos`)
+  - desktop_drop (from `Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos`)
   - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
   - macos_window_utils (from `Flutter/ephemeral/.symlinks/plugins/macos_window_utils/macos`)
@@ -54,6 +57,8 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/audio_session/macos
   auto_updater_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/auto_updater_macos/macos
+  desktop_drop:
+    :path: Flutter/ephemeral/.symlinks/plugins/desktop_drop/macos
   file_selector_macos:
     :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
   FlutterMacOS:
@@ -79,6 +84,7 @@ SPEC CHECKSUMS:
   app_links: c3185399a5cabc2e610ee5ad52fb7269b84ff869
   audio_session: 728ae3823d914f809c485d390274861a24b0904e
   auto_updater_macos: 3e3462c418fe4e731917eacd8d28eef7af84086d
+  desktop_drop: 1eeeb9484299585770b6461e4f3d60950e99efa2
   file_selector_macos: 3e56eaea051180007b900eacb006686fd54da150
   FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
   macos_window_utils: 721df4da91cb4bde7b2b7b6ae93cdead4851118f

--- a/client/pubspec.lock
+++ b/client/pubspec.lock
@@ -249,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  desktop_drop:
+    dependency: "direct main"
+    description:
+      name: desktop_drop
+      sha256: aa1e797255bfbc76f9eb5aa4f61e5b68dbf69962ab1be6495816d2f251bc0d1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.1"
   diff_match_patch:
     dependency: "direct main"
     description:
@@ -1290,6 +1298,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  universal_platform:
+    dependency: transitive
+    description:
+      name: universal_platform
+      sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   url_launcher:
     dependency: "direct main"
     description:

--- a/client/pubspec.yaml
+++ b/client/pubspec.yaml
@@ -88,6 +88,7 @@ dependencies:
   audio_session: ^0.1.25
   mp_audio_stream: ^0.2.2
   diff_match_patch: ^0.4.1
+  desktop_drop: ^0.7.1
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/client/test/widget/conversation_input_panel_rebuild_test.dart
+++ b/client/test/widget/conversation_input_panel_rebuild_test.dart
@@ -29,6 +29,7 @@ import 'package:sanad_client/features/provider_setup/data/provider_setup_client.
 import 'package:sanad_client/features/provider_setup/presentation/bloc/provider_usage_cubit.dart';
 import 'package:sanad_client/infrastructure/local_tools/workspace_policy.dart';
 import 'package:sanad_client/utils/workspace_picker_helper.dart';
+import 'package:desktop_drop/desktop_drop.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -868,6 +869,66 @@ void main() {
     expect(pickerCalled, isFalse);
     expect(conversationRepository.browseWorkspaceTreeRequests, isEmpty);
     expect(conversationRepository.createdWorkspaces, isEmpty);
+  });
+
+  testWidgets('appends dropped file paths to input field when files are dragged and dropped', (tester) async {
+    socket.setConnected(true);
+    agent = DeviceConfig(
+      id: 'agent-1',
+      name: 'SanadAgent',
+      isOnline: true,
+      metadata: const {'is_local_reachable': true},
+    );
+    agentRepository.seedAgents([agent], activeAgentId: agent.id);
+    agentCubit.emitState(DeviceActive(activeAgent: agent, agents: [agent]));
+
+    await pumpTestApp(
+      tester,
+      agentCubit: agentCubit,
+      sessionCubit: sessionCubit,
+      sessionMessagesCubit: sessionMessagesCubit,
+      capabilities: capabilities,
+      child: ConversationInputPanel(onSendMessage: (_, {intent = MessageDeliveryIntent.auto}) {}),
+    );
+    await tester.pumpAndSettle();
+
+    final dropTargetFinder = find.byType(DropTarget);
+    expect(dropTargetFinder, findsOneWidget);
+    final DropTarget dropTarget = tester.widget(dropTargetFinder);
+
+    // 1. Drop a single file on an empty input
+    dropTarget.onDragDone?.call(
+      DropDoneDetails(
+        files: [
+          DropItemFile('/path/to/first_file.txt'),
+        ],
+        localPosition: Offset.zero,
+        globalPosition: Offset.zero,
+      ),
+    );
+    await tester.pump();
+
+    // Verify input text is updated to the file path
+    final textFieldFinder = find.byKey(const Key('chat_input'));
+    expect(textFieldFinder, findsOneWidget);
+    final TextField textField1 = tester.widget(textFieldFinder);
+    expect(textField1.controller?.text, '/path/to/first_file.txt ');
+
+    // 2. Drop multiple files on a non-empty input
+    dropTarget.onDragDone?.call(
+      DropDoneDetails(
+        files: [
+          DropItemFile('/path/to/second_file.jpg'),
+          DropItemFile('/path/to/third_file.png'),
+        ],
+        localPosition: Offset.zero,
+        globalPosition: Offset.zero,
+      ),
+    );
+    await tester.pump();
+
+    final TextField textField2 = tester.widget(textFieldFinder);
+    expect(textField2.controller?.text, '/path/to/first_file.txt /path/to/second_file.jpg /path/to/third_file.png ');
   });
 }
 

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -97,6 +97,8 @@ thinking mode. A first-time user with no thinking preference starts at
 runtime has an authoritative provider/model route, the model selector is never
 left empty merely because only the provider half was restored.
 
+Dragging and dropping files of any type onto the composer area captures their full local paths and appends them directly to the message input field. During a drag-over action, the composer card displays a highlighted primary border and a matching subtle background tint for clear visual feedback.
+
 A workspace created elsewhere in the client appears on the selector's first
 opening; users never need to close and reopen the menu to refresh it.
 


### PR DESCRIPTION
## Problem / Goal
Add a feature to the Flutter client that allows dragging and dropping any file onto the message composer area to insert its full local path with correct spacing, and showing a visual highlight during dragging without layout jitter.

## Technical Changes
- Added `desktop_drop: ^0.7.1` dependency to client.
- Wrapped the composition card with `DropTarget` in `ConversationInputPanel`.
- Implemented visual highlight feedback during drag (tinted background, primary colored outline) with a constant width of `1.0` to avoid layout jitter.
- Implemented logic in `onDragDone` to format and insert single or multiple file paths with preceding space (if input is not empty/does not end with space) and trailing space.
- Added comprehensive widget tests in `conversation_input_panel_rebuild_test.dart` simulating drag done with `DropItemFile`.
- Updated `docs/product/client_interface.md` with the new feature details.

## Verification
- Ran static analysis: `fvm flutter analyze` - passed without issues.
- Ran widget tests: `fvm flutter test test/widget/conversation_input_panel_rebuild_test.dart` - passed.