### PR TITLE
fix(agent): restore DuckDuckGo web search results

### DIFF
--- a/agent/lib/capabilities/runtime/web_search/duckduckgo_provider.dart
+++ b/agent/lib/capabilities/runtime/web_search/duckduckgo_provider.dart
@@ -114,12 +114,24 @@ class DuckDuckGoProvider implements WebSearchProvider {
   }
 
   String? _decodeDdgRedirect(String url) {
-    if (!url.startsWith('/l/?')) {
-      return url;
+    // DuckDuckGo currently emits both `/l/?...` and protocol-relative
+    // `//duckduckgo.com/l/?...` redirect URLs. Normalize both before parsing;
+    // otherwise the latter has no scheme and is rejected by SSRF validation.
+    final normalizedUrl = url.startsWith('//')
+        ? 'https:$url'
+        : url.startsWith('/l/?')
+        ? 'https://duckduckgo.com$url'
+        : url;
+    final uri = Uri.tryParse(normalizedUrl);
+    if (uri == null || uri.path != '/l/' || !uri.hasQuery) {
+      return url.startsWith('//') ? null : url;
     }
 
-    final uri = Uri.tryParse('https://duckduckgo.com$url');
-    final uddg = uri?.queryParameters['uddg'];
-    return uddg == null || uddg.isEmpty ? null : Uri.decodeComponent(uddg);
+    // Uri.queryParameters already percent-decodes `uddg` exactly once. A
+    // second decode would corrupt legitimate percent-encoded path segments.
+    final redirectedUrl = uri.queryParameters['uddg'];
+    return redirectedUrl == null || redirectedUrl.isEmpty
+        ? null
+        : redirectedUrl;
   }
 }

--- a/agent/test/capabilities/duckduckgo_provider_test.dart
+++ b/agent/test/capabilities/duckduckgo_provider_test.dart
@@ -1,0 +1,48 @@
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:sanad_agent/capabilities/runtime/web_search/duckduckgo_provider.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('decodes DuckDuckGo protocol-relative redirect URLs', () async {
+    final client = MockClient((request) async {
+      expect(request.url.host, 'html.duckduckgo.com');
+      return http.Response('''
+        <html>
+          <div class="result results_links">
+            <a class="result__a" href="//duckduckgo.com/l/?uddg=https%3A%2F%2Fopenai.com%2Fguides%2Fbuilding%2520agents&amp;rut=test">
+              Building AI Agents
+            </a>
+            <a class="result__snippet">A guide to building agents.</a>
+          </div>
+        </html>
+      ''', 200);
+    });
+
+    final result = await DuckDuckGoProvider(
+      client: client,
+    ).search('Building AI Agents');
+
+    expect(result.hits, hasLength(1));
+    expect(result.hits.single.title, 'Building AI Agents');
+    expect(
+      result.hits.single.url,
+      'https://openai.com/guides/building%20agents',
+    );
+    expect(result.hits.single.snippet, 'A guide to building agents.');
+  });
+
+  test('keeps direct result URLs unchanged', () async {
+    final client = MockClient((request) async {
+      return http.Response('''
+        <div class="result">
+          <a class="result__a" href="https://example.com/result">Example</a>
+        </div>
+      ''', 200);
+    });
+
+    final result = await DuckDuckGoProvider(client: client).search('example');
+
+    expect(result.hits.single.url, 'https://example.com/result');
+  });
+}

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -119,6 +119,7 @@ These files are mandatory execution contracts governing subdirectories. Always r
 - [مواصفات نظام التصميم والمكونات المرئية للمشاريع](docs/technical/design_system.md): توثيق شامل للألوان، الخطوط، الهيكل البنائي والواجهات التفاعلية المشتركة لمشاريع Sanad (التطبيق الرئيسي، صفحة الهبوط، ولوحة التحكم).
 - [Desktop Authentication Exchange](docs/technical/desktop_authentication_exchange.md): Credential-free live authentication reconciliation between a native Flutter client and its local Dart daemon.
 - [Device Runtime Settings Protocol](docs/technical/device_runtime_settings_protocol.md): Unified local/cloud protocol commands, validation, persistence, and secret-handling rules for device settings.
+- [Web Search Runtime](docs/technical/web_search_runtime.md): Daemon-owned search providers, DuckDuckGo redirect normalization, fallback behavior, and SSRF filtering.
 - [Hosted Services Boundary](docs/technical/hosted_services_boundary.md): Ownership and compatibility boundary between the open-source Sanad Agent clients and EastStar AI hosted services.
 - [MCP Server Configuration, Secrets, and Inspection](docs/technical/mcp_server_configuration.md): Daemon-owned MCP configuration, secret handling, inspection, OAuth, import/export, and runtime isolation architecture.
 - [Message Turn Replay Protocol](docs/technical/message_turn_replay_protocol.md): Technical specification and protocols governing historical message turn replay and recovery.

--- a/docs/technical/MOC.md
+++ b/docs/technical/MOC.md
@@ -25,6 +25,7 @@ This directory owns the technical specifications of "HOW" the system is structur
 - **[Client Conversation Navigation Runtime](client_conversation_navigation.md):** Device-scoped sidebar projection, atomic history swaps, and deletion fallback.
 - **[Client Conversation Cache Schema](client_conversation_cache_schema.md):** Device-scoped local cache, drafts, destinations, and recovery data.
 - **[Device Runtime Settings Protocol](device_runtime_settings_protocol.md):** Client/daemon settings commands, ownership, validation, and synchronization.
+- **[Web Search Runtime](web_search_runtime.md):** Daemon-owned providers, DuckDuckGo redirect normalization, fallback behavior, and SSRF filtering.
 - **[Message Turn Replay Protocol](message_turn_replay_protocol.md):** Latest-turn identity, replay safety confirmation, authoritative idle boundary, history replacement, and route payload contract.
 - **[Run Cancellation and Process Ownership](run_cancellation_and_process_ownership.md):** Run-scoped Stop, provider/tool interruption, process containment, bounded cleanup, and live/history terminal parity.
 - **[Background Terminal Task Runtime](background_terminal_task_runtime.md):** Durable task ownership, atomic shell handoff, PTY supervision, cursor replay, typed wake admission, secure input, and lifecycle recovery.

--- a/docs/technical/web_search_runtime.md
+++ b/docs/technical/web_search_runtime.md
@@ -1,0 +1,34 @@
+---
+title: "Web Search Runtime"
+description: "Daemon-owned web search providers, DuckDuckGo redirect normalization, fallback behavior, and SSRF filtering."
+---
+
+# Web Search Runtime
+
+The `web_search` tool is assembled by the daemon's local runtime catalog. The
+service resolves `WEB_SEARCH_PROVIDER` and `SERPER_API_KEY` at execution time,
+so settings changes apply without rebuilding the service.
+
+## Providers
+
+The default provider is the keyless DuckDuckGo HTML provider (`ddg`). Serper
+(`serper`) is used when selected and configured with `SERPER_API_KEY`; the
+service falls through the ordered provider list when a provider is unavailable,
+throws, or returns no usable hits.
+
+DuckDuckGo result links may be either `/l/?...` paths or protocol-relative
+`//duckduckgo.com/l/?...` URLs. The provider normalizes both forms before
+extracting the `uddg` target. `Uri.queryParameters` performs the one required
+percent-decoding pass; decoding the extracted target again can corrupt valid
+percent-encoded path segments.
+
+## Safety boundary
+
+Search hits are passed through `UrlSafetyValidator` before they are returned.
+Only HTTP(S) URLs resolving exclusively to public addresses are allowed. This
+prevents search results from becoming an SSRF path to loopback, private,
+link-local, or multicast hosts. Provider failures and safety-filtered results
+are intentionally represented as an empty search result by the service.
+
+The provider regression tests use a representative DuckDuckGo HTML response so
+redirect-shape changes are detected without depending on a live search engine.


### PR DESCRIPTION
## Problem / Goal

DuckDuckGo's HTML endpoint now emits protocol-relative redirect URLs such as `//duckduckgo.com/l/?uddg=...`. The runtime only decoded `/l/?...`, so protocol-relative links reached SSRF validation without an HTTP(S) scheme and every otherwise valid search hit was removed.

## Changes

- Normalize both DuckDuckGo redirect forms before extracting the `uddg` target.
- Avoid a second percent-decoding pass that can corrupt encoded target paths.
- Add focused regression coverage for the live DuckDuckGo HTML link shape and direct result URLs.
- Document provider fallback, redirect normalization, and SSRF filtering.

## Verification

- `fvm dart analyze` — passed.
- `fvm dart test test/capabilities/duckduckgo_provider_test.dart test/capabilities/web_search_dynamic_config_test.dart` — passed (3 tests).
- Restarted the managed daemon through `sanad-dev restart agent --timeout 60`.
- Live `web_search` for `Building AI Agents` returned five valid results.

## Risk and cross-platform impact

Low. The change is provider parsing only and is platform-independent. SSRF filtering remains unchanged and still validates the decoded destination URL.

## Documentation

Added `docs/technical/web_search_runtime.md` and indexed it in the technical MOC and `docs/llms.txt`.

## Rollback

Revert this pull request to restore the previous redirect handling.
