### PR TITLE
fix(agent): serialize concurrent permission prompts per session

### DIFF
--- a/agent/e2e_test/local_tool_permissions_e2e_test.dart
+++ b/agent/e2e_test/local_tool_permissions_e2e_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:sanad_agent/engine/adapters/e2e_fixture_adapter.dart';
 import 'package:test/test.dart';
 
 import 'support/local_gateway_test_support.dart';
@@ -182,6 +183,244 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 3)),
   );
+
+  test(
+    'parallel external file reads present permission requests one at a time',
+    () async {
+      final port = _pickPort();
+      final sanadagentLocalDir = Directory.current;
+      final sanadHome = await Directory.systemTemp.createTemp(
+        'sanad-agent-parallel-permission-e2e-home',
+      );
+      final sanadStateHome = await Directory.systemTemp.createTemp(
+        'sanad-agent-parallel-permission-e2e-state',
+      );
+      final workspaceDir = Directory('${sanadHome.path}/workspace')
+        ..createSync(recursive: true);
+      final externalDir = Directory('${sanadHome.path}/external')
+        ..createSync(recursive: true);
+      final externalPaths = <String>[];
+      for (var index = 0; index < 3; index++) {
+        final file = File('${externalDir.path}/external-$index.txt');
+        await file.writeAsString('external-content-$index');
+        externalPaths.add(file.path);
+      }
+
+      addTearDown(() async {
+        if (sanadHome.existsSync()) {
+          await sanadHome.delete(recursive: true);
+        }
+        if (sanadStateHome.existsSync()) {
+          await sanadStateHome.delete(recursive: true);
+        }
+      });
+      await File(
+        '${workspaceDir.path}/AGENTS.md',
+      ).writeAsString('Workspace owned by the parallel permission e2e test.');
+
+      final daemon = await _startDaemon(
+        sanadagentLocalDir: sanadagentLocalDir,
+        sanadHome: sanadHome,
+        sanadStateHome: sanadStateHome,
+        port: port,
+      );
+      addTearDown(() async {
+        daemon.kill(ProcessSignal.sigterm);
+        await daemon.exitCode.timeout(
+          const Duration(seconds: 5),
+          onTimeout: () {
+            daemon.kill(ProcessSignal.sigkill);
+            return -1;
+          },
+        );
+      });
+      await _waitForHealth(port, sanadHome.path);
+
+      final socket = await connectAuthenticatedLocalGateway(
+        port: port,
+        sanadHomePath: sanadHome.path,
+      );
+      final probe = _FrameProbe(socket);
+      addTearDown(probe.close);
+      addTearDown(socket.close);
+
+      final registerSuccess = await probe.waitForFrameType(
+        'register_success',
+        timeout: const Duration(seconds: 10),
+      );
+      final deviceId =
+          registerSuccess['device_id']?.toString() ?? 'local-agent';
+      final sessionId =
+          'parallel-permission-e2e-${DateTime.now().millisecondsSinceEpoch}';
+      socket.add(
+        jsonEncode({
+          'type': 'execute_command',
+          'command': 'think',
+          'payload': {
+            'request_id':
+                'req-parallel-permission-${DateTime.now().millisecondsSinceEpoch}',
+            'session_id': sessionId,
+            'workspace_id': workspaceDir.path,
+            'model': 'e2e-model',
+            'message':
+                '${E2eFixtureAdapter.parallelExternalReadPromptPrefix}${jsonEncode(externalPaths)}',
+          },
+        }),
+      );
+
+      final seenPaths = <String>{};
+      for (var index = 0; index < externalPaths.length; index++) {
+        final permissionRequest = await probe.waitForDeviceEvent(
+          sessionId: sessionId,
+          eventType: 'tool_permission_request',
+          occurrence: index + 1,
+          timeout: const Duration(seconds: 45),
+        );
+        expect(permissionRequest['payload']['tool_name'], equals('file_read'));
+        final toolInput = Map<String, dynamic>.from(
+          permissionRequest['payload']['tool_input'] as Map,
+        );
+        seenPaths.add(toolInput['path'].toString());
+
+        await Future<void>.delayed(const Duration(milliseconds: 250));
+        expect(
+          probe.deviceEventCount(sessionId, 'tool_permission_request'),
+          index + 1,
+          reason: 'The next permission must wait for the current response.',
+        );
+
+        socket.add(
+          jsonEncode({
+            'type': 'execute_command',
+            'device_id': deviceId,
+            'command': 'tool_permission_response',
+            'payload': {
+              'session_id': sessionId,
+              'request_id': permissionRequest['payload']['request_id'],
+              'allowed': true,
+              'scope': 'once',
+              'decision': 'allow',
+            },
+          }),
+        );
+      }
+
+      final finalAnswer = await probe.waitForDeviceEvent(
+        sessionId: sessionId,
+        eventType: 'final_answer',
+        occurrence: 1,
+        timeout: const Duration(seconds: 45),
+      );
+      expect(
+        finalAnswer['payload']['content'],
+        E2eFixtureAdapter.parallelExternalReadResponseText,
+      );
+      final canonicalExternalPaths = externalPaths
+          .map((path) => File(path).resolveSymbolicLinksSync())
+          .toList(growable: false);
+      expect(seenPaths, unorderedEquals(canonicalExternalPaths));
+      expect(
+        probe.deviceEventCount(sessionId, 'tool_permission_request'),
+        externalPaths.length,
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+}
+
+class _FrameProbe {
+  _FrameProbe(WebSocket socket) {
+    _subscription = socket.listen((rawFrame) {
+      final frame = jsonDecode(rawFrame as String) as Map<String, dynamic>;
+      _frames.add(frame);
+      _changes.add(null);
+    });
+  }
+
+  final List<Map<String, dynamic>> _frames = [];
+  final StreamController<void> _changes = StreamController<void>.broadcast(
+    sync: true,
+  );
+  late final StreamSubscription<dynamic> _subscription;
+
+  int deviceEventCount(String sessionId, String eventType) => _frames
+      .where(
+        (frame) =>
+            frame['type'] == 'device_event' &&
+            _sessionId(frame) == sessionId &&
+            frame['event'] == eventType,
+      )
+      .length;
+
+  Future<Map<String, dynamic>> waitForFrameType(
+    String type, {
+    required Duration timeout,
+  }) => _waitFor(
+    (frame) => frame['type'] == type,
+    description: 'frame type $type',
+    timeout: timeout,
+  );
+
+  Future<Map<String, dynamic>> waitForDeviceEvent({
+    required String sessionId,
+    required String eventType,
+    required int occurrence,
+    required Duration timeout,
+  }) => _waitFor(
+    (frame) {
+      if (frame['type'] != 'device_event' ||
+          _sessionId(frame) != sessionId ||
+          frame['event'] != eventType) {
+        return false;
+      }
+      final matches = _frames
+          .takeWhile((candidate) => !identical(candidate, frame))
+          .where(
+            (candidate) =>
+                candidate['type'] == 'device_event' &&
+                _sessionId(candidate) == sessionId &&
+                candidate['event'] == eventType,
+          )
+          .length;
+      return matches + 1 == occurrence;
+    },
+    description: '$eventType occurrence $occurrence on $sessionId',
+    timeout: timeout,
+  );
+
+  Future<Map<String, dynamic>> _waitFor(
+    bool Function(Map<String, dynamic> frame) predicate, {
+    required String description,
+    required Duration timeout,
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (true) {
+      for (final frame in _frames) {
+        if (predicate(frame)) return frame;
+      }
+      final remaining = deadline.difference(DateTime.now());
+      if (remaining <= Duration.zero) {
+        throw StateError('Timed out waiting for $description');
+      }
+      try {
+        await _changes.stream.first.timeout(remaining);
+      } on TimeoutException {
+        throw StateError('Timed out waiting for $description');
+      }
+    }
+  }
+
+  String? _sessionId(Map<String, dynamic> frame) {
+    final payload = frame['payload'] is Map
+        ? Map<String, dynamic>.from(frame['payload'] as Map)
+        : const <String, dynamic>{};
+    return frame['session_id']?.toString() ?? payload['session_id']?.toString();
+  }
+
+  Future<void> close() async {
+    await _subscription.cancel();
+    await _changes.close();
+  }
 }
 
 Future<Map<String, dynamic>> _awaitEvent({

--- a/agent/lib/capabilities/permissions/AGENTS.md
+++ b/agent/lib/capabilities/permissions/AGENTS.md
@@ -9,6 +9,7 @@ This contract applies to `agent/lib/capabilities/permissions/`.
 - Persist workspace policy through the dedicated store and keep permission origin/scope explicit.
 - Apply approval grants at once, session, and workspace scope. A denial rejects only the current invocation and never creates a durable or session-wide deny rule; explicit workspace policy deny entries remain authoritative configuration.
 - External workspace-file grants are keyed by tool plus canonical target path. Keep original arguments in the durable checkpoint for resume, but expose only sanitized action/path details in the permission payload.
+- A session has at most one unresolved interactive permission request. Concurrent authorization checks queue FIFO per session and re-evaluate current policy when they reach the front; different sessions remain independent.
 
 ## Durable Suspension
 - Write a durable suspended checkpoint before a sensitive tool call waits for user approval.

--- a/agent/lib/capabilities/permissions/permission_manager.dart
+++ b/agent/lib/capabilities/permissions/permission_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:sanad_agent/capabilities/models/local_tool_spec.dart';
@@ -26,6 +27,7 @@ class PermissionManager {
   final Map<String, Set<String>> _sessionAllow = {};
   final Map<String, Set<String>> _sessionDeny = {};
   final Map<String, Set<String>> _oneShotAllow = {};
+  final Map<String, Future<void>> _sessionPermissionTails = {};
 
   Future<void> syncWorkspacePermissionMode({
     required String workspacePath,
@@ -46,11 +48,30 @@ class PermissionManager {
     required ToolContext context,
     String? approvalKeyOverride,
     Map<String, dynamic>? permissionDisplayArguments,
-  }) async {
+  }) {
     if (!_requiresApproval(tool)) {
-      return;
+      return Future<void>.value();
     }
 
+    return _serializeForSession(
+      context.sessionId,
+      () => _ensureAuthorized(
+        tool: tool,
+        arguments: arguments,
+        context: context,
+        approvalKeyOverride: approvalKeyOverride,
+        permissionDisplayArguments: permissionDisplayArguments,
+      ),
+    );
+  }
+
+  Future<void> _ensureAuthorized({
+    required LocalToolSpec tool,
+    required Map<String, dynamic> arguments,
+    required ToolContext context,
+    String? approvalKeyOverride,
+    Map<String, dynamic>? permissionDisplayArguments,
+  }) async {
     final sessionMetadata = context.metadata;
     final workspace = sessionMetadata['workspace'] is Map<String, dynamic>
         ? sessionMetadata['workspace'] as Map<String, dynamic>
@@ -161,6 +182,27 @@ class PermissionManager {
       workspacePath: workspacePath,
       currentPolicy: workspacePolicy,
     );
+  }
+
+  Future<void> _serializeForSession(
+    String sessionId,
+    Future<void> Function() action,
+  ) async {
+    final predecessor =
+        _sessionPermissionTails[sessionId] ?? Future<void>.value();
+    final completion = Completer<void>();
+    final currentTail = completion.future;
+    _sessionPermissionTails[sessionId] = currentTail;
+
+    await predecessor;
+    try {
+      await action();
+    } finally {
+      completion.complete();
+      if (identical(_sessionPermissionTails[sessionId], currentTail)) {
+        _sessionPermissionTails.remove(sessionId);
+      }
+    }
   }
 
   Future<void> applyResolvedDecision({

--- a/agent/lib/engine/adapters/e2e_fixture_adapter.dart
+++ b/agent/lib/engine/adapters/e2e_fixture_adapter.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import '../../capabilities/models/tool_schema.dart';
 import '../../core/models/agent_response.dart';
 import '../../core/models/message.dart';
@@ -17,6 +19,10 @@ class E2eFixtureAdapter implements LLMAdapter {
   static const permissionToolName = 'system_screenshot';
   static const permissionToolCallId = 'e2e-permission-tool-call';
   static const permissionResponseText = 'SCREEN_OK';
+  static const parallelExternalReadPromptPrefix =
+      '__SANAD_E2E_PARALLEL_EXTERNAL_READS__';
+  static const parallelExternalReadResponseText = 'EXTERNAL_READS_OK';
+  static const parallelExternalReadToolName = 'file_read';
   static const memoryToolName = 'memory';
   static const memoryAddPrompt = '__SANAD_E2E_MEMORY_ADD__';
   static const memoryReadPrompt = '__SANAD_E2E_MEMORY_READ__';
@@ -140,6 +146,55 @@ class E2eFixtureAdapter implements LLMAdapter {
           content: memoryToolCallId == memoryAddToolCallId
               ? 'MEMORY_STORED'
               : 'MEMORY_READ',
+        ),
+        model: modelId,
+        provider: providerId,
+        finishReason: LLMFinishReason.stop,
+      );
+    }
+
+    final isParallelExternalReadScenario =
+        latestUserContent?.startsWith(parallelExternalReadPromptPrefix) ??
+        false;
+    final hasParallelExternalReadTool =
+        tools?.any((tool) => tool.name == parallelExternalReadToolName) ??
+        false;
+    if (isParallelExternalReadScenario && hasParallelExternalReadTool) {
+      final encodedPaths = latestUserContent!.substring(
+        parallelExternalReadPromptPrefix.length,
+      );
+      final paths = (jsonDecode(encodedPaths) as List<dynamic>)
+          .map((path) => path.toString())
+          .toList(growable: false);
+      final toolCalls = [
+        for (var index = 0; index < paths.length; index++)
+          ToolCall(
+            id: 'e2e-external-file-read-$index',
+            name: parallelExternalReadToolName,
+            arguments: {'path': paths[index]},
+          ),
+      ];
+      final completedToolCallIds = history
+          .where((message) => message.role == MessageRole.tool)
+          .map((message) => message.toolCallId)
+          .whereType<String>()
+          .toSet();
+      final hasAllResults = toolCalls.every(
+        (toolCall) => completedToolCallIds.contains(toolCall.id),
+      );
+      if (!hasAllResults) {
+        return AgentResponse(
+          message: Message(role: MessageRole.assistant, toolCalls: toolCalls),
+          isToolCall: true,
+          model: modelId,
+          provider: providerId,
+          finishReason: LLMFinishReason.toolCalls,
+        );
+      }
+      return AgentResponse(
+        message: Message(
+          role: MessageRole.assistant,
+          content: parallelExternalReadResponseText,
         ),
         model: modelId,
         provider: providerId,

--- a/agent/test/capabilities/permission_manager_test.dart
+++ b/agent/test/capabilities/permission_manager_test.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
 
+import 'dart:async';
+
 import 'package:sanad_agent/capabilities/mcp/sanad_settings_store.dart';
 import 'package:sanad_agent/capabilities/models/local_tool_spec.dart';
 import 'package:sanad_agent/capabilities/permissions/permission_manager.dart';
@@ -29,6 +31,50 @@ class FakePlatformRuntimeBridge extends PlatformRuntimeBridge {
     lastPermissionPayload = payload;
     return nextDecision;
   }
+}
+
+class BlockingPlatformRuntimeBridge extends PlatformRuntimeBridge {
+  final List<Completer<Map<String, dynamic>>> _decisions = [];
+  final StreamController<int> _requestCounts = StreamController<int>.broadcast(
+    sync: true,
+  );
+  int requestCount = 0;
+  int activeRequestCount = 0;
+  int maxActiveRequestCount = 0;
+
+  @override
+  Future<Map<String, dynamic>> requestToolPermission({
+    required String sessionId,
+    required Map<String, dynamic> payload,
+    Duration timeout = const Duration(seconds: 60),
+  }) async {
+    final decision = Completer<Map<String, dynamic>>();
+    _decisions.add(decision);
+    requestCount++;
+    activeRequestCount++;
+    if (activeRequestCount > maxActiveRequestCount) {
+      maxActiveRequestCount = activeRequestCount;
+    }
+    _requestCounts.add(requestCount);
+    try {
+      return await decision.future;
+    } finally {
+      activeRequestCount--;
+    }
+  }
+
+  Future<void> waitForRequestCount(int expected) async {
+    if (requestCount >= expected) return;
+    await _requestCounts.stream
+        .firstWhere((count) => count >= expected)
+        .timeout(const Duration(seconds: 2));
+  }
+
+  void resolveRequest(int index, {bool allowed = true, String scope = 'once'}) {
+    _decisions[index].complete({'allowed': allowed, 'scope': scope});
+  }
+
+  Future<void> close() => _requestCounts.close();
 }
 
 class FakeCheckpointStore extends SuspendedCheckpointStore {
@@ -259,6 +305,243 @@ void main() {
         expect(bridge.requestCount, equals(1));
       },
     );
+
+    test(
+      'serializes concurrent permission requests within one session',
+      () async {
+        final blockingBridge = BlockingPlatformRuntimeBridge();
+        final concurrentCheckpoints = FakeCheckpointStore();
+        final concurrentManager = PermissionManager(
+          policyStore: store,
+          platformRuntimeBridge: blockingBridge,
+          checkpointStore: concurrentCheckpoints,
+        );
+        final context = ToolContext(
+          sessionId: 'thread-concurrent',
+          metadata: {
+            'workspace': {
+              'id': workspaceDir.path,
+              'name': 'workspace',
+              'path': workspaceDir.path,
+            },
+          },
+        );
+
+        final authorizations = List<Future<void>>.generate(
+          5,
+          (index) => concurrentManager.ensureAuthorized(
+            tool: shellTool,
+            arguments: {'command': 'read-external-$index'},
+            context: ToolContext(
+              sessionId: context.sessionId,
+              toolCallId: 'call-$index',
+              metadata: context.metadata,
+            ),
+          ),
+        );
+
+        await blockingBridge.waitForRequestCount(1);
+        expect(blockingBridge.requestCount, 1);
+        expect(blockingBridge.maxActiveRequestCount, 1);
+        expect(concurrentCheckpoints.byRequestId, hasLength(1));
+
+        for (var index = 0; index < authorizations.length; index++) {
+          blockingBridge.resolveRequest(index);
+          if (index + 1 < authorizations.length) {
+            await blockingBridge.waitForRequestCount(index + 2);
+            expect(blockingBridge.activeRequestCount, 1);
+            expect(blockingBridge.maxActiveRequestCount, 1);
+          }
+        }
+
+        await Future.wait(authorizations);
+        expect(blockingBridge.requestCount, 5);
+        expect(
+          concurrentCheckpoints.byRequestId.values.map(
+            (checkpoint) => checkpoint.status,
+          ),
+          everyElement('approved'),
+        );
+        await blockingBridge.close();
+      },
+    );
+
+    test('queued authorization re-evaluates a new session grant', () async {
+      final blockingBridge = BlockingPlatformRuntimeBridge();
+      final grantManager = PermissionManager(
+        policyStore: store,
+        platformRuntimeBridge: blockingBridge,
+        checkpointStore: FakeCheckpointStore(),
+      );
+      final metadata = {
+        'workspace': {
+          'id': workspaceDir.path,
+          'name': 'workspace',
+          'path': workspaceDir.path,
+        },
+      };
+      final authorizations = [
+        grantManager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {'command': 'shared-command'},
+          context: ToolContext(
+            sessionId: 'thread-shared-grant',
+            toolCallId: 'call-first',
+            metadata: metadata,
+          ),
+        ),
+        grantManager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {'command': 'shared-command'},
+          context: ToolContext(
+            sessionId: 'thread-shared-grant',
+            toolCallId: 'call-second',
+            metadata: metadata,
+          ),
+        ),
+      ];
+
+      await blockingBridge.waitForRequestCount(1);
+      blockingBridge.resolveRequest(0, scope: 'session');
+      await Future.wait(authorizations);
+
+      expect(blockingBridge.requestCount, 1);
+      expect(blockingBridge.maxActiveRequestCount, 1);
+      await blockingBridge.close();
+    });
+
+    test(
+      'denial releases the next permission request in the session',
+      () async {
+        final blockingBridge = BlockingPlatformRuntimeBridge();
+        final denialManager = PermissionManager(
+          policyStore: store,
+          platformRuntimeBridge: blockingBridge,
+          checkpointStore: FakeCheckpointStore(),
+        );
+        final metadata = {
+          'workspace': {
+            'id': workspaceDir.path,
+            'name': 'workspace',
+            'path': workspaceDir.path,
+          },
+        };
+        final denied = denialManager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {'command': 'first'},
+          context: ToolContext(
+            sessionId: 'thread-denial-queue',
+            toolCallId: 'call-denied',
+            metadata: metadata,
+          ),
+        );
+        final deniedExpectation = expectLater(
+          denied,
+          throwsA(isA<Exception>()),
+        );
+        final allowed = denialManager.ensureAuthorized(
+          tool: shellTool,
+          arguments: {'command': 'second'},
+          context: ToolContext(
+            sessionId: 'thread-denial-queue',
+            toolCallId: 'call-allowed',
+            metadata: metadata,
+          ),
+        );
+
+        await blockingBridge.waitForRequestCount(1);
+        blockingBridge.resolveRequest(0, allowed: false);
+        await deniedExpectation;
+        await blockingBridge.waitForRequestCount(2);
+        blockingBridge.resolveRequest(1);
+        await allowed;
+
+        expect(blockingBridge.maxActiveRequestCount, 1);
+        await blockingBridge.close();
+      },
+    );
+
+    test(
+      'permission requests in different sessions remain concurrent',
+      () async {
+        final blockingBridge = BlockingPlatformRuntimeBridge();
+        final independentManager = PermissionManager(
+          policyStore: store,
+          platformRuntimeBridge: blockingBridge,
+          checkpointStore: FakeCheckpointStore(),
+        );
+        final metadata = {
+          'workspace': {
+            'id': workspaceDir.path,
+            'name': 'workspace',
+            'path': workspaceDir.path,
+          },
+        };
+        final authorizations = [
+          independentManager.ensureAuthorized(
+            tool: shellTool,
+            arguments: {'command': 'session-a'},
+            context: ToolContext(
+              sessionId: 'thread-a',
+              toolCallId: 'call-a',
+              metadata: metadata,
+            ),
+          ),
+          independentManager.ensureAuthorized(
+            tool: shellTool,
+            arguments: {'command': 'session-b'},
+            context: ToolContext(
+              sessionId: 'thread-b',
+              toolCallId: 'call-b',
+              metadata: metadata,
+            ),
+          ),
+        ];
+
+        await blockingBridge.waitForRequestCount(2);
+        expect(blockingBridge.activeRequestCount, 2);
+        blockingBridge.resolveRequest(0);
+        blockingBridge.resolveRequest(1);
+        await Future.wait(authorizations);
+
+        expect(blockingBridge.maxActiveRequestCount, 2);
+        await blockingBridge.close();
+      },
+    );
+
+    test('non-sensitive tools do not enter the permission queue', () async {
+      final blockingBridge = BlockingPlatformRuntimeBridge();
+      final safeManager = PermissionManager(
+        policyStore: store,
+        platformRuntimeBridge: blockingBridge,
+        checkpointStore: FakeCheckpointStore(),
+      );
+      const safeTool = LocalToolSpec(
+        name: 'safe_read',
+        displayName: 'Safe Read',
+        description: 'Reads an already authorized resource.',
+        inputSchema: {'type': 'object'},
+        source: {'type': 'builtin_local', 'id': 'sanad-agent'},
+        category: 'core',
+        workspaceRequired: false,
+        approval: {'mode': 'default', 'sensitive': false},
+        execution: {'target': 'local_runtime'},
+      );
+
+      await Future.wait(
+        List.generate(
+          5,
+          (index) => safeManager.ensureAuthorized(
+            tool: safeTool,
+            arguments: {'index': index},
+            context: ToolContext(sessionId: 'thread-safe'),
+          ),
+        ),
+      );
+
+      expect(blockingBridge.requestCount, 0);
+      await blockingBridge.close();
+    });
 
     test('uses full_access workspace mode without prompting', () async {
       await store.savePolicy(

--- a/docs/agent_engine/capability_runtime.md
+++ b/docs/agent_engine/capability_runtime.md
@@ -82,7 +82,14 @@ Permission policy combines workspace rules with once, session, and workspace
 user decisions. Before a sensitive call waits for approval, the manager writes a
 durable suspended checkpoint containing enough identity and tool context for
 restart. A resumed decision is reapplied before execution; a once decision uses
-a one-shot bypass to avoid immediately prompting again.
+a one-shot bypass to avoid immediately prompting again. Concurrent authorization
+checks are serialized FIFO per session so the client and durable session state
+never have more than one unresolved interactive permission request for that
+session. Each queued check re-evaluates current policy when it reaches the front,
+while checks from different sessions remain independent. Daemon-backed E2E
+verification drives a parallel external-file-read batch through the authenticated
+local socket and requires each permission response before the next request is
+emitted.
 
 ## MCP and Skills
 

--- a/docs/plans/tasks/serialize_concurrent_permission_prompts.md
+++ b/docs/plans/tasks/serialize_concurrent_permission_prompts.md
@@ -1,0 +1,57 @@
+---
+title: "Serialize Concurrent Permission Prompts"
+status: complete
+current_gate: done
+remaining_estimate: "0%"
+---
+
+# Serialize Concurrent Permission Prompts
+
+## Goal
+Prevent a session from becoming trapped when a parallel tool batch contains multiple calls that require user approval by allowing at most one unresolved permission prompt per session.
+
+## Locked Decisions and Scope
+- Serialize only permission authorization for the same session; preserve concurrency across sessions.
+- Preserve parallel execution for tools that do not require approval and for post-authorization tool work.
+- Keep the existing single pending-permission client and session-hydration contract.
+- Re-evaluate policy when each queued authorization reaches the front so prior session or workspace grants take effect.
+- Do not change runtime source or stop any active runtime during implementation.
+
+## Gates
+
+### G0 — Discovery
+- [x] Confirm parallel tool execution can enter multiple external-path permission checks concurrently.
+- [x] Confirm the client and history hydration project only one pending permission per session.
+- [x] Select daemon-side per-session FIFO serialization as the smallest safe ownership fix.
+
+### G1 — Implementation
+- [x] Add per-session permission authorization serialization in `PermissionManager`.
+- [x] Ensure queue cleanup occurs after success, denial, or exception.
+- [x] Add focused concurrent regression coverage.
+
+### G2 — Documentation and Verification
+- [x] Document the one-unresolved-permission-per-session invariant.
+- [x] Extend external workspace access QA with the parallel batch scenario.
+- [x] Format and analyze the agent changes.
+- [x] Run focused permission-manager and relevant engine tests.
+- [x] Update Graphify and review the final diff.
+
+### G3 — Daemon-backed multi-request verification
+- [x] Extend the deterministic E2E adapter with a parallel external-file-read scenario.
+- [x] Verify over the authenticated local socket that only one permission request is emitted before each response.
+- [x] Resolve every request and verify all tool results reach a terminal final answer.
+- [x] Run the focused E2E sequentially, re-run analysis, and update Graphify.
+
+## Acceptance Criteria
+- [x] Given five concurrent approval-requiring calls in one session, only one permission request is active at a time.
+- [x] Resolving one request exposes the next request without leaving hidden waiters.
+- [x] A denial or exception releases the queue for later requests.
+- [x] Approval requests from different sessions are not serialized against each other.
+- [x] Non-sensitive tools remain outside the permission queue.
+
+## Definition of Done
+- [x] Focused automated tests pass.
+- [x] `fvm dart analyze` passes with bounded output.
+- [x] Runtime and QA documentation match behavior.
+- [x] `graphify update .` completes.
+- [x] No commit, push, runtime switch, stop, or restart occurs without separate user authorization.

--- a/docs/qa_maintenance/external_workspace_file_access_qa.md
+++ b/docs/qa_maintenance/external_workspace_file_access_qa.md
@@ -21,11 +21,14 @@ description: "Regression matrix for permission-aware file and search access outs
 | A missing external write target has a symlinked ancestor | Authorization binds to the canonicalized destination before parent creation or write. |
 | An authorized external directory is searched | Results use absolute paths and remain confined to that authorized canonical root. |
 | A write/edit request is displayed for approval | The UI receives action and canonical path only; original content remains only in the durable resume checkpoint. |
+| One parallel tool batch targets multiple external paths | Permission prompts are presented FIFO with at most one unresolved request for the session; resolving or denying one exposes the next and the turn does not retain hidden waiters. |
+| Different sessions request external-path permission concurrently | Each session progresses independently; one session's pending prompt does not block another session. |
 
 ## Focused Automated Verification
 
 - `agent/test/capabilities/workspace_path_resolver_test.dart`
 - `agent/test/capabilities/runtime_catalog_test.dart`
 - `agent/test/capabilities/permission_manager_test.dart`
+- `agent/e2e_test/local_tool_permissions_e2e_test.dart` (authenticated local-daemon sequencing for a parallel external-read batch)
 
 The permission-card copy is verified with focused client tests: known file actions use action-specific prompts and labeled canonical paths, unknown actions retain a generic fallback, and write/edit content remains absent from the display payload.


### PR DESCRIPTION
## Problem
When a parallel tool batch within a single session contains multiple calls requiring user permission (e.g. accessing external workspace paths), multiple concurrent permission prompts could be triggered simultaneously, causing state inconsistency on the single pending-permission client contract.

## Solution
- Add FIFO queue serialization per session in `PermissionManager` for tools requiring user approval.
- Ensure that only one permission prompt is active and unresolved at a time per session, while preserving concurrency across distinct sessions and non-sensitive tool executions.
- Re-evaluate permission policies when each queued request reaches the front so prior session or workspace grants take effect immediately.
- Ensure queue cleanup occurs after grant, denial, or exception.

## Verification
- Unit tests in `agent/test/capabilities/permission_manager_test.dart` covering concurrent requests, cross-session concurrency, non-sensitive bypass, and once-scope caching.
- End-to-end tests in `agent/e2e_test/local_tool_permissions_e2e_test.dart`.
- `fvm dart analyze` cleanly passes with zero issues.
- Documentation updated in `docs/agent_engine/capability_runtime.md` and `docs/qa_maintenance/external_workspace_file_access_qa.md`.