### PR TITLE
feat(auth): upgrade macOS keychain to SecItem, sanitize auth storage, and configure CLI PATH

### DIFF
--- a/agent/lib/core/auth/agent_secret_store.dart
+++ b/agent/lib/core/auth/agent_secret_store.dart
@@ -26,119 +26,169 @@ AgentSecretStore createAgentSecretStore() {
 }
 
 class MacOsKeychainAgentSecretStore implements AgentSecretStore {
-  MacOsKeychainAgentSecretStore({required this.scope, DynamicLibrary? library})
-    : _security =
-          library ??
-          DynamicLibrary.open(
-            '/System/Library/Frameworks/Security.framework/Security',
-          );
+  MacOsKeychainAgentSecretStore({
+    required this.scope,
+    DynamicLibrary? securityLibrary,
+    DynamicLibrary? coreFoundationLibrary,
+  }) : _security =
+           securityLibrary ??
+           DynamicLibrary.open(
+             '/System/Library/Frameworks/Security.framework/Security',
+           ),
+       _cf =
+           coreFoundationLibrary ??
+           DynamicLibrary.open(
+             '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation',
+           );
 
   static const _service = 'ai.eaststar.sanad.agent';
   static const _itemNotFound = -25300;
 
   final String scope;
   final DynamicLibrary _security;
+  final DynamicLibrary _cf;
 
   String _account(String key) => '$scope:$key';
 
+  Pointer<Void> _createString(String str) {
+    final native = str.toNativeUtf8();
+    try {
+      return _cfStringCreate(nullptr, native, 0x08000100);
+    } finally {
+      calloc.free(native);
+    }
+  }
+
+  Pointer<Void> _createData(Uint8List bytes) {
+    final ptr = calloc<Uint8>(bytes.length);
+    ptr.asTypedList(bytes.length).setAll(0, bytes);
+    try {
+      return _cfDataCreate(nullptr, ptr, bytes.length);
+    } finally {
+      ptr.asTypedList(bytes.length).fillRange(0, bytes.length, 0);
+      calloc.free(ptr);
+    }
+  }
+
+  Pointer<Void> _createDictionary(Map<Pointer<Void>, Pointer<Void>> entries) {
+    final count = entries.length;
+    final keys = calloc<Pointer<Void>>(count);
+    final values = calloc<Pointer<Void>>(count);
+    var i = 0;
+    for (final entry in entries.entries) {
+      keys[i] = entry.key;
+      values[i] = entry.value;
+      i++;
+    }
+    try {
+      return _cfDictionaryCreate(
+        nullptr,
+        keys,
+        values,
+        count,
+        _kCFTypeDictionaryKeyCallBacks,
+        _kCFTypeDictionaryValueCallBacks,
+      );
+    } finally {
+      calloc.free(keys);
+      calloc.free(values);
+    }
+  }
+
   @override
   Future<String?> read(String key) async {
-    final service = _service.toNativeUtf8();
-    final account = _account(key).toNativeUtf8();
-    final length = calloc<Uint32>();
-    final data = calloc<Pointer<Void>>();
+    final cfService = _createString(_service);
+    final cfAccount = _createString(_account(key));
+    final query = _createDictionary({
+      _kSecClass: _kSecClassGenericPassword,
+      _kSecAttrService: cfService,
+      _kSecAttrAccount: cfAccount,
+      _kSecReturnData: _kCFBooleanTrue,
+      _kSecMatchLimit: _kSecMatchLimitOne,
+    });
+    final result = calloc<Pointer<Void>>();
     try {
-      final status = _find(
-        nullptr,
-        service.length,
-        service.cast(),
-        account.length,
-        account.cast(),
-        length,
-        data,
-        nullptr,
-      );
+      final status = _secItemCopyMatching(query, result);
       if (status == _itemNotFound) return null;
       if (status != 0) throw _failure('read', status);
-      return utf8.decode(data.value.cast<Uint8>().asTypedList(length.value));
+      final dataRef = result.value;
+      if (dataRef == nullptr) return null;
+      try {
+        final length = _cfDataGetLength(dataRef);
+        final bytes = _cfDataGetBytePtr(dataRef);
+        return utf8.decode(bytes.asTypedList(length));
+      } finally {
+        _cfRelease(dataRef);
+      }
     } finally {
-      if (data.value != nullptr) _freeContent(nullptr, data.value);
-      calloc.free(data);
-      calloc.free(length);
-      calloc.free(account);
-      calloc.free(service);
+      calloc.free(result);
+      _cfRelease(query);
+      _cfRelease(cfAccount);
+      _cfRelease(cfService);
     }
   }
 
   @override
   Future<void> write(String key, String value) async {
-    final service = _service.toNativeUtf8();
-    final account = _account(key).toNativeUtf8();
-    final secret = Uint8List.fromList(utf8.encode(value));
-    final secretPointer = calloc<Uint8>(secret.length)
-      ..asTypedList(secret.length).setAll(0, secret);
-    final item = calloc<Pointer<Void>>();
+    final cfService = _createString(_service);
+    final cfAccount = _createString(_account(key));
+    final secretBytes = Uint8List.fromList(utf8.encode(value));
+    final cfData = _createData(secretBytes);
+    final query = _createDictionary({
+      _kSecClass: _kSecClassGenericPassword,
+      _kSecAttrService: cfService,
+      _kSecAttrAccount: cfAccount,
+    });
     try {
-      final findStatus = _find(
-        nullptr,
-        service.length,
-        service.cast(),
-        account.length,
-        account.cast(),
-        nullptr,
-        nullptr,
-        item,
-      );
-      final status = findStatus == _itemNotFound
-          ? _add(
-              nullptr,
-              service.length,
-              service.cast(),
-              account.length,
-              account.cast(),
-              secret.length,
-              secretPointer.cast(),
-              nullptr,
-            )
-          : findStatus == 0
-          ? _modify(item.value, nullptr, secret.length, secretPointer.cast())
-          : findStatus;
-      if (status != 0) throw _failure('write', status);
+      final updateAttrs = _createDictionary({_kSecValueData: cfData});
+      try {
+        final updateStatus = _secItemUpdate(query, updateAttrs);
+        if (updateStatus == 0) return;
+        if (updateStatus != _itemNotFound) {
+          throw _failure('write (update)', updateStatus);
+        }
+      } finally {
+        _cfRelease(updateAttrs);
+      }
+
+      final addDict = _createDictionary({
+        _kSecClass: _kSecClassGenericPassword,
+        _kSecAttrService: cfService,
+        _kSecAttrAccount: cfAccount,
+        _kSecValueData: cfData,
+        _kSecAttrAccessible: _kSecAttrAccessibleAfterFirstUnlock,
+      });
+      try {
+        final addStatus = _secItemAdd(addDict, nullptr);
+        if (addStatus != 0) throw _failure('write (add)', addStatus);
+      } finally {
+        _cfRelease(addDict);
+      }
     } finally {
-      if (item.value != nullptr) _cfRelease(item.value);
-      secretPointer.asTypedList(secret.length).fillRange(0, secret.length, 0);
-      calloc.free(item);
-      calloc.free(secretPointer);
-      calloc.free(account);
-      calloc.free(service);
+      _cfRelease(query);
+      _cfRelease(cfData);
+      _cfRelease(cfAccount);
+      _cfRelease(cfService);
     }
   }
 
   @override
   Future<void> delete(String key) async {
-    final service = _service.toNativeUtf8();
-    final account = _account(key).toNativeUtf8();
-    final item = calloc<Pointer<Void>>();
+    final cfService = _createString(_service);
+    final cfAccount = _createString(_account(key));
+    final query = _createDictionary({
+      _kSecClass: _kSecClassGenericPassword,
+      _kSecAttrService: cfService,
+      _kSecAttrAccount: cfAccount,
+    });
     try {
-      final findStatus = _find(
-        nullptr,
-        service.length,
-        service.cast(),
-        account.length,
-        account.cast(),
-        nullptr,
-        nullptr,
-        item,
-      );
-      if (findStatus == _itemNotFound) return;
-      if (findStatus != 0) throw _failure('delete', findStatus);
-      final status = _deleteItem(item.value);
+      final status = _secItemDelete(query);
+      if (status == _itemNotFound) return;
       if (status != 0) throw _failure('delete', status);
     } finally {
-      if (item.value != nullptr) _cfRelease(item.value);
-      calloc.free(item);
-      calloc.free(account);
-      calloc.free(service);
+      _cfRelease(query);
+      _cfRelease(cfAccount);
+      _cfRelease(cfService);
     }
   }
 
@@ -147,74 +197,87 @@ class MacOsKeychainAgentSecretStore implements AgentSecretStore {
         'macOS Keychain $operation failed ($status).',
       );
 
-  late final _find = _security
-      .lookupFunction<
-        Int32 Function(
-          Pointer<Void>,
-          Uint32,
-          Pointer<Void>,
-          Uint32,
-          Pointer<Void>,
-          Pointer<Uint32>,
-          Pointer<Pointer<Void>>,
-          Pointer<Pointer<Void>>,
-        ),
-        int Function(
-          Pointer<Void>,
-          int,
-          Pointer<Void>,
-          int,
-          Pointer<Void>,
-          Pointer<Uint32>,
-          Pointer<Pointer<Void>>,
-          Pointer<Pointer<Void>>,
-        )
-      >('SecKeychainFindGenericPassword');
-  late final _add = _security
-      .lookupFunction<
-        Int32 Function(
-          Pointer<Void>,
-          Uint32,
-          Pointer<Void>,
-          Uint32,
-          Pointer<Void>,
-          Uint32,
-          Pointer<Void>,
-          Pointer<Pointer<Void>>,
-        ),
-        int Function(
-          Pointer<Void>,
-          int,
-          Pointer<Void>,
-          int,
-          Pointer<Void>,
-          int,
-          Pointer<Void>,
-          Pointer<Pointer<Void>>,
-        )
-      >('SecKeychainAddGenericPassword');
-  late final _modify = _security
-      .lookupFunction<
-        Int32 Function(Pointer<Void>, Pointer<Void>, Uint32, Pointer<Void>),
-        int Function(Pointer<Void>, Pointer<Void>, int, Pointer<Void>)
-      >('SecKeychainItemModifyAttributesAndData');
-  late final _deleteItem = _security
-      .lookupFunction<
-        Int32 Function(Pointer<Void>),
-        int Function(Pointer<Void>)
-      >('SecKeychainItemDelete');
-  late final _freeContent = _security
-      .lookupFunction<
-        Int32 Function(Pointer<Void>, Pointer<Void>),
-        int Function(Pointer<Void>, Pointer<Void>)
-      >('SecKeychainItemFreeContent');
-  late final _cfRelease =
-      DynamicLibrary.open(
-        '/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation',
-      ).lookupFunction<
-        Void Function(Pointer<Void>),
-        void Function(Pointer<Void>)
-      >('CFRelease');
+  late final _kSecClass = _security.lookup<Pointer<Void>>('kSecClass').value;
+  late final _kSecClassGenericPassword =
+      _security.lookup<Pointer<Void>>('kSecClassGenericPassword').value;
+  late final _kSecAttrService =
+      _security.lookup<Pointer<Void>>('kSecAttrService').value;
+  late final _kSecAttrAccount =
+      _security.lookup<Pointer<Void>>('kSecAttrAccount').value;
+  late final _kSecValueData =
+      _security.lookup<Pointer<Void>>('kSecValueData').value;
+  late final _kSecReturnData =
+      _security.lookup<Pointer<Void>>('kSecReturnData').value;
+  late final _kSecMatchLimit =
+      _security.lookup<Pointer<Void>>('kSecMatchLimit').value;
+  late final _kSecMatchLimitOne =
+      _security.lookup<Pointer<Void>>('kSecMatchLimitOne').value;
+  late final _kSecAttrAccessible =
+      _security.lookup<Pointer<Void>>('kSecAttrAccessible').value;
+  late final _kSecAttrAccessibleAfterFirstUnlock =
+      _security.lookup<Pointer<Void>>('kSecAttrAccessibleAfterFirstUnlock').value;
+
+  late final _kCFBooleanTrue = _cf.lookup<Pointer<Void>>('kCFBooleanTrue').value;
+  late final _kCFTypeDictionaryKeyCallBacks =
+      _cf.lookup<Void>('kCFTypeDictionaryKeyCallBacks');
+  late final _kCFTypeDictionaryValueCallBacks =
+      _cf.lookup<Void>('kCFTypeDictionaryValueCallBacks');
+
+  late final _cfRelease = _cf.lookupFunction<
+    Void Function(Pointer<Void>),
+    void Function(Pointer<Void>)
+  >('CFRelease');
+  late final _cfStringCreate = _cf.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>, Uint32),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Utf8>, int)
+  >('CFStringCreateWithCString');
+  late final _cfDataCreate = _cf.lookupFunction<
+    Pointer<Void> Function(Pointer<Void>, Pointer<Uint8>, IntPtr),
+    Pointer<Void> Function(Pointer<Void>, Pointer<Uint8>, int)
+  >('CFDataCreate');
+  late final _cfDataGetBytePtr = _cf.lookupFunction<
+    Pointer<Uint8> Function(Pointer<Void>),
+    Pointer<Uint8> Function(Pointer<Void>)
+  >('CFDataGetBytePtr');
+  late final _cfDataGetLength = _cf.lookupFunction<
+    IntPtr Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('CFDataGetLength');
+  late final _cfDictionaryCreate = _cf.lookupFunction<
+    Pointer<Void> Function(
+      Pointer<Void>,
+      Pointer<Pointer<Void>>,
+      Pointer<Pointer<Void>>,
+      IntPtr,
+      Pointer<Void>,
+      Pointer<Void>,
+    ),
+    Pointer<Void> Function(
+      Pointer<Void>,
+      Pointer<Pointer<Void>>,
+      Pointer<Pointer<Void>>,
+      int,
+      Pointer<Void>,
+      Pointer<Void>,
+    )
+  >('CFDictionaryCreate');
+
+  late final _secItemAdd = _security.lookupFunction<
+    Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>),
+    int Function(Pointer<Void>, Pointer<Pointer<Void>>)
+  >('SecItemAdd');
+  late final _secItemCopyMatching = _security.lookupFunction<
+    Int32 Function(Pointer<Void>, Pointer<Pointer<Void>>),
+    int Function(Pointer<Void>, Pointer<Pointer<Void>>)
+  >('SecItemCopyMatching');
+  late final _secItemUpdate = _security.lookupFunction<
+    Int32 Function(Pointer<Void>, Pointer<Void>),
+    int Function(Pointer<Void>, Pointer<Void>)
+  >('SecItemUpdate');
+  late final _secItemDelete = _security.lookupFunction<
+    Int32 Function(Pointer<Void>),
+    int Function(Pointer<Void>)
+  >('SecItemDelete');
 }
 
 final class _DataBlob extends Struct {

--- a/agent/lib/core/auth/auth_manager.dart
+++ b/agent/lib/core/auth/auth_manager.dart
@@ -128,9 +128,14 @@ class AuthManager {
 
       if (data != null &&
           (data.containsKey('device_token') ||
-              data.containsKey('pending_device_token'))) {
-        data.remove('device_token');
-        data.remove('pending_device_token');
+              data.containsKey('pending_device_token') ||
+              data.containsKey('access_token') ||
+              data.containsKey('refresh_token'))) {
+        data
+          ..remove('device_token')
+          ..remove('pending_device_token')
+          ..remove('access_token')
+          ..remove('refresh_token');
         await boundary.writeSecretBytes(
           'auth.json',
           utf8.encode(jsonEncode(data)),

--- a/agent/lib/core/setup/cli_path_manager.dart
+++ b/agent/lib/core/setup/cli_path_manager.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import '../constants.dart';
+
+class CliPathManager {
+  static final _logger = Logger('CliPathManager');
+
+  /// Ensures that the Sanad bin directory is added to the user's shell PATH.
+  static Future<bool> ensureOnPath({
+    String? customHomeDir,
+    String? customBinDir,
+  }) async {
+    final home = customHomeDir ?? _getHomeDirectory();
+    final binDir = customBinDir ?? p.join(getSanadHome(), 'bin');
+    if (home.isEmpty) {
+      return false;
+    }
+
+    if (Platform.isWindows) {
+      return _ensureWindowsPath(binDir);
+    } else {
+      return _ensurePosixPath(home, binDir);
+    }
+  }
+
+  static String _getHomeDirectory() {
+    if (Platform.isWindows) {
+      return Platform.environment['USERPROFILE'] ?? '';
+    }
+    return Platform.environment['HOME'] ?? '';
+  }
+
+  static Future<bool> _ensurePosixPath(String home, String binDir) async {
+    var modifiedAny = false;
+    final pathExportLine = 'export PATH="$binDir:\$PATH"';
+    final commentLine = '# Added by Sanad';
+
+    // Candidate shell profiles
+    final candidateFiles = <String>[];
+
+    if (Platform.isMacOS) {
+      // On macOS, zsh is default. Always ensure .zshrc exists/is updated
+      candidateFiles.add(p.join(home, '.zshrc'));
+      for (final name in ['.bash_profile', '.bashrc', '.profile', '.zprofile']) {
+        final path = p.join(home, name);
+        if (File(path).existsSync() && !candidateFiles.contains(path)) {
+          candidateFiles.add(path);
+        }
+      }
+    } else {
+      // Linux: .bashrc, .profile, .zshrc
+      for (final name in ['.bashrc', '.profile', '.zshrc']) {
+        final path = p.join(home, name);
+        if (File(path).existsSync() && !candidateFiles.contains(path)) {
+          candidateFiles.add(path);
+        }
+      }
+      if (candidateFiles.isEmpty) {
+        candidateFiles.add(p.join(home, '.bashrc'));
+      }
+    }
+
+    for (final filePath in candidateFiles) {
+      final file = File(filePath);
+      try {
+        if (file.existsSync()) {
+          final content = await file.readAsString();
+          if (content.contains('.sanad/bin') || content.contains(binDir)) {
+            _logger.fine('Sanad bin is already present in $filePath');
+            continue;
+          }
+          final separator = content.endsWith('\n') || content.isEmpty ? '' : '\n';
+          await file.writeAsString(
+            '$content$separator\n$commentLine\n$pathExportLine\n',
+          );
+          _logger.info('Added Sanad bin to $filePath');
+          modifiedAny = true;
+        } else {
+          await file.parent.create(recursive: true);
+          await file.writeAsString('$commentLine\n$pathExportLine\n');
+          _logger.info('Created $filePath and added Sanad bin to PATH');
+          modifiedAny = true;
+        }
+      } catch (e) {
+        _logger.warning('Could not update shell profile $filePath: $e');
+      }
+    }
+
+    // Attempt user-level symlink creation if ~/.local/bin exists
+    await _tryCreateSymlink(binDir, p.join(home, '.local', 'bin'));
+
+    return modifiedAny;
+  }
+
+  static Future<void> _tryCreateSymlink(String binDir, String targetDir) async {
+    try {
+      final targetDirObj = Directory(targetDir);
+      if (targetDirObj.existsSync()) {
+        final symlinkPath = p.join(targetDir, 'sanad');
+        final targetExec = p.join(binDir, 'sanad');
+        if (File(targetExec).existsSync() &&
+            !File(symlinkPath).existsSync() &&
+            !Link(symlinkPath).existsSync()) {
+          await Link(symlinkPath).create(targetExec);
+          _logger.info('Created symlink at $symlinkPath -> $targetExec');
+        }
+      }
+    } catch (_) {
+      // Best-effort, ignore permission or filesystem errors
+    }
+  }
+
+  static Future<bool> _ensureWindowsPath(String binDir) async {
+    try {
+      final result = await Process.run('powershell', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        '''
+        \$currentPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+        if (\$currentPath -notlike "*$binDir*") {
+            [Environment]::SetEnvironmentVariable('Path', "\$currentPath;$binDir", 'User')
+            exit 0
+        }
+        exit 0
+        ''',
+      ]);
+      return result.exitCode == 0;
+    } catch (e) {
+      _logger.warning('Could not update Windows user PATH: $e');
+      return false;
+    }
+  }
+}

--- a/agent/lib/core/setup/service_manager.dart
+++ b/agent/lib/core/setup/service_manager.dart
@@ -5,6 +5,7 @@ import 'dart:typed_data';
 import 'package:path/path.dart' as p;
 import 'package:sanad_agent/core/constants.dart';
 import 'package:sanad_agent/core/sanad_home/sanad_home_bootstrap.dart';
+import 'package:sanad_agent/core/setup/cli_path_manager.dart';
 
 class ServiceManager {
   static String get _instance {
@@ -125,7 +126,11 @@ class ServiceManager {
         // Load service
         await Process.run('launchctl', ['unload', configPath]);
         final result = await Process.run('launchctl', ['load', configPath]);
-        return result.exitCode == 0;
+        if (result.exitCode == 0) {
+          await CliPathManager.ensureOnPath();
+          return true;
+        }
+        return false;
       } else if (Platform.isLinux) {
         final configPath = getServiceConfigPath();
         final serviceContent =
@@ -161,7 +166,11 @@ WantedBy=default.target
           '--now',
           serviceName,
         ]);
-        return result.exitCode == 0;
+        if (result.exitCode == 0) {
+          await CliPathManager.ensureOnPath();
+          return true;
+        }
+        return false;
       } else if (Platform.isWindows) {
         final daemonCommand = buildWindowsDaemonCommand(
           executable: finalExec,
@@ -182,7 +191,11 @@ WantedBy=default.target
           '-EncodedCommand',
           encodePowerShellCommand(registrationCommand),
         ]);
-        return result.exitCode == 0;
+        if (result.exitCode == 0) {
+          await CliPathManager.ensureOnPath();
+          return true;
+        }
+        return false;
       }
     } catch (_) {
       return false;

--- a/agent/test/core/agent_secret_store_test.dart
+++ b/agent/test/core/agent_secret_store_test.dart
@@ -224,10 +224,40 @@ void main() {
       expect(await store.read(key), isNull);
       await store.write(key, 'synthetic-secret-value');
       expect(await store.read(key), 'synthetic-secret-value');
+      // Overwrite/update existing key
+      await store.write(key, 'updated-secret-value-12345');
+      expect(await store.read(key), 'updated-secret-value-12345');
       await store.delete(key);
       expect(await store.read(key), isNull);
     } finally {
       await store.delete(key);
+    }
+  }, skip: !Platform.isMacOS);
+
+  test('macOS Keychain handles multiple keys and special characters', () async {
+    final scope = 'sec01e-multi-${const Uuid().v4()}';
+    final store = MacOsKeychainAgentSecretStore(scope: scope);
+    const key1 = 'device_credential';
+    const key2 = 'provider:openai_api_key';
+    const value1 = 'token_abc123!@#\$%^&*()_+~`|}{[]:;?><,./';
+    const value2 = '{"type":"json_secret","nested":{"field":123}}';
+
+    try {
+      await store.write(key1, value1);
+      await store.write(key2, value2);
+
+      expect(await store.read(key1), value1);
+      expect(await store.read(key2), value2);
+
+      await store.delete(key1);
+      expect(await store.read(key1), isNull);
+      expect(await store.read(key2), value2);
+
+      await store.delete(key2);
+      expect(await store.read(key2), isNull);
+    } finally {
+      await store.delete(key1);
+      await store.delete(key2);
     }
   }, skip: !Platform.isMacOS);
 }

--- a/agent/test/core/auth_test.dart
+++ b/agent/test/core/auth_test.dart
@@ -330,8 +330,8 @@ void main() {
 
         final persisted =
             jsonDecode(await authFile.readAsString()) as Map<String, dynamic>;
-        expect(persisted['access_token'], 'new-account-access');
-        expect(persisted['refresh_token'], 'new-account-refresh');
+        expect(persisted['access_token'], isNull);
+        expect(persisted['refresh_token'], isNull);
         expect(persisted['hardware_id'], 'stable-hardware');
         expect(persisted[AuthManager.pendingAgentLogoutKey], isNull);
         expect(persisted['pairing_token'], isNull);

--- a/agent/test/core/cli_path_manager_test.dart
+++ b/agent/test/core/cli_path_manager_test.dart
@@ -32,9 +32,11 @@ void main() {
       if (!Platform.isWindows) {
         expect(modified, isTrue);
 
-        final zshrc = File(p.join(tempHome.path, '.zshrc'));
-        expect(zshrc.existsSync(), isTrue);
-        final content = await zshrc.readAsString();
+        final targetProfile = File(
+          p.join(tempHome.path, Platform.isMacOS ? '.zshrc' : '.bashrc'),
+        );
+        expect(targetProfile.existsSync(), isTrue);
+        final content = await targetProfile.readAsString();
         expect(content, contains('export PATH="${tempBin.path}:\$PATH"'));
 
         // Running a second time should not duplicate the line
@@ -44,7 +46,7 @@ void main() {
         );
         expect(modifiedAgain, isFalse);
 
-        final contentAgain = await zshrc.readAsString();
+        final contentAgain = await targetProfile.readAsString();
         final occurrences = 'export PATH="${tempBin.path}:\$PATH"'
             .allMatches(contentAgain)
             .length;

--- a/agent/test/core/cli_path_manager_test.dart
+++ b/agent/test/core/cli_path_manager_test.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:sanad_agent/core/setup/cli_path_manager.dart';
+
+void main() {
+  group('CliPathManager', () {
+    late Directory tempHome;
+    late Directory tempBin;
+
+    setUp(() async {
+      tempHome = await Directory.systemTemp.createTemp('sanad-cli-path-home-');
+      tempBin = Directory(p.join(tempHome.path, '.sanad', 'bin'));
+      await tempBin.create(recursive: true);
+      // Create a dummy sanad executable
+      final exec = File(p.join(tempBin.path, 'sanad'));
+      await exec.writeAsString('#!/bin/sh\necho "Sanad CLI"');
+    });
+
+    tearDown(() async {
+      if (tempHome.existsSync()) {
+        await tempHome.delete(recursive: true);
+      }
+    });
+
+    test('creates and appends PATH export in shell profile idempotently', () async {
+      final modified = await CliPathManager.ensureOnPath(
+        customHomeDir: tempHome.path,
+        customBinDir: tempBin.path,
+      );
+
+      if (!Platform.isWindows) {
+        expect(modified, isTrue);
+
+        final zshrc = File(p.join(tempHome.path, '.zshrc'));
+        expect(zshrc.existsSync(), isTrue);
+        final content = await zshrc.readAsString();
+        expect(content, contains('export PATH="${tempBin.path}:\$PATH"'));
+
+        // Running a second time should not duplicate the line
+        final modifiedAgain = await CliPathManager.ensureOnPath(
+          customHomeDir: tempHome.path,
+          customBinDir: tempBin.path,
+        );
+        expect(modifiedAgain, isFalse);
+
+        final contentAgain = await zshrc.readAsString();
+        final occurrences = 'export PATH="${tempBin.path}:\$PATH"'
+            .allMatches(contentAgain)
+            .length;
+        expect(occurrences, 1);
+      }
+    });
+
+    test('creates symlink in ~/.local/bin if directory exists', () async {
+      if (!Platform.isWindows) {
+        final localBin = Directory(p.join(tempHome.path, '.local', 'bin'));
+        await localBin.create(recursive: true);
+
+        await CliPathManager.ensureOnPath(
+          customHomeDir: tempHome.path,
+          customBinDir: tempBin.path,
+        );
+
+        final link = Link(p.join(localBin.path, 'sanad'));
+        expect(link.existsSync(), isTrue);
+        expect(await link.target(), p.join(tempBin.path, 'sanad'));
+      }
+    });
+  });
+}

--- a/client/lib/features/auth/infrastructure/auth_service.dart
+++ b/client/lib/features/auth/infrastructure/auth_service.dart
@@ -197,49 +197,44 @@ class AuthService {
   Future<void> init({String? fallbackDeviceId}) async {
     final prefs = await _getPrefs();
 
+    final storedSession = _readStoredAuthSession(prefs);
+    _backendAccessToken = storedSession.$1;
+    _backendRefreshToken = storedSession.$2;
+
     if (AppPlatform.isDesktop) {
       try {
-        final restored = await _settingsStore.withAuthFileLock(() async {
+        await _settingsStore.withAuthFileLock(() async {
           final authDoc = await _settingsStore.readAuthDocument();
           final String? token = authDoc['access_token'];
           final String? refreshToken = authDoc['refresh_token'];
           final String? hardwareId = authDoc['hardware_id']?.toString();
-          if (token == null && hardwareId == null) return false;
 
-          _logger.info('Restored auth from auth.json');
-          _backendAccessToken = token;
-          _backendRefreshToken = refreshToken;
-          _hardwareId = hardwareId;
-          if (token != null) {
-            await prefs.setString('backend_access_token', token);
-          }
-          if (refreshToken != null) {
-            await prefs.setString('backend_refresh_token', refreshToken);
-          }
-          if (hardwareId != null) {
+          if (hardwareId != null && hardwareId.isNotEmpty) {
+            _hardwareId = hardwareId;
             await prefs.setString('hardware_id', hardwareId);
+          } else {
+            _hardwareId = fallbackDeviceId;
           }
-          await _syncAuthToFileUnlocked();
-          return true;
-        });
-        if (restored) {
-          if (_backendAccessToken != null) {
-            await fetchProfile();
-            _emitAccessToken();
-          }
-          return;
-        }
-      } catch (e) {
-        _logger.warning(
-          'Failed to load auth from file on desktop, using SharedPreferences: $e',
-        );
-      }
-    }
 
-    final storedSession = _readStoredAuthSession(prefs);
-    _backendAccessToken = storedSession.$1;
-    _backendRefreshToken = storedSession.$2;
-    _hardwareId = AppPlatform.isDesktop ? fallbackDeviceId : prefs.getString('hardware_id') ?? fallbackDeviceId;
+          // If authDoc has an external token (e.g. from CLI), adopt it
+          if (token != null && token.isNotEmpty) {
+            _backendAccessToken = token;
+            _backendRefreshToken = refreshToken;
+            await _persistAuthPair(
+              prefs,
+              accessToken: token,
+              refreshToken: refreshToken,
+            );
+          }
+
+          await _syncAuthToFileUnlocked();
+        });
+      } catch (e) {
+        _logger.warning('Failed to load auth from file on desktop: $e');
+      }
+    } else {
+      _hardwareId = prefs.getString('hardware_id') ?? fallbackDeviceId;
+    }
 
     if (_backendAccessToken != null) {
       if (AppPlatform.isDesktop) {
@@ -260,27 +255,16 @@ class AuthService {
 
   Future<void> _synchronizeDesktopAuthFileUnlocked() async {
     final authDoc = await _settingsStore.readAuthDocument();
-    final nextAccessToken = authDoc['access_token']?.toString();
-    final nextRefreshToken = authDoc['refresh_token']?.toString();
     final nextHardwareId = authDoc['hardware_id']?.toString();
-    final accessChanged = nextAccessToken != _backendAccessToken;
-    final refreshChanged = nextRefreshToken != _backendRefreshToken;
-
-    if (!accessChanged && !refreshChanged) {
-      if (nextHardwareId != null && nextHardwareId.isNotEmpty) {
-        _hardwareId = nextHardwareId;
-      }
-      return;
-    }
-
-    _backendAccessToken = nextAccessToken?.isNotEmpty == true ? nextAccessToken : null;
-    _backendRefreshToken = nextRefreshToken?.isNotEmpty == true ? nextRefreshToken : null;
     if (nextHardwareId != null && nextHardwareId.isNotEmpty) {
       _hardwareId = nextHardwareId;
     }
 
-    final prefs = await _getPrefs();
-    if (_backendAccessToken == null) {
+    final isLogoutRequested = authDoc[_pendingAgentLogoutKey] == true;
+    if (isLogoutRequested) {
+      final prefs = await _getPrefs();
+      _backendAccessToken = null;
+      _backendRefreshToken = null;
       await prefs.remove(_authSessionKey);
       await prefs.remove('backend_access_token');
       await prefs.remove('backend_refresh_token');
@@ -290,17 +274,26 @@ class AuthService {
       userId = null;
       userCredits = 0.0;
       totalCredits = 0.0;
-    } else {
+      _emitAccessToken();
+      return;
+    }
+
+    final fileAccessToken = authDoc['access_token']?.toString();
+    final fileRefreshToken = authDoc['refresh_token']?.toString();
+    if (fileAccessToken != null &&
+        fileAccessToken.isNotEmpty &&
+        fileAccessToken != _backendAccessToken) {
+      _backendAccessToken = fileAccessToken;
+      _backendRefreshToken = fileRefreshToken;
+      final prefs = await _getPrefs();
       await _persistAuthPair(
         prefs,
         accessToken: _backendAccessToken!,
         refreshToken: _backendRefreshToken,
       );
-      if (accessChanged) {
-        await fetchProfile();
-      }
+      await fetchProfile();
+      _emitAccessToken();
     }
-    _emitAccessToken();
   }
 
   Future<void> _syncAuthToFile() async {
@@ -312,13 +305,11 @@ class AuthService {
     if (!AppPlatform.isDesktop) return;
     try {
       final existing = await _settingsStore.readAuthDocument();
-      final next = Map<String, dynamic>.from(existing);
-      if (_backendAccessToken != null) {
-        next['access_token'] = _backendAccessToken;
-      }
-      if (_backendRefreshToken != null) {
-        next['refresh_token'] = _backendRefreshToken;
-      }
+      final next = Map<String, dynamic>.from(existing)
+        ..remove('access_token')
+        ..remove('refresh_token')
+        ..remove('device_token')
+        ..remove('pending_device_token');
       if (_hardwareId != null) next['hardware_id'] = _hardwareId;
       await _settingsStore.saveAuthDocument(next);
     } catch (e) {

--- a/client/test/unit/services/auth_service_test.dart
+++ b/client/test/unit/services/auth_service_test.dart
@@ -252,7 +252,10 @@ void main() {
         await authService.synchronizeDesktopAuthFile();
         expect(authService.accessToken, 'external-access');
 
-        mockStore.authDocument = {'hardware_id': 'device-1'};
+        mockStore.authDocument = {
+          'hardware_id': 'device-1',
+          'agent_logout_pending': true,
+        };
         await authService.synchronizeDesktopAuthFile();
         expect(authService.accessToken, isNull);
         expect(exchangeCount, 0);
@@ -274,8 +277,8 @@ void main() {
         await authService.init(fallbackDeviceId: 'device-1');
 
         expect(authService.accessToken, 'atomic-access');
-        expect(mockStore.authDocument['access_token'], 'atomic-access');
-        expect(mockStore.authDocument['refresh_token'], 'atomic-refresh');
+        expect(mockStore.authDocument['access_token'], isNull);
+        expect(mockStore.authDocument['refresh_token'], isNull);
       },
     );
 
@@ -291,7 +294,7 @@ void main() {
         expect(authService.accessToken, equals('prefs_token'));
         expect(authService.hardwareId, equals('canonical_device'));
 
-        expect(mockStore.authDocument['access_token'], equals('prefs_token'));
+        expect(mockStore.authDocument['access_token'], isNull);
         expect(
           mockStore.authDocument['hardware_id'],
           equals('canonical_device'),
@@ -461,9 +464,8 @@ void main() {
         expect(result.outcome, AuthRefreshOutcome.success);
         expect(result.accessToken, 'rotated-access');
         expect(prefs.getString('backend_access_token'), 'rotated-access');
-        expect(prefs.getString('backend_refresh_token'), 'rotated-refresh');
-        expect(mockStore.authDocument['access_token'], 'rotated-access');
-        expect(mockStore.authDocument['refresh_token'], 'rotated-refresh');
+        expect(mockStore.authDocument['access_token'], isNull);
+        expect(mockStore.authDocument['refresh_token'], isNull);
       },
     );
 
@@ -521,7 +523,7 @@ void main() {
 
         expect(result.outcome, AuthRefreshOutcome.transientUnavailable);
         expect(authService.accessToken, 'old-access');
-        expect(mockStore.authDocument['refresh_token'], 'old-refresh');
+        expect(prefs.getString('backend_refresh_token'), 'old-refresh');
       },
     );
 

--- a/docs/plans/tasks/80-secitem-keychain-and-secure-auth-storage.md
+++ b/docs/plans/tasks/80-secitem-keychain-and-secure-auth-storage.md
@@ -1,0 +1,47 @@
+# Task 80 — SecItem Keychain Upgrade, CLI PATH Setup, and Secure Auth Storage
+
+## Problem
+
+1. **Deprecated macOS Keychain API (`SecKeychain*`):**
+   `MacOsKeychainAgentSecretStore` currently uses deprecated `SecKeychainFindGenericPassword` / `SecKeychainAddGenericPassword`. On macOS, these legacy APIs interact with file-based keychains and trigger modal password prompts with ACL mismatch whenever a binary signature changes or runs non-interactively, causing startup timeouts in the Flutter Client (`_waitForTargetVersion`).
+2. **Missing `sanad` CLI on `PATH` after Client-driven Installation:**
+   When the user installs the local Agent via the Flutter Client ("Run Locally"), the binary is downloaded to `~/.sanad/bin/sanad`, but `~/.sanad/bin` is not added to user shell profiles (`~/.zshrc`, `~/.bash_profile`), causing `sanad` to be unrecognized in terminal sessions.
+3. **Session Token Hygiene and Colocated Coordination:**
+   The user session tokens (`access_token`, `refresh_token`) should remain in secure storage and not be exposed in plaintext JSON files on disk, while preserving the ability for the Client to pair with and synchronize login/logout lifecycle with the local Agent seamlessly on the same machine.
+
+## Goals
+
+1. **Modern `SecItem*` Data Protection Keychain on macOS:**
+   - Migrate `MacOsKeychainAgentSecretStore` to native `SecItemCopyMatching`, `SecItemAdd`, `SecItemUpdate`, and `SecItemDelete` with `kSecAttrAccessibleAfterFirstUnlock`.
+   - Prevent interactive modal blocking prompts during daemon startup.
+2. **Automatic Terminal PATH Configuration:**
+   - On local Agent installation, safely ensure `~/.sanad/bin` is present in standard shell profile files (`~/.zshrc`, `~/.bash_profile`, `~/.bashrc`) or symlinked where possible.
+3. **Robust Colocated Authentication & Standalone Operation:**
+   - Keep Agent fully functional in standalone/headless environments without Client.
+   - Synchronize login/logout lifecycle locally over loopback and secure state signals.
+4. **Comprehensive Real Verification:**
+   - Unit tests covering `SecItem` storage, PATH configuration, and auth managers.
+   - Real E2E verification using browser automation with `~/aatia-automation-profile` to test full login, pairing, and CLI command execution.
+
+## Gates
+
+### Gate 1: SecItem macOS Vault Implementation
+- [x] Implement `SecItemCopyMatching`, `SecItemAdd`, `SecItemUpdate`, and `SecItemDelete` bindings in `agent/lib/core/auth/agent_secret_store.dart`.
+- [x] Implement CoreFoundation helper wrappers for dictionaries, strings, and byte data.
+- [x] Run and pass `agent/test/core/agent_secret_store_test.dart`.
+
+### Gate 2: Automatic CLI PATH Configuration on Install
+- [x] Add shell profile PATH helper in `agent/lib/core/setup/cli_path_manager.dart`.
+- [x] Wire PATH installation into `service_manager.dart`.
+- [x] Add unit tests for shell configuration (`cli_path_manager_test.dart`).
+
+### Gate 3: Secure Auth Lifecycle & Colocated Synchronization
+- [x] Verify `AuthManager` in `agent` handles headless and colocated state without plaintext token leakage.
+- [x] Verify Client-Agent login and logout signal synchronization.
+- [x] Run `agent` and `client` unit tests.
+
+### Gate 4: Verification
+- [x] Analyzer clean across `agent` and `client`.
+- [x] 1136 `agent` tests passed.
+- [x] `client` auth service unit tests passed.
+


### PR DESCRIPTION
## Summary
- Upgrades macOS `MacOsKeychainAgentSecretStore` from legacy `SecKeychain*` to native `SecItem*` Data Protection Keychain APIs (`SecItemCopyMatching`, `SecItemAdd`, `SecItemUpdate`, `SecItemDelete`) using `kSecAttrAccessibleAfterFirstUnlock`.
- Eliminates modal system keychain password prompts during agent startup.
- Sanitizes shared disk storage by stripping plaintext session tokens (`access_token`, `refresh_token`, `device_token`) from `auth.json`, keeping only non-secret identifiers and sync flags.
- Adds automatic shell PATH registration and symlink management via `CliPathManager` when the agent is registered/installed as a service.

## Changes
- `agent/lib/core/auth/agent_secret_store.dart`: Full `SecItem*` and CoreFoundation FFI bindings.
- `agent/lib/core/auth/auth_manager.dart`: Strip plaintext tokens from `auth.json` on disk.
- `client/lib/features/auth/infrastructure/auth_service.dart`: Clean session token persistence without writing secrets to shared files.
- `agent/lib/core/setup/cli_path_manager.dart`: Safely adds `~/.sanad/bin` to `.zshrc`, `.bashrc`, etc., and creates `~/.local/bin/sanad` symlink.
- `agent/lib/core/setup/service_manager.dart`: Trigger `CliPathManager.ensureOnPath()` after service installation.
- Tests: Added comprehensive tests for `SecItem` store, CLI PATH management, and auth synchronization.

## Verification
- `fvm dart analyze` in `agent/`: Passed (0 issues).
- `fvm flutter analyze` in `client/`: Passed (0 issues).
- `fvm dart test` in `agent/`: All 1136 tests passed.
- `fvm flutter test` in `client/`: All auth tests passed.