### PR TITLE
docs: update free LLM resource link

### DIFF
--- a/README.ar.md
+++ b/README.ar.md
@@ -239,7 +239,7 @@ Subscription عرض نافذتي الاستهلاك Session وWeekly المعت�
 يمكنك استخدام Sanad مع مزودين محليين أو مستضافين، وإضافة عدة حسابات للمزود
 نفسه.
 
-- [Free LLM API Resources](https://github.com/cheahjs/free-llm-api-resources) —
+- [Free LLM API Resources](https://github.com/nejib1/Free-LLM) —
   دليل مجتمعي لخدمات LLM التي توفر خططًا مجانية أو أرصدة تجريبية.
 
 هذا مورد خارجي مستقل وغير تابع لـSanad. قد تتغير النماذج والحصص والأسعار

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ their authoritative Session and Weekly usage windows.
 Sanad can work with local or hosted providers and multiple accounts for the
 same provider.
 
-- [Free LLM API Resources](https://github.com/cheahjs/free-llm-api-resources) —
+- [Free LLM API Resources](https://github.com/nejib1/Free-LLM) —
   a community-maintained directory of LLM services offering free tiers or
   trial credits.
 


### PR DESCRIPTION
## Problem / Goal

The Free LLM API resource linked from the English and Arabic READMEs was deleted. Replace it with the maintained successor requested by the project owner.

## Changes

- Updated the English README resource URL.
- Updated the Arabic README resource URL.

## Verification

- `git diff --check`
- Confirmed both README files contain the new URL and no longer contain the deleted URL.
- Confirmed `https://github.com/nejib1/Free-LLM` responds successfully.

## Risk and cross-platform impact

Documentation-only; no runtime or platform impact.

## Documentation

Updated `README.md` and `README.ar.md`, the owning public product documentation.

## Rollback

Revert this pull request.