### PR TITLE
fix(permissions): clarify approvals and gate MCP tools

### DIFF
--- a/agent/lib/capabilities/mcp/AGENTS.md
+++ b/agent/lib/capabilities/mcp/AGENTS.md
@@ -8,7 +8,7 @@ This contract applies to `agent/lib/capabilities/mcp/`.
 - Persist client-requested mutations through the same settings owner used by runtime discovery.
 - Clients consume refreshed daemon snapshots and never become configuration truth.
 - Keep secret values out of snapshots, logs, protocol errors, export, and Advanced JSON.
-- Store MCP credentials only through the owner-protected `McpSecretStore`; configuration files contain opaque references and non-secret metadata.
+- Store MCP credentials only through the owner-protected `McpSecretStore`; configuration files contain opaque references and non-secret metadata, including secret STDIO argument values associated with recognized credential flags.
 - Import is preview-first and bounded; Advanced JSON is one-server-only with a reviewed revision before mutation.
 
 ## Runtime Manager

--- a/agent/lib/capabilities/mcp/mcp_runtime_manager.dart
+++ b/agent/lib/capabilities/mcp/mcp_runtime_manager.dart
@@ -278,12 +278,18 @@ class McpRuntimeManager {
       return true;
     }
     return jsonEncode(oldConfig.args) != jsonEncode(newConfig.args) ||
+        jsonEncode(_encodableSecretArgs(oldConfig.secretArgs)) !=
+            jsonEncode(_encodableSecretArgs(newConfig.secretArgs)) ||
         jsonEncode(oldConfig.env) != jsonEncode(newConfig.env) ||
         jsonEncode(oldConfig.secretEnv) != jsonEncode(newConfig.secretEnv) ||
         jsonEncode(oldConfig.headers) != jsonEncode(newConfig.headers) ||
         jsonEncode(oldConfig.secretHeaders) !=
             jsonEncode(newConfig.secretHeaders);
   }
+
+  Map<String, String> _encodableSecretArgs(Map<int, String> values) => {
+    for (final entry in values.entries) entry.key.toString(): entry.value,
+  };
 
   Future<void> _closeConnection(String serverName) async {
     final client = _activeClients.remove(serverName);
@@ -346,7 +352,7 @@ class McpRuntimeManager {
         config: clientConfig,
         transportConfig: TransportConfig.stdio(
           command: config.command!,
-          arguments: config.args,
+          arguments: _settingsStore.resolveArguments(config),
           environment: _buildSafeEnvironment(
             resolvedEnvironment ?? _settingsStore.resolveEnvironment(config),
           ),

--- a/agent/lib/capabilities/mcp/mcp_server_config.dart
+++ b/agent/lib/capabilities/mcp/mcp_server_config.dart
@@ -33,6 +33,7 @@ class McpServerConfig {
     this.disabledTools = const [],
     this.command,
     this.args = const [],
+    this.secretArgs = const {},
     this.env = const {},
     this.secretEnv = const {},
     this.headers = const {},
@@ -59,6 +60,7 @@ class McpServerConfig {
   final List<String> disabledTools;
   final String? command;
   final List<String> args;
+  final Map<int, String> secretArgs;
   final Map<String, String> env;
   final Map<String, String> secretEnv;
   final Map<String, String> headers;
@@ -88,6 +90,12 @@ class McpServerConfig {
     if (transport == McpTransportType.stdio) {
       json['command'] = command;
       if (args.isNotEmpty) json['args'] = args;
+      if (secretArgs.isNotEmpty) {
+        json['secretArgs'] = {
+          for (final entry in secretArgs.entries)
+            entry.key.toString(): entry.value,
+        };
+      }
       if (env.isNotEmpty) json['env'] = env;
       if (secretEnv.isNotEmpty) json['secretEnv'] = secretEnv;
     } else {
@@ -117,6 +125,12 @@ class McpServerConfig {
     if (bearerTokenRef != null) {
       json.remove('bearerTokenRef');
       json['bearerConfigured'] = true;
+    }
+    if (secretArgs.isNotEmpty) {
+      json['secretArgs'] = {
+        for (final index in secretArgs.keys)
+          index.toString(): const {'configured': true},
+      };
     }
     if (secretEnv.isNotEmpty) {
       json['secretEnv'] = {
@@ -159,6 +173,7 @@ class McpServerConfig {
       disabledTools: _stringList(json['disabledTools']),
       command: _string(json['command']),
       args: _stringList(json['args']),
+      secretArgs: _secretArgRefMap(json['secretArgs']),
       env: _stringMap(json['env']),
       secretEnv: _secretRefMap(json['secretEnv']),
       headers: _stringMap(json['headers']),
@@ -195,6 +210,7 @@ class McpServerConfig {
     List<String>? disabledTools,
     String? command,
     List<String>? args,
+    Map<int, String>? secretArgs,
     Map<String, String>? env,
     Map<String, String>? secretEnv,
     Map<String, String>? headers,
@@ -220,6 +236,7 @@ class McpServerConfig {
     disabledTools: disabledTools ?? this.disabledTools,
     command: command ?? this.command,
     args: args ?? this.args,
+    secretArgs: secretArgs ?? this.secretArgs,
     env: env ?? this.env,
     secretEnv: secretEnv ?? this.secretEnv,
     headers: headers ?? this.headers,
@@ -295,6 +312,18 @@ class McpServerConfig {
 
   static Map<String, dynamic> _stringMapDynamic(Object? value) =>
       value is Map ? Map<String, dynamic>.from(value) : const {};
+
+  static Map<int, String> _secretArgRefMap(Object? value) {
+    if (value is! Map) return const {};
+    final result = <int, String>{};
+    for (final entry in value.entries) {
+      final index = int.tryParse(entry.key.toString());
+      if (index != null && entry.value is String) {
+        result[index] = entry.value as String;
+      }
+    }
+    return result;
+  }
 
   static Map<String, String> _secretRefMap(Object? value) {
     if (value is! Map) return const {};

--- a/agent/lib/capabilities/mcp/sanad_settings_store.dart
+++ b/agent/lib/capabilities/mcp/sanad_settings_store.dart
@@ -196,6 +196,22 @@ class SanadSettingsStore {
   String? resolveOAuthClientSecret(McpServerConfig config) =>
       _secrets.resolve(config.oauthClientSecretRef);
 
+  List<String> resolveArguments(McpServerConfig config) {
+    if (config.secretArgs.isEmpty) return config.args;
+    final resolved = List<String>.from(config.args);
+    for (final entry in config.secretArgs.entries) {
+      if (entry.key < 0 || entry.key >= resolved.length) {
+        throw StateError('MCP secret argument index ${entry.key} is invalid.');
+      }
+      final value = _secrets.resolve(entry.value);
+      if (value == null) {
+        throw StateError('MCP secret argument ${entry.key} is unavailable.');
+      }
+      resolved[entry.key] = value;
+    }
+    return resolved;
+  }
+
   Map<String, String> resolveEnvironment(McpServerConfig config) => {
     ...config.env,
     ..._secrets.resolveMany(config.secretEnv),
@@ -302,6 +318,32 @@ class SanadSettingsStore {
         server.remove('env');
       }
       if (secretEnv.isNotEmpty) server['secretEnv'] = secretEnv;
+
+      final args = _stringList(server['args']).toList(growable: false);
+      final secretArgs = _indexedStringMap(server['secretArgs']);
+      for (var index = 0; index < args.length - 1; index++) {
+        if (!_secretArgumentFlags.contains(args[index].toLowerCase())) continue;
+        final valueIndex = index + 1;
+        final rawValue = args[valueIndex];
+        if (rawValue.isEmpty ||
+            rawValue == '<secret>' ||
+            McpSecretStore.isReference(rawValue)) {
+          continue;
+        }
+        secretArgs[valueIndex] = await _secrets.put(
+          rawValue,
+          existingRef: secretArgs[valueIndex],
+        );
+        args[valueIndex] = '<secret>';
+        changed = true;
+      }
+      if (args.isNotEmpty) server['args'] = args;
+      if (secretArgs.isNotEmpty) {
+        server['secretArgs'] = {
+          for (final item in secretArgs.entries)
+            item.key.toString(): item.value,
+        };
+      }
 
       migrated[entry.key.toString()] = server;
     }
@@ -410,6 +452,28 @@ class SanadSettingsStore {
   static List<String> _stringList(Object? value) => value is List
       ? value.map((item) => item.toString()).toList(growable: false)
       : const [];
+
+  static Map<int, String> _indexedStringMap(Object? value) {
+    if (value is! Map) return <int, String>{};
+    final result = <int, String>{};
+    for (final entry in value.entries) {
+      final index = int.tryParse(entry.key.toString());
+      if (index != null) result[index] = entry.value.toString();
+    }
+    return result;
+  }
+
+  static const _secretArgumentFlags = {
+    '--api-key',
+    '--apikey',
+    '--api_key',
+    '--token',
+    '--access-token',
+    '--access_token',
+    '--client-secret',
+    '--client_secret',
+    '--password',
+  };
 
   static final RegExp _likelySecretKey = RegExp(
     r'(token|secret|password|passwd|api[_-]?key|credential)',

--- a/agent/lib/capabilities/permissions/AGENTS.md
+++ b/agent/lib/capabilities/permissions/AGENTS.md
@@ -7,7 +7,7 @@ This contract applies to `agent/lib/capabilities/permissions/`.
 - `PermissionManager` is the sole authority for sensitive runtime and platform-tool approval enforcement.
 - UI and transports may present and return decisions but cannot bypass policy or own grant caches.
 - Persist workspace policy through the dedicated store and keep permission origin/scope explicit.
-- Apply once, session, and workspace decisions according to their exact scope.
+- Apply approval grants at once, session, and workspace scope. A denial rejects only the current invocation and never creates a durable or session-wide deny rule; explicit workspace policy deny entries remain authoritative configuration.
 - External workspace-file grants are keyed by tool plus canonical target path. Keep original arguments in the durable checkpoint for resume, but expose only sanitized action/path details in the permission payload.
 
 ## Durable Suspension

--- a/agent/lib/capabilities/permissions/permission_manager.dart
+++ b/agent/lib/capabilities/permissions/permission_manager.dart
@@ -143,14 +143,6 @@ class PermissionManager {
       status: isAllowed ? 'approved' : 'denied',
     );
     if (!isAllowed) {
-      await _persistDecision(
-        allowed: false,
-        scope: scope,
-        approvalKey: approvalKey,
-        sessionId: context.sessionId,
-        workspacePath: workspacePath,
-        currentPolicy: workspacePolicy,
-      );
       final denyComment = decision['comment']?.toString().trim();
       if (denyComment != null && denyComment.isNotEmpty) {
         throw Exception(
@@ -195,7 +187,10 @@ class PermissionManager {
         ? null
         : await _policyStore.readPolicy(workspacePath);
 
-    if (allowed && scope == 'once' && sessionId.isNotEmpty) {
+    if (!allowed) {
+      return;
+    }
+    if (scope == 'once' && sessionId.isNotEmpty) {
       _oneShotAllow.putIfAbsent(sessionId, () => <String>{}).add(approvalKey);
       return;
     }

--- a/agent/lib/capabilities/runtime/AGENTS.md
+++ b/agent/lib/capabilities/runtime/AGENTS.md
@@ -7,6 +7,7 @@ This contract applies to `agent/lib/capabilities/runtime/`.
 - Build workspace-bound, MCP-bound, skill, web, and explicit platform tool context for every turn.
 - Do not cache mutable workspace/MCP catalogs across turns without an identity/fingerprint invalidation boundary.
 - Preserve local tool source, execution target, approval, workspace, availability, and replay metadata.
+- Every sensitive MCP tool executes through `PermissionManager` before `McpRuntimeManager`; denial prevents the server call, and once/session/workspace grants use the canonical approval owner.
 - Return the assembled catalog to the engine; do not execute the model loop here.
 
 ## Runtime Context

--- a/agent/lib/capabilities/runtime/local_runtime_catalog.dart
+++ b/agent/lib/capabilities/runtime/local_runtime_catalog.dart
@@ -87,6 +87,30 @@ class LocalRuntimeCatalog {
         CallbackTool(
           toolSpec: spec,
           onExecute: (args, {context}) async {
+            final existingWorkspace = context?.metadata['workspace'] is Map
+                ? Map<String, dynamic>.from(
+                    context!.metadata['workspace'] as Map,
+                  )
+                : <String, dynamic>{};
+            final toolContext = ToolContext(
+              sessionId: context?.sessionId ?? request.sessionId,
+              toolCallId: context?.toolCallId,
+              metadata: {
+                ...request.toMetadata(),
+                ...?context?.metadata,
+                if (workspacePath != null)
+                  'workspace': {
+                    ...existingWorkspace,
+                    'id': existingWorkspace['id'] ?? request.workspaceId,
+                    'path': workspacePath,
+                  },
+              },
+            );
+            await _permissionManager.ensureAuthorized(
+              tool: spec,
+              arguments: args,
+              context: toolContext,
+            );
             return _mcpRuntimeManager.executeTool(
               spec.name,
               args,

--- a/agent/test/capabilities/mcp_configuration_test.dart
+++ b/agent/test/capabilities/mcp_configuration_test.dart
@@ -132,6 +132,7 @@ void main() {
             },
             'stdio': {
               'command': 'node',
+              'args': ['server', '--api-key', 'argument-value'],
               'env': {'MODE': 'safe', 'API_KEY': 'env-value'},
             },
           },
@@ -148,10 +149,20 @@ void main() {
         'client-value',
         'header-value',
         'env-value',
+        'argument-value',
       ]) {
         expect(serialized, isNot(contains(secret)));
       }
       expect(serialized, contains('mcp-secret://'));
+      final stdio = settings
+          .parseMcpServersDocument(first)
+          .singleWhere((server) => server.name == 'stdio');
+      expect(stdio.args, ['server', '--api-key', '<secret>']);
+      expect(settings.resolveArguments(stdio), [
+        'server',
+        '--api-key',
+        'argument-value',
+      ]);
       final snapshot = settings.encodeMcpSnapshotDocument(
         settings.parseMcpServersDocument(first),
       );

--- a/agent/test/capabilities/permission_manager_test.dart
+++ b/agent/test/capabilities/permission_manager_test.dart
@@ -152,48 +152,49 @@ void main() {
       },
     );
 
-    test('persists workspace deny decisions and rejects later calls', () async {
-      bridge.nextDecision = const {'allowed': false, 'scope': 'workspace'};
-      final context = ToolContext(
-        sessionId: 'thread-2',
-        toolCallId: 'call-2',
-        metadata: {
-          'workspace': {
-            'id': workspaceDir.path,
-            'name': 'workspace',
-            'path': workspaceDir.path,
+    test(
+      'denial rejects only the current call and prompts again later',
+      () async {
+        bridge.nextDecision = const {'allowed': false, 'scope': 'workspace'};
+        final context = ToolContext(
+          sessionId: 'thread-2',
+          toolCallId: 'call-2',
+          metadata: {
+            'workspace': {
+              'id': workspaceDir.path,
+              'name': 'workspace',
+              'path': workspaceDir.path,
+            },
           },
-        },
-      );
+        );
 
-      await expectLater(
-        manager.ensureAuthorized(
+        await expectLater(
+          manager.ensureAuthorized(
+            tool: shellTool,
+            arguments: {'command': 'rm -rf build'},
+            context: context,
+          ),
+          throwsA(isA<Exception>()),
+        );
+
+        final policy = await store.readPolicy(workspaceDir.path);
+        expect(policy.permissions.deny, isEmpty);
+        expect(bridge.requestCount, equals(1));
+        expect(
+          checkpointStore.byRequestId.values.single.status,
+          equals('denied'),
+        );
+
+        bridge.nextDecision = const {'allowed': true, 'scope': 'once'};
+        await manager.ensureAuthorized(
           tool: shellTool,
           arguments: {'command': 'rm -rf build'},
           context: context,
-        ),
-        throwsA(isA<Exception>()),
-      );
+        );
 
-      final policy = await store.readPolicy(workspaceDir.path);
-      expect(policy.permissions.deny, contains('shell_execute::rm -rf build'));
-      expect(bridge.requestCount, equals(1));
-      expect(
-        checkpointStore.byRequestId.values.single.status,
-        equals('denied'),
-      );
-
-      await expectLater(
-        manager.ensureAuthorized(
-          tool: shellTool,
-          arguments: {'command': 'rm -rf build'},
-          context: context,
-        ),
-        throwsA(isA<Exception>()),
-      );
-
-      expect(bridge.requestCount, equals(1));
-    });
+        expect(bridge.requestCount, equals(2));
+      },
+    );
 
     test(
       'uses explicit approval keys with sanitized display arguments',

--- a/agent/test/capabilities/runtime_catalog_test.dart
+++ b/agent/test/capabilities/runtime_catalog_test.dart
@@ -298,7 +298,108 @@ Use the review skill.''');
           .execute({'path': 'notes.txt'});
       expect(mcpResult, contains('mcp__filesystem__read_file'));
       expect(fakeMcpManager.lastArguments?['path'], equals('notes.txt'));
-      expect(fakePlatformBridge.permissionRequestCount, equals(0));
+      expect(fakePlatformBridge.permissionRequestCount, equals(1));
+      expect(
+        fakePlatformBridge.lastPermissionPayload?['tool_name'],
+        equals('mcp__filesystem__read_file'),
+      );
+      expect(fakePlatformBridge.lastPermissionPayload?['tool_input'], {
+        'path': 'notes.txt',
+      });
+      expect(
+        fakePlatformBridge.lastPermissionPayload?['tool'],
+        containsPair('server_name', 'filesystem'),
+      );
+    });
+
+    test('MCP denial prevents execution', () async {
+      fakePlatformBridge.nextDecision = const {
+        'allowed': false,
+        'scope': 'once',
+      };
+      final tools = await catalog.buildTools(
+        registry: registry,
+        request: AgentTurnRequest(
+          sessionId: 'thread-mcp-denied',
+          message: 'Read through MCP',
+          workspaceId: workspaceDir.path,
+        ),
+      );
+      registry.registerTools(tools);
+
+      await expectLater(
+        registry.getTool('mcp__filesystem__read_file')!.execute({
+          'path': 'notes.txt',
+        }),
+        throwsA(isA<Exception>()),
+      );
+
+      expect(fakePlatformBridge.permissionRequestCount, equals(1));
+      expect(fakeMcpManager.lastToolName, isNull);
+      expect(fakeMcpManager.lastArguments, isNull);
+    });
+
+    test(
+      'MCP session approval suppresses repeated prompts for exact input',
+      () async {
+        fakePlatformBridge.nextDecision = const {
+          'allowed': true,
+          'scope': 'session',
+        };
+        final tools = await catalog.buildTools(
+          registry: registry,
+          request: AgentTurnRequest(
+            sessionId: 'thread-mcp-session',
+            message: 'Read through MCP twice',
+            workspaceId: workspaceDir.path,
+          ),
+        );
+        registry.registerTools(tools);
+        final tool = registry.getTool('mcp__filesystem__read_file')!;
+
+        await tool.execute({'path': 'notes.txt'});
+        await tool.execute({'path': 'notes.txt'});
+
+        expect(fakePlatformBridge.permissionRequestCount, equals(1));
+        expect(fakeMcpManager.lastArguments?['path'], equals('notes.txt'));
+      },
+    );
+
+    test('MCP workspace approval persists through workspace policy', () async {
+      fakePlatformBridge.nextDecision = const {
+        'allowed': true,
+        'scope': 'workspace',
+      };
+      final request = AgentTurnRequest(
+        sessionId: 'thread-mcp-workspace',
+        message: 'Read through MCP',
+        workspaceId: workspaceDir.path,
+      );
+      var tools = await catalog.buildTools(
+        registry: registry,
+        request: request,
+      );
+      registry.registerTools(tools);
+      await registry.getTool('mcp__filesystem__read_file')!.execute({
+        'path': 'notes.txt',
+      });
+      expect(fakePlatformBridge.permissionRequestCount, equals(1));
+
+      final nextRegistry = ToolsRegistry();
+      tools = await catalog.buildTools(
+        registry: nextRegistry,
+        request: AgentTurnRequest(
+          sessionId: 'thread-mcp-workspace-next',
+          message: 'Read through MCP from another session',
+          workspaceId: workspaceDir.path,
+        ),
+      );
+      nextRegistry.registerTools(tools);
+      await nextRegistry.getTool('mcp__filesystem__read_file')!.execute({
+        'path': 'notes.txt',
+      });
+
+      expect(fakePlatformBridge.permissionRequestCount, equals(1));
     });
 
     test(

--- a/client/lib/features/conversations/presentation/AGENTS.md
+++ b/client/lib/features/conversations/presentation/AGENTS.md
@@ -38,7 +38,8 @@ This contract applies to `client/lib/features/conversations/presentation/`.
 - Render permissions, clarifying questions, and runtime notices inline in the active conversation; do not use app-global approval dialogs.
 - Block normal sending only in the session with the pending suspension.
 - Preserve pending UI until authoritative resolution.
-- Permission-card language remains action-neutral so the same surface accurately covers commands, file access, and other permissioned tools.
+- Permission cards use action-specific titles and readable labeled fields for known command, file, search, and MCP actions; unknown tools fall back to action-neutral language. Render only daemon-provided display input and never reconstruct redacted arguments. Visually separate the darker request content from the prompt and choices.
+- A running tool row whose matching suspension awaits permission shows the permission shield instead of progress; `system_ask_user` shows the question icon while awaiting an answer. Unblocked running tools retain progress.
 - Keep background suspension and recovery state out of the active composer while surfacing its session-row attention state.
 
 ## Atomic Session Presentation

--- a/client/lib/features/conversations/presentation/screens/brain_activity_view.dart
+++ b/client/lib/features/conversations/presentation/screens/brain_activity_view.dart
@@ -10,6 +10,7 @@ import 'package:sanad_client/features/conversations/presentation/widgets/event_t
 import 'package:sanad_client/features/conversations/domain/models/message_delivery_intent.dart';
 import 'package:sanad_client/features/conversations/domain/models/turn_replay_result.dart';
 import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_cubit.dart';
+import 'package:sanad_client/features/conversations/presentation/bloc/conversation_input_state.dart';
 import 'package:sanad_client/utils/toast_utils.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../widgets/sidebar/sidebar_composition.dart';
@@ -796,39 +797,45 @@ class _BrainActivityViewState extends State<BrainActivityView> {
   Widget _buildEventTile(CanonicalEvent event) {
     final latestUserIndex = _lastUserMessageIndex(_messages);
     final canReplay = latestUserIndex >= 0 && _messages[latestUserIndex].id == event.id && event.requestId != null;
-    return EventTile(
-      key: ValueKey(event.id),
-      event: event,
-      isExpanded: _expandedEventIds.contains(event.id),
-      onToggleExpanded: (expanded) {
-        if (expanded) {
-          _expandedEventIds.add(event.id);
-        } else {
-          _expandedEventIds.remove(event.id);
-        }
-      },
-      onCancelPendingSteer: (requestId) =>
-          context.read<ConversationInputCubit>().cancelPendingSteer(requestId: requestId),
-      isCancellingPendingSteer:
-          event.requestId != null && widget.pendingSteerCancellationRequestIds.contains(event.requestId),
-      canReplay: canReplay,
-      isEditing: _editingEventId == event.id,
-      isReplayPending: _replayPendingEventId == event.id,
-      editController: _editingEventId == event.id ? _editController : null,
-      onBeginEdit: canReplay ? () => _beginInlineEdit(event) : null,
-      onCancelEdit: _cancelInlineEdit,
-      onSubmitEdit: canReplay
-          ? () async {
-              final text = _editController?.text.trim() ?? '';
-              if (text.isEmpty) return;
-              await _replayTurn(
-                event,
-                action: TurnReplayAction.edit,
-                message: text,
-              );
-            }
-          : null,
-      onRetry: canReplay ? () => _replayTurn(event, action: TurnReplayAction.retry) : null,
+    return BlocSelector<ConversationInputCubit, ConversationInputState, String?>(
+      selector: (state) => state.pendingSuspendedRequest?.toolName,
+      builder: (context, pendingToolName) => EventTile(
+        key: ValueKey(event.id),
+        event: event,
+        waitingIndicator: event.status == EventStatus.running && pendingToolName == event.toolName
+            ? (event.toolName == 'system_ask_user' ? ToolWaitingIndicator.question : ToolWaitingIndicator.permission)
+            : ToolWaitingIndicator.none,
+        isExpanded: _expandedEventIds.contains(event.id),
+        onToggleExpanded: (expanded) {
+          if (expanded) {
+            _expandedEventIds.add(event.id);
+          } else {
+            _expandedEventIds.remove(event.id);
+          }
+        },
+        onCancelPendingSteer: (requestId) =>
+            context.read<ConversationInputCubit>().cancelPendingSteer(requestId: requestId),
+        isCancellingPendingSteer:
+            event.requestId != null && widget.pendingSteerCancellationRequestIds.contains(event.requestId),
+        canReplay: canReplay,
+        isEditing: _editingEventId == event.id,
+        isReplayPending: _replayPendingEventId == event.id,
+        editController: _editingEventId == event.id ? _editController : null,
+        onBeginEdit: canReplay ? () => _beginInlineEdit(event) : null,
+        onCancelEdit: _cancelInlineEdit,
+        onSubmitEdit: canReplay
+            ? () async {
+                final text = _editController?.text.trim() ?? '';
+                if (text.isEmpty) return;
+                await _replayTurn(
+                  event,
+                  action: TurnReplayAction.edit,
+                  message: text,
+                );
+              }
+            : null,
+        onRetry: canReplay ? () => _replayTurn(event, action: TurnReplayAction.retry) : null,
+      ),
     );
   }
 }

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart
@@ -8,6 +8,7 @@ import 'package:google_fonts/google_fonts.dart';
 import '../../../../../utils/app_platform.dart';
 import '../../../domain/models/device_suspended_request.dart';
 import '../../bloc/conversation_input_cubit.dart';
+import 'permission_request_presentation.dart';
 
 class PermissionRequestCard extends StatefulWidget {
   final DeviceSuspendedRequest request;
@@ -85,10 +86,18 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
     if (character == '3' || character == '٣') return 2;
     if (character == '4' || character == '٤') return 3;
 
-    if (logicalKey == LogicalKeyboardKey.digit1 || logicalKey == LogicalKeyboardKey.numpad1) return 0;
-    if (logicalKey == LogicalKeyboardKey.digit2 || logicalKey == LogicalKeyboardKey.numpad2) return 1;
-    if (logicalKey == LogicalKeyboardKey.digit3 || logicalKey == LogicalKeyboardKey.numpad3) return 2;
-    if (logicalKey == LogicalKeyboardKey.digit4 || logicalKey == LogicalKeyboardKey.numpad4) return 3;
+    if (logicalKey == LogicalKeyboardKey.digit1 || logicalKey == LogicalKeyboardKey.numpad1) {
+      return 0;
+    }
+    if (logicalKey == LogicalKeyboardKey.digit2 || logicalKey == LogicalKeyboardKey.numpad2) {
+      return 1;
+    }
+    if (logicalKey == LogicalKeyboardKey.digit3 || logicalKey == LogicalKeyboardKey.numpad3) {
+      return 2;
+    }
+    if (logicalKey == LogicalKeyboardKey.digit4 || logicalKey == LogicalKeyboardKey.numpad4) {
+      return 3;
+    }
 
     return null;
   }
@@ -112,7 +121,9 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final commandPreview = widget.request.commandPreview ?? widget.request.toolInput.toString();
+    final presentation = PermissionRequestPresentation.fromRequest(
+      widget.request,
+    );
     final showNumbers = !AppPlatform.isMobile;
 
     final cardContent = Column(
@@ -123,7 +134,7 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
             Icon(Icons.shield_outlined, size: 16, color: colorScheme.tertiary),
             const SizedBox(width: 8),
             Text(
-              'Allow this tool action?',
+              presentation.title,
               style: GoogleFonts.inter(
                 color: colorScheme.onSurface,
                 fontSize: 15,
@@ -137,18 +148,40 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
           width: double.infinity,
           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
           decoration: BoxDecoration(
-            color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.4),
+            color: Color.alphaBlend(
+              colorScheme.onSurface.withValues(alpha: 0.07),
+              colorScheme.surfaceContainerHighest,
+            ),
             borderRadius: BorderRadius.circular(10),
             border: Border.all(color: widget.borderColor),
           ),
-          child: Text(
-            commandPreview,
-            style: TextStyle(
-              color: colorScheme.onSurface,
-              fontSize: 13,
-              height: 1.45,
-              fontFamily: 'monospace',
-            ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              for (var index = 0; index < presentation.details.length; index++) ...[
+                if (index > 0) const SizedBox(height: 8),
+                SelectableText.rich(
+                  TextSpan(
+                    style: TextStyle(
+                      color: colorScheme.onSurface,
+                      fontSize: 13,
+                      height: 1.45,
+                    ),
+                    children: [
+                      if (presentation.details[index].label != null)
+                        TextSpan(
+                          text: '${presentation.details[index].label}: ',
+                          style: const TextStyle(fontWeight: FontWeight.w600),
+                        ),
+                      TextSpan(
+                        text: presentation.details[index].value,
+                        style: const TextStyle(fontFamily: 'monospace'),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
           ),
         ),
         const SizedBox(height: 12),
@@ -193,7 +226,9 @@ class _PermissionRequestCardState extends State<PermissionRequestCard> {
               hintText: 'Tell the agent what to do instead (optional)',
               hintStyle: GoogleFonts.inter(fontSize: 13),
               filled: true,
-              fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.25),
+              fillColor: colorScheme.surfaceContainerHighest.withValues(
+                alpha: 0.25,
+              ),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(10),
                 borderSide: BorderSide(color: widget.borderColor),

--- a/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_presentation.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_input/permission_request_presentation.dart
@@ -1,0 +1,176 @@
+import '../../../domain/models/device_suspended_request.dart';
+
+class PermissionRequestDetail {
+  final String? label;
+  final String value;
+
+  const PermissionRequestDetail({this.label, required this.value});
+}
+
+class PermissionRequestPresentation {
+  final String title;
+  final List<PermissionRequestDetail> details;
+
+  const PermissionRequestPresentation({
+    required this.title,
+    required this.details,
+  });
+
+  factory PermissionRequestPresentation.fromRequest(
+    DeviceSuspendedRequest request,
+  ) {
+    final action = _normalizedAction(request);
+    final toolSource = request.tool['source'];
+    final isMcp =
+        action.startsWith('mcp__') ||
+        request.tool['category'] == 'mcp' ||
+        (toolSource is Map && toolSource['type'] == 'mcp_server');
+
+    if (isMcp) {
+      return PermissionRequestPresentation(
+        title: 'Allow Sanad to use this MCP tool?',
+        details: _mcpDetails(request, action),
+      );
+    }
+
+    final title = switch (action) {
+      'shell_execute' => 'Allow Sanad to run this command?',
+      'file_read' => 'Allow Sanad to read this file?',
+      'file_write' => 'Allow Sanad to write to this file?',
+      'file_edit' => 'Allow Sanad to edit this file?',
+      'search_glob' => 'Allow Sanad to search for matching files?',
+      'search_grep' => 'Allow Sanad to search these files?',
+      _ => 'Allow Sanad to use this tool?',
+    };
+
+    final details = <PermissionRequestDetail>[];
+    if (action == 'shell_execute') {
+      _addDetail(details, null, request.toolInput['command']);
+      _addDetail(details, 'Working directory', request.toolInput['cwd']);
+      _addRemainingInputs(
+        details,
+        request.toolInput,
+        excludedKeys: const {'action', 'command', 'cwd'},
+      );
+    } else if (_knownActions.contains(action)) {
+      _addDetail(details, null, request.toolInput['path']);
+      _addDetail(details, 'Pattern', request.toolInput['pattern']);
+      _addRemainingInputs(
+        details,
+        request.toolInput,
+        excludedKeys: const {'action', 'path', 'pattern'},
+      );
+    } else {
+      _addDetail(
+        details,
+        null,
+        request.tool['display_name'] ?? request.toolName,
+      );
+      _addRemainingInputs(
+        details,
+        request.toolInput,
+        excludedKeys: const {'action'},
+      );
+    }
+
+    if (details.isEmpty) {
+      _addDetail(details, null, request.toolName);
+    }
+    return PermissionRequestPresentation(title: title, details: details);
+  }
+
+  static const _knownActions = {
+    'shell_execute',
+    'file_read',
+    'file_write',
+    'file_edit',
+    'search_glob',
+    'search_grep',
+  };
+
+  static String _normalizedAction(DeviceSuspendedRequest request) {
+    final displayAction = request.toolInput['action']?.toString().trim();
+    if (displayAction != null && displayAction.isNotEmpty) {
+      return displayAction;
+    }
+    return request.toolName.trim();
+  }
+
+  static List<PermissionRequestDetail> _mcpDetails(
+    DeviceSuspendedRequest request,
+    String action,
+  ) {
+    final details = <PermissionRequestDetail>[];
+    final source = request.tool['source'];
+    final sourceMap = source is Map ? source : const <String, dynamic>{};
+    final nameParts = action.split('__');
+    final server = request.tool['server_name'] ?? sourceMap['id'] ?? (nameParts.length >= 3 ? nameParts[1] : null);
+    final toolName =
+        request.tool['display_name'] ??
+        sourceMap['original_name'] ??
+        (nameParts.length >= 3 ? nameParts.sublist(2).join('__') : action);
+
+    final identity = [
+      server,
+      toolName,
+    ].where((value) => value != null && value.toString().trim().isNotEmpty).join(' / ');
+    _addDetail(details, null, identity);
+    _addRemainingInputs(
+      details,
+      request.toolInput,
+      excludedKeys: const {'action'},
+    );
+    return details;
+  }
+
+  static void _addRemainingInputs(
+    List<PermissionRequestDetail> details,
+    Map<String, dynamic> inputs, {
+    required Set<String> excludedKeys,
+  }) {
+    for (final entry in inputs.entries) {
+      if (excludedKeys.contains(entry.key)) continue;
+      _addDetail(details, _humanize(entry.key), entry.value);
+    }
+  }
+
+  static void _addDetail(
+    List<PermissionRequestDetail> details,
+    String? label,
+    Object? value,
+  ) {
+    if (value == null) return;
+    final formatted = _formatValue(value);
+    if (formatted.isEmpty) return;
+    details.add(PermissionRequestDetail(label: label, value: formatted));
+  }
+
+  static String _humanize(String key) {
+    final words = key
+        .replaceAllMapped(
+          RegExp(r'([a-z0-9])([A-Z])'),
+          (match) => '${match[1]} ${match[2]}',
+        )
+        .replaceAll(RegExp(r'[_-]+'), ' ')
+        .trim();
+    if (words.isEmpty) return 'Value';
+    return '${words[0].toUpperCase()}${words.substring(1)}';
+  }
+
+  static String _formatValue(Object? value, {int depth = 0}) {
+    if (value == null) return 'None';
+    if (value is Map) {
+      if (value.isEmpty) return 'None';
+      return value.entries
+          .map(
+            (entry) => '${_humanize(entry.key.toString())}: ${_formatValue(entry.value, depth: depth + 1)}',
+          )
+          .join('\n');
+    }
+    if (value is Iterable) {
+      if (value.isEmpty) return 'None';
+      return value.map((item) => '• ${_formatValue(item, depth: depth + 1)}').join('\n');
+    }
+    return value.toString();
+  }
+}

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -18,6 +18,8 @@ import 'package:sanad_client/features/conversations/presentation/widgets/tools/s
 import 'package:sanad_client/features/conversations/presentation/widgets/user_message_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/app_markdown_renderer.dart';
 
+enum ToolWaitingIndicator { none, permission, question }
+
 class EventTile extends StatefulWidget {
   final CanonicalEvent event;
   final bool? isExpanded;
@@ -32,6 +34,7 @@ class EventTile extends StatefulWidget {
   final VoidCallback? onCancelEdit;
   final Future<void> Function()? onSubmitEdit;
   final Future<void> Function()? onRetry;
+  final ToolWaitingIndicator waitingIndicator;
 
   const EventTile({
     super.key,
@@ -48,6 +51,7 @@ class EventTile extends StatefulWidget {
     this.onCancelEdit,
     this.onSubmitEdit,
     this.onRetry,
+    this.waitingIndicator = ToolWaitingIndicator.none,
   });
 
   @override
@@ -491,6 +495,18 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
   }
 
   Widget _buildStatusIndicator() {
+    if (widget.waitingIndicator != ToolWaitingIndicator.none) {
+      final isQuestion = widget.waitingIndicator == ToolWaitingIndicator.question;
+      return Semantics(
+        label: isQuestion ? 'Waiting for your answer' : 'Waiting for permission',
+        child: Icon(
+          isQuestion ? Icons.help_outline_rounded : Icons.shield_outlined,
+          key: Key(isQuestion ? 'tool_waiting_question_icon' : 'tool_waiting_permission_icon'),
+          size: 18,
+          color: Theme.of(context).colorScheme.tertiary,
+        ),
+      );
+    }
     if (widget.event.status == EventStatus.running && widget.event.toolName != 'system_ask_user') {
       return Padding(
         padding: const EdgeInsets.all(2),
@@ -498,6 +514,7 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
           width: 14,
           height: 14,
           child: CircularProgressIndicator(
+            key: const Key('tool_running_progress_indicator'),
             strokeWidth: 2,
             color: Theme.of(context).colorScheme.primary,
           ),

--- a/client/test/unit/widgets/permission_request_card_test.dart
+++ b/client/test/unit/widgets/permission_request_card_test.dart
@@ -2,38 +2,163 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_suspended_request.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/permission_request_card.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/conversation_input/permission_request_presentation.dart';
 
 void main() {
-  testWidgets('uses action-neutral copy for external file permission', (
+  group('PermissionRequestPresentation', () {
+    test('formats shell execution as a labeled command', () {
+      final presentation = PermissionRequestPresentation.fromRequest(
+        request(toolName: 'shell_execute', toolInput: const {'command': 'pwd'}),
+      );
+
+      expect(presentation.title, 'Allow Sanad to run this command?');
+      expect(presentation.details.single.label, isNull);
+      expect(presentation.details.single.value, 'pwd');
+    });
+
+    test('formats external file reads without raw map syntax', () {
+      final presentation = PermissionRequestPresentation.fromRequest(
+        request(
+          toolName: 'file_read',
+          toolInput: const {
+            'action': 'file_read',
+            'path': '/external/project/file.txt',
+          },
+        ),
+      );
+
+      expect(presentation.title, 'Allow Sanad to read this file?');
+      expect(presentation.details.single.label, isNull);
+      expect(presentation.details.single.value, '/external/project/file.txt');
+      expect(presentation.details.single.value, isNot(contains('{')));
+    });
+
+    test('classifies safe write and edit inputs without inventing content', () {
+      final writePresentation = PermissionRequestPresentation.fromRequest(
+        request(
+          toolName: 'file_write',
+          toolInput: const {
+            'action': 'file_write',
+            'path': '/external/output.txt',
+          },
+        ),
+      );
+      final editPresentation = PermissionRequestPresentation.fromRequest(
+        request(
+          toolName: 'file_edit',
+          toolInput: const {
+            'action': 'file_edit',
+            'path': '/external/output.txt',
+          },
+        ),
+      );
+
+      expect(writePresentation.title, 'Allow Sanad to write to this file?');
+      expect(editPresentation.title, 'Allow Sanad to edit this file?');
+      expect(writePresentation.details.map((detail) => detail.label), [null]);
+      expect(editPresentation.details.map((detail) => detail.label), [null]);
+      expect(
+        [...writePresentation.details, ...editPresentation.details].map((detail) => detail.value).join(),
+        isNot(contains('content')),
+      );
+    });
+
+    test('shows MCP server, tool, and readable nested inputs', () {
+      final presentation = PermissionRequestPresentation.fromRequest(
+        request(
+          toolName: 'mcp__github__create_issue',
+          toolInput: const {
+            'title': 'Bug',
+            'metadata': {'priority': 'high'},
+            'labels': ['client', 'ux'],
+          },
+          tool: const {
+            'display_name': 'create_issue',
+            'server_name': 'github',
+            'category': 'mcp',
+            'source': {
+              'type': 'mcp_server',
+              'id': 'github',
+              'original_name': 'create_issue',
+            },
+          },
+        ),
+      );
+
+      expect(presentation.title, 'Allow Sanad to use this MCP tool?');
+      expect(presentation.details[0].label, isNull);
+      expect(presentation.details[0].value, 'github / create_issue');
+      expect(
+        presentation.details.singleWhere((detail) => detail.label == 'Metadata').value,
+        'Priority: high',
+      );
+      expect(
+        presentation.details.singleWhere((detail) => detail.label == 'Labels').value,
+        '• client\n• ux',
+      );
+    });
+
+    test('falls back to a generic title and humanized labels', () {
+      final presentation = PermissionRequestPresentation.fromRequest(
+        request(
+          toolName: 'custom_tool',
+          toolInput: const {'target_id': '42', 'dryRun': true},
+          tool: const {'display_name': 'Custom Tool'},
+        ),
+      );
+
+      expect(presentation.title, 'Allow Sanad to use this tool?');
+      expect(presentation.details[0].label, isNull);
+      expect(presentation.details[0].value, 'Custom Tool');
+      expect(presentation.details[1].label, 'Target id');
+      expect(presentation.details[2].label, 'Dry Run');
+    });
+  });
+
+  testWidgets('renders an action-specific title and labeled path', (
     tester,
   ) async {
-    const externalPath = '/external/project/file.txt';
-    const request = DeviceSuspendedRequest(
-      requestId: 'permission-1',
-      sessionId: 'session-1',
-      toolName: 'file_write',
-      permissionClass: 'external_workspace_path',
-      scope: 'once',
-      workspaceId: 'workspace-1',
-      workspaceName: 'workspace',
-      workspacePath: '/workspace',
-      toolInput: {'action': 'file_write', 'path': externalPath},
-      tool: {'name': 'file_write'},
+    final externalRead = request(
+      toolName: 'file_read',
+      toolInput: const {
+        'action': 'file_read',
+        'path': '/external/project/file.txt',
+      },
     );
 
     await tester.pumpWidget(
-      const MaterialApp(
+      MaterialApp(
         home: Scaffold(
           body: PermissionRequestCard(
-            request: request,
+            request: externalRead,
             borderColor: Colors.grey,
           ),
         ),
       ),
     );
 
-    expect(find.text('Allow this tool action?'), findsOneWidget);
-    expect(find.textContaining(externalPath), findsOneWidget);
-    expect(find.text('Allow running this command?'), findsNothing);
+    expect(find.text('Allow Sanad to read this file?'), findsOneWidget);
+    expect(find.textContaining('Path: '), findsNothing);
+    expect(find.textContaining('/external/project/file.txt'), findsOneWidget);
+    expect(find.textContaining('{action:'), findsNothing);
   });
+}
+
+DeviceSuspendedRequest request({
+  required String toolName,
+  required Map<String, dynamic> toolInput,
+  Map<String, dynamic>? tool,
+}) {
+  return DeviceSuspendedRequest(
+    requestId: 'permission-1',
+    sessionId: 'session-1',
+    toolName: toolName,
+    permissionClass: 'test',
+    scope: 'once',
+    workspaceId: 'workspace-1',
+    workspaceName: 'workspace',
+    workspacePath: '/workspace',
+    toolInput: toolInput,
+    tool: tool ?? {'name': toolName},
+  );
 }

--- a/client/test/widget/conversation_input_panel_rebuild_test.dart
+++ b/client/test/widget/conversation_input_panel_rebuild_test.dart
@@ -629,7 +629,8 @@ void main() {
     await tester.pump();
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(find.text('Allow this tool action?'), findsOneWidget);
+    expect(find.text('Allow Sanad to run this command?'), findsOneWidget);
+    expect(find.textContaining('Command: '), findsNothing);
     expect(find.textContaining('echo hello'), findsOneWidget);
     expect(find.byKey(const Key('chat_input')), findsNothing);
   });

--- a/client/test/widget/tool_waiting_indicator_test.dart
+++ b/client/test/widget/tool_waiting_indicator_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/event_tile.dart';
+
+void main() {
+  testWidgets('permission suspension replaces the running spinner with a shield', (
+    tester,
+  ) async {
+    await pumpEvent(
+      tester,
+      toolName: 'mcp__context7__resolve-library-id',
+      waitingIndicator: ToolWaitingIndicator.permission,
+    );
+
+    expect(find.byKey(const Key('tool_waiting_permission_icon')), findsOneWidget);
+    expect(find.byKey(const Key('tool_running_progress_indicator')), findsNothing);
+  });
+
+  testWidgets('clarifying question replaces the running state with a question icon', (
+    tester,
+  ) async {
+    await pumpEvent(
+      tester,
+      toolName: 'system_ask_user',
+      waitingIndicator: ToolWaitingIndicator.question,
+    );
+
+    expect(find.byKey(const Key('tool_waiting_question_icon')), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('ordinary running tools retain the progress indicator', (tester) async {
+    await pumpEvent(
+      tester,
+      toolName: 'web_search',
+      waitingIndicator: ToolWaitingIndicator.none,
+    );
+
+    expect(find.byKey(const Key('tool_running_progress_indicator')), findsOneWidget);
+    expect(find.byKey(const Key('tool_waiting_permission_icon')), findsNothing);
+  });
+}
+
+Future<void> pumpEvent(
+  WidgetTester tester, {
+  required String toolName,
+  required ToolWaitingIndicator waitingIndicator,
+}) {
+  return tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: EventTile(
+          event: CanonicalEvent(
+            id: 'tool-event',
+            kind: EventKind.toolCall,
+            timestamp: DateTime(2026),
+            status: EventStatus.running,
+            tool: {
+              'name': toolName,
+              'input': const {'query': 'test'},
+            },
+          ),
+          waitingIndicator: waitingIndicator,
+        ),
+      ),
+    ),
+  );
+}

--- a/docs/plans/tasks/67-context-aware-permission-action-presentation.md
+++ b/docs/plans/tasks/67-context-aware-permission-action-presentation.md
@@ -1,0 +1,84 @@
+---
+title: "Context-Aware Permission Action Presentation"
+description: "تصنيف طلبات إذن الأدوات حسب الإجراء وعرض مدخلاتها كحقول مقروءة وآمنة بدل النص العام وتمثيل Map الخام."
+status: "completed"
+current_gate: "Complete — verified locally"
+priority: "high"
+scope: "Flutter client inline permission card and permission UX documentation"
+---
+
+# Task 67: Context-Aware Permission Action Presentation
+
+## 1. المشكلة
+
+تعرض بطاقة الإذن حاليًا العنوان العام `Allow this tool action?` لكل الأدوات.
+كما تعرض `command` كنص منفرد، أو تستدعي `toolInput.toString()` لبقية الأدوات،
+فتظهر المدخلات بصيغة Map خام مثل `{action: file_read, path: ...}`. لا يستطيع
+المستخدم تمييز قانون الإجراء بسرعة بين تنفيذ أمر، قراءة ملف، تعديل ملف، بحث،
+أو استخدام أداة MCP.
+
+## 2. الهدف
+
+تحويل بطاقة الإذن إلى عرض يعتمد على نوع الحدث مع الحفاظ على البطاقة المدمجة
+ومصدر الحقيقة الحاليين:
+
+- عنوان موحد بصيغة `Allow Sanad to …?` ومحدد للإجراء المطلوب.
+- عرض الأمر أو المسار الرئيسي مباشرة دون label مكرر، مع `Label: Value` للمدخلات الثانوية فقط.
+- تمييز أدوات MCP بهوية `server / tool` مباشرة.
+- fallback آمن ومقروء للأدوات الجديدة أو غير المعروفة.
+- عدم إعادة عرض محتوى الكتابة/التعديل الذي ينزعه الوكيل من payload العرض.
+
+## 3. بوابات التنفيذ
+
+### Gate A — Presentation contract
+
+- [x] تعريف نموذج عرض مشتق من `DeviceSuspendedRequest` دون إنشاء runtime state جديد.
+- [x] تصنيف shell وfile read/write/edit وsearch وMCP والعرض العام.
+- [x] تعريف labels بشرية وتحويل القيم المركبة إلى نص مقروء ومحدود.
+- [x] الحفاظ على payload الآمن الذي يرسله الوكيل وعدم استرجاع arguments الأصلية.
+
+### Gate B — Inline card implementation
+
+- [x] استبدال العنوان العام بعنوان `Allow Sanad to …?` المصنف.
+- [x] استبدال `Map.toString()` بهدف رئيسي بلا label وحقول ثانوية `Label: Value` واضحة.
+- [x] استخدام monospace للقيم التقنية مع دعم الالتفاف والنسخ البصري الواضح.
+- [x] إبقاء خيارات الموافقة والرفض واختصارات لوحة المفاتيح دون تغيير.
+
+### Gate C — Regression coverage
+
+- [x] اختبار عنوان وتنظيم `shell_execute`.
+- [x] اختبار عنوان ومسار `file_read` الخارجي دون Map خام.
+- [x] اختبار file write/edit مع عدم ظهور محتوى غير موجود في payload الآمن.
+- [x] اختبار عرض MCP باسم الخادم والأداة ومدخلاته.
+- [x] إصلاح بوابة MCP لتستدعي `PermissionManager` قبل التنفيذ مع تغطية الموافقة والرفض ونطاقات session/workspace.
+- [x] ترحيل قيم CLI السرية المعروفة إلى `McpSecretStore` مع placeholder ومراجع لا تظهر في snapshots.
+- [x] اختبار fallback لأداة غير معروفة وقيم nested/list.
+
+### Gate D — Documentation and verification
+
+- [x] تحديث وصف واجهة الإذن في وثائق المنتج.
+- [x] تحديث QA لإزالة شرط العنوان action-neutral واستبداله بعناوين دقيقة مع fallback عام.
+- [x] تحديث عقد presentation الدائم إذا أصبح شرطه الحالي قديمًا.
+- [x] نجاح `fvm flutter analyze`.
+- [x] نجاح اختبار widget المركّز.
+- [x] تشغيل `graphify update .` بعد تعديل الكود.
+
+## 4. معايير القبول
+
+- [x] يظهر `Allow Sanad to run this command?` عند `shell_execute` وتظهر قيمة الأمر مباشرة.
+- [x] يظهر عنوان `Allow Sanad to …?` دقيق عند القراءة أو الكتابة أو التعديل أو البحث.
+- [x] يظهر `Allow Sanad to use this MCP tool?` مع هوية `server / tool` مباشرة.
+- [x] لا تظهر المدخلات بصيغة `{key: value}` أو JSON خام في البطاقة.
+- [x] تعرض المفاتيح غير المعروفة كـlabels بشرية بدل إسقاطها.
+- [x] لا تتعطل البطاقة عند وجود Map أو List أو null أو payload فارغ.
+- [x] يبقى العنوان العام fallback فقط عندما لا يمكن تصنيف الإجراء.
+- [x] الموافقة تدعم once/session/workspace، بينما الرفض يوقف الاستدعاء الحالي فقط ولا يمنع الطلب لاحقًا.
+- [x] صندوق محتوى الطلب أغمق بصريًا من السؤال والخيارات.
+- [x] صف الأداة المعلقة يعرض أيقونة permission أو question بدل مؤشر الدوران، مع إبقاء progress للتنفيذ غير المعلق.
+
+## 5. خارج النطاق
+
+- تغيير سياسات الأذونات أو approval keys أو scopes.
+- تغيير checkpoint/resume أو بروتوكول حسم الطلب.
+- عرض arguments الأصلية التي حجبها الوكيل لأسباب أمنية.
+- إعادة تصميم composer أو مؤشرات تعليق الجلسات.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -142,11 +142,11 @@ When the agent calls the user-question tool, the composer area displays an
 inline question card with the prompt, suggested answers, and a custom-answer
 option. Submitting the answer resumes the same suspended turn.
 
-Permission cards show the requested tool action and the available approval
-scope. For file access outside the selected workspace, the card shows the
-canonical target path without exposing write or edit content. Permission
-decisions remain owned by the workspace and are distinct from ordinary
-clarification answers.
+Permission cards ask whether Sanad may perform the specific command, file,
+search, or MCP action. The primary command, path, or `server / tool` identity
+appears without a redundant label; only secondary inputs use readable labels.
+Unknown tools retain a generic fallback prompt. The request content uses a darker surface than the prompt and choices. For file access outside the selected workspace, the card shows
+the canonical target path without exposing write or edit content. Approval grants may cover once, session, or workspace; denial stops only the current invocation so a later request can ask again. Permission decisions remain distinct from ordinary clarification answers. While suspended, the matching running tool row shows a permission shield, or a question icon for `system_ask_user`, instead of indefinite progress.
 
 ## Providers and models
 

--- a/docs/qa_maintenance/external_workspace_file_access_qa.md
+++ b/docs/qa_maintenance/external_workspace_file_access_qa.md
@@ -28,4 +28,4 @@ description: "Regression matrix for permission-aware file and search access outs
 - `agent/test/capabilities/runtime_catalog_test.dart`
 - `agent/test/capabilities/permission_manager_test.dart`
 
-The permission-card copy is verified with the focused client analyzer and widget surface review; it must remain action-neutral rather than command-specific.
+The permission-card copy is verified with focused client tests: known file actions use action-specific prompts and labeled canonical paths, unknown actions retain a generic fallback, and write/edit content remains absent from the display payload.

--- a/docs/qa_maintenance/mcp_server_configuration_qa.md
+++ b/docs/qa_maintenance/mcp_server_configuration_qa.md
@@ -10,6 +10,8 @@ description: "Security, form, import/export, OAuth, lifecycle, and regression ch
 - Device and Workspace management commands succeed only through the authenticated local gateway; every import, export, Advanced JSON, inspection, and OAuth command remains rejected on the cloud management path.
 - Device and Workspace snapshots preserve same-name Workspace precedence and contain configured markers only, never bearer, header, environment, OAuth access/refresh, or client-secret values.
 - Draft inspection uses entered credentials ephemerally and leaves neither configuration nor secret-store files behind.
+- Every sensitive discovered MCP tool requests canonical permission before server execution. Denial produces no MCP call and no persisted deny rule, so a later invocation asks again; approval executes once, and repeated exact input honors session/workspace grants and full-access bypass.
+- Legacy STDIO credential arguments following recognized flags migrate idempotently to `McpSecretStore`; configuration and snapshots never retain or expose the value, while runtime launch resolves the original argument.
 - Export and Advanced initial JSON omit every credential shape. Errors and OAuth status snapshots do not echo response bodies or tokens.
 
 ## Form and cards

--- a/docs/technical/mcp_server_configuration.md
+++ b/docs/technical/mcp_server_configuration.md
@@ -11,6 +11,8 @@ The local daemon is the only authority for MCP configuration persistence, secret
 
 Device and Workspace definitions remain independent. A Workspace definition with the same normalized name overrides the Device definition in the effective catalog.
 
+Discovered MCP tools join the per-turn catalog with sensitive approval metadata. `LocalRuntimeCatalog` must call `PermissionManager` before `McpRuntimeManager.executeTool`; rejection never reaches the MCP server, while once, session, workspace, and full-access behavior remain owned by the canonical permission policy.
+
 ## Form-first product contract
 
 The primary flow is:
@@ -44,7 +46,7 @@ Configuration documents contain non-secret values and opaque secret references o
 
 `mcp_secrets.json` under owner-protected Sanad Home is the single MCP secret owner. It uses the existing `SanadHomeBootstrap` atomic-write and owner-only permission boundary. Keys are opaque references scoped by configuration origin and server identity.
 
-Secrets include bearer tokens, secret custom-header values, secret environment values, OAuth access/refresh tokens, and OAuth client secrets. OAuth client IDs, endpoints, ordinary headers, and ordinary environment values are non-secret metadata.
+Secrets include bearer tokens, secret custom-header values, secret environment values, OAuth access/refresh tokens, OAuth client secrets, and STDIO argument values following recognized credential flags such as `--api-key` or `--token`. Secret argument positions retain a redacted placeholder plus opaque reference in configuration and resolve only when the daemon launches the server. OAuth client IDs, endpoints, ordinary arguments, ordinary headers, and ordinary environment values are non-secret metadata.
 
 Migration is idempotent:
 


### PR DESCRIPTION
## Problem / Goal
Permission prompts used generic copy and raw map-like input, MCP execution bypassed the canonical permission manager, and denial could persist as a workspace deny rule. MCP STDIO credential arguments could also remain inline in configuration.

## Changes
- render action-aware `Allow Sanad to …?` prompts with a direct primary value and readable secondary fields
- visually separate request content and replace suspended tool spinners with permission/question icons
- gate every sensitive MCP invocation through `PermissionManager` before server execution
- make denial current-invocation-only while preserving explicit configured deny rules
- migrate recognized secret STDIO argument values to `McpSecretStore` and resolve them only at launch
- update runtime/client contracts, product docs, QA guidance, and Task 67

## Verification
- `agent`: `fvm dart analyze` — no issues
- `agent`: focused permission/MCP/runtime tests — 30 passed
- `client`: `fvm flutter analyze` — no issues
- `client`: focused permission/waiting/composer tests — 30 passed
- `git diff --check` — passed
- live verification in default permission mode:
  - file, shell, search, ask-user, and Context7 MCP prompts displayed
  - MCP approval executed only after response
  - MCP denial prevented execution and a later invocation prompted again
  - Context7 inline API-key argument migrated to an opaque secret reference

## Risk / Cross-platform impact
- Permission policy behavior changes for all platforms: interactive denial no longer creates a durable deny rule.
- MCP STDIO secret-argument migration affects local daemon configurations on desktop/server hosts; migration is idempotent and keeps runtime argument resolution.
- UI changes are Flutter cross-platform and preserve normal running progress outside suspended states.

## Documentation
Updated capability contracts, client presentation contract, MCP technical/QA docs, client interface documentation, external workspace QA, and Task 67.

## Rollback
Revert the squash commit. Existing opaque MCP secret references remain safe and can continue to resolve through `McpSecretStore`.
