### PR TITLE
fix(release): harden macOS Agent runtime trust verification

### DIFF
--- a/agent/test/core/update/release_manifest_test.dart
+++ b/agent/test/core/update/release_manifest_test.dart
@@ -168,6 +168,56 @@ void main() {
     });
   });
 
+  group('macOS platform trust', () {
+    test(
+      'uses the exact Apple-anchored NanoSoft publisher requirement',
+      () async {
+        String? executable;
+        List<String>? arguments;
+
+        final trusted = await verifyPlatformCodeSignature(
+          File('/tmp/sanad-agent-candidate'),
+          'macos',
+          processRunner: (command, commandArguments) async {
+            executable = command;
+            arguments = commandArguments;
+            return ProcessResult(1, 0, '', '');
+          },
+        );
+
+        expect(trusted, isTrue);
+        expect(executable, '/usr/bin/codesign');
+        expect(arguments, [
+          '--verify',
+          '--strict',
+          '--verbose=2',
+          '--test-requirement',
+          macosAgentPublisherRequirement,
+          '/tmp/sanad-agent-candidate',
+        ]);
+        expect(
+          macosAgentPublisherRequirement,
+          allOf(
+            contains('anchor apple generic'),
+            contains('certificate leaf[subject.OU] = "UC2824B99G"'),
+            contains('Developer ID Application: NanoSoft LY LLC (UC2824B99G)'),
+            isNot(contains('notarized')),
+          ),
+        );
+      },
+    );
+
+    test('fails closed when the publisher requirement is rejected', () async {
+      final trusted = await verifyPlatformCodeSignature(
+        File('/tmp/untrusted-agent-candidate'),
+        'macos',
+        processRunner: (_, _) async => ProcessResult(1, 3, '', 'rejected'),
+      );
+
+      expect(trusted, isFalse);
+    });
+  });
+
   group('AgentUpdateService', () {
     late Directory temporaryDirectory;
 

--- a/agent/test/guards/installer_pairing_contract_guard_test.dart
+++ b/agent/test/guards/installer_pairing_contract_guard_test.dart
@@ -19,6 +19,14 @@ void main() {
       expect(posix, contains('service install'));
       expect(posix, contains('service restart'));
       expect(posix, contains('SERVICE_WAS_RUNNING'));
+      expect(posix, contains('anchor apple generic'));
+      expect(posix, contains('certificate leaf[subject.OU] = "UC2824B99G"'));
+      expect(
+        posix,
+        contains('Developer ID Application: NanoSoft LY LLC (UC2824B99G)'),
+      );
+      expect(posix, isNot(contains("--test-requirement '=notarized'")));
+      expect(posix, isNot(contains('spctl --assess --type execute')));
 
       expect(windows, contains('[string]\$PairingToken'));
       expect(windows, contains('[switch]\$Login'));

--- a/client/test/unit/services/verified_agent_bootstrap_installer_test.dart
+++ b/client/test/unit/services/verified_agent_bootstrap_installer_test.dart
@@ -148,7 +148,7 @@ void main() {
     expect(File(target).readAsBytesSync(), bytes);
   });
 
-  test('macOS rejects an invalid Developer ID or notarization result', () async {
+  test('macOS keeps the existing agent when publisher trust fails', () async {
     final bytes = utf8.encode('candidate');
     final artifactFile = File('${temporaryDirectory.path}/candidate')..writeAsBytesSync(bytes);
     final manifest = _manifest(

--- a/docs/operations/release_and_signing.md
+++ b/docs/operations/release_and_signing.md
@@ -55,8 +55,11 @@ workflow fetches the authoritative notary log with a bounded retry and requires
 architecture plus `cdhash` match to the signed executable. This avoids relying
 on the local `codesign --test-requirement '=notarized'` online-ticket cache,
 which remained unavailable for more than ten minutes despite an accepted ticket
-for the exact raw CLI. `spctl --type execute` is not used because it rejects
-valid notarized non-bundle executables.
+for the exact raw CLI. Runtime installers instead require the canonical size and
+SHA-256 plus a valid Apple-anchored Developer ID signature with exact Team ID
+`UC2824B99G` and publisher name. They do not repeat the nondeterministic ticket
+lookup. `spctl --type execute` is not used because it rejects valid notarized
+non-bundle executables.
 
 The hosted macOS Client job restores the exported Sparkle Ed25519 key to a
 runner-temporary file and passes that file directly to Sparkle `sign_update`.

--- a/docs/plans/tasks/macos-agent-runtime-trust-verification.md
+++ b/docs/plans/tasks/macos-agent-runtime-trust-verification.md
@@ -1,8 +1,8 @@
 ---
 title: "macOS Agent Runtime Trust Verification"
-status: ready_for_pr
-current_gate: complete
-remaining_estimate: 0%
+status: in_review
+current_gate: G3
+remaining_estimate: 10%
 ---
 
 # macOS Agent Runtime Trust Verification
@@ -27,6 +27,10 @@ Allow a verified raw macOS Agent executable to install without relying on the no
 ### G2 — Verification
 - [x] Pass analyzers, focused tests, shell validation, diff review, and Graphify update.
 
+### G3 — Pull Request Review
+- [x] Commit, push, and open the focused pull request.
+- [ ] Pass hosted checks and receive the required protected reviews before merge.
+
 ## Acceptance Criteria
 - [x] Correct Apple-anchored NanoSoft artifacts pass without a runtime notarization-ticket lookup.
 - [x] Invalid signatures, non-Apple chains, wrong Team IDs, and wrong publisher names fail closed.
@@ -34,4 +38,6 @@ Allow a verified raw macOS Agent executable to install without relying on the no
 
 ## Definition of Done
 - [x] Code, tests, and owning documentation are consistent.
-- [x] No commit, push, release, or runtime switch is performed.
+- [x] The focused change is committed, pushed, and opened for review.
+- [ ] Hosted checks and protected reviews pass before merge.
+- [x] No release or runtime switch is performed.

--- a/docs/plans/tasks/macos-agent-runtime-trust-verification.md
+++ b/docs/plans/tasks/macos-agent-runtime-trust-verification.md
@@ -1,0 +1,37 @@
+---
+title: "macOS Agent Runtime Trust Verification"
+status: ready_for_pr
+current_gate: complete
+remaining_estimate: 0%
+---
+
+# macOS Agent Runtime Trust Verification
+
+## Goal
+Allow a verified raw macOS Agent executable to install without relying on the nondeterministic local notarization-ticket lookup, while retaining an exact Apple-anchored publisher boundary.
+
+## Locked Scope
+- Release CI remains responsible for mandatory notarization and exact ticket/`cdhash` matching.
+- Runtime installation requires canonical metadata, size, SHA-256, a valid signature, Apple trust anchor, exact Team ID `UC2824B99G`, and exact publisher certificate name.
+- Runtime installation does not use `spctl --type execute` or `codesign '=notarized'` for the raw CLI.
+
+## Gates
+
+### G0 — Evidence
+- [x] Reproduce the raw-CLI `spctl` rejection and verify the official 1.0.5 signature, publisher, checksum, and release notarization gate.
+
+### G1 — Implementation
+- [x] Apply the exact Apple-anchored requirement in the shared Dart contract and POSIX installer.
+- [x] Add focused regression coverage and update release documentation.
+
+### G2 — Verification
+- [x] Pass analyzers, focused tests, shell validation, diff review, and Graphify update.
+
+## Acceptance Criteria
+- [x] Correct Apple-anchored NanoSoft artifacts pass without a runtime notarization-ticket lookup.
+- [x] Invalid signatures, non-Apple chains, wrong Team IDs, and wrong publisher names fail closed.
+- [x] The Client bootstrap and canonical POSIX installer enforce the same publisher identity.
+
+## Definition of Done
+- [x] Code, tests, and owning documentation are consistent.
+- [x] No commit, push, release, or runtime switch is performed.

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -65,6 +65,13 @@ alternative.
 | Client iOS | signed IPA export for NanoSoft LY LLC; App Store Connect record and API key ready | Internal TestFlight upload |
 | Client Web | analyzer, startup contract test, Production-profile release build, exact source and version markers, Flutter shell/bootstrap/favicon probes, and hosted readability | attested-run/source match, protected immutable deployment, public source probe, automatic selector rollback, cache/SPA checks, and clean-browser visible render with no uncaught startup/CSP/CanvasKit/Wasm error |
 
+For raw macOS Agent installation, runtime verification must accept the exact
+Apple-anchored NanoSoft Developer ID requirement (Team ID `UC2824B99G`) after
+size and SHA-256 verification, reject any signature or publisher mismatch, and
+must not depend on `spctl --type execute` or the local `=notarized` ticket cache.
+Release CI remains the authority for accepted notarization and exact ticket
+architecture/`cdhash` matching.
+
 Windows 11 evidence follows the dedicated
 [Windows Release Clean-Machine Validation](windows_release_clean_machine.md)
 procedure. Its harness downloads the private validation-only candidate, pins

--- a/release/contract/lib/release_contract.dart
+++ b/release/contract/lib/release_contract.dart
@@ -9,6 +9,19 @@ enum ReleaseChannel { rc, stable }
 
 typedef PlatformArtifactVerifier =
     Future<bool> Function(File file, String operatingSystem);
+typedef ReleaseProcessRunner =
+    Future<ProcessResult> Function(String executable, List<String> arguments);
+
+const macosAgentPublisherRequirement =
+    '=anchor apple generic and '
+    'certificate leaf[subject.OU] = "UC2824B99G" and '
+    'certificate leaf[subject.CN] = '
+    '"Developer ID Application: NanoSoft LY LLC (UC2824B99G)"';
+
+Future<ProcessResult> _runReleaseProcess(
+  String executable,
+  List<String> arguments,
+) => Process.run(executable, arguments);
 
 /// Central metadata policy shared by manifest validation, bootstrap, and update.
 /// GitHub attestations are release-pipeline evidence; runtime verification still
@@ -389,38 +402,19 @@ Future<bool> verifyReleaseArtifactTrust(
 
 Future<bool> verifyPlatformCodeSignature(
   File file,
-  String operatingSystem,
-) async {
+  String operatingSystem, {
+  ReleaseProcessRunner processRunner = _runReleaseProcess,
+}) async {
   if (operatingSystem == 'macos') {
-    final verification = await Process.run('/usr/bin/codesign', [
+    final verification = await processRunner('/usr/bin/codesign', [
       '--verify',
       '--strict',
       '--verbose=2',
-      file.path,
-    ]);
-    if (verification.exitCode != 0) return false;
-    final details = await Process.run('/usr/bin/codesign', [
-      '-dv',
-      '--verbose=4',
-      file.path,
-    ]);
-    final output = '${details.stdout}\n${details.stderr}';
-    if (details.exitCode != 0 ||
-        !output.contains('Developer ID Application: NanoSoft LY LLC')) {
-      return false;
-    }
-    // Raw CLI executables are not app bundles, so spctl rejects them even when
-    // Apple notarized them. codesign's explicit notarized requirement validates
-    // the ticket without weakening the Developer ID check above.
-    final notarization = await Process.run('/usr/bin/codesign', [
-      '--verify',
-      '--strict',
       '--test-requirement',
-      '=notarized',
-      '--verbose=2',
+      macosAgentPublisherRequirement,
       file.path,
     ]);
-    return notarization.exitCode == 0;
+    return verification.exitCode == 0;
   }
   if (operatingSystem == 'windows') {
     final escaped = file.path.replaceAll("'", "''");

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -212,17 +212,10 @@ if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
   exit 66
 fi
 if [ "$PLATFORM" = "macos" ]; then
-  if ! codesign --verify --strict --verbose=2 "$STAGED"; then
-    echo "Downloaded artifact code-signature verification failed." >&2
-    exit 66
-  fi
-  if ! codesign -dv --verbose=4 "$STAGED" 2>&1 |
-    grep -Fq 'Developer ID Application: NanoSoft LY LLC'; then
-    echo "Downloaded artifact publisher is not trusted." >&2
-    exit 66
-  fi
-  if ! spctl --assess --type execute --verbose=2 "$STAGED"; then
-    echo "Downloaded artifact notarization verification failed." >&2
+  MACOS_AGENT_PUBLISHER_REQUIREMENT='=anchor apple generic and certificate leaf[subject.OU] = "UC2824B99G" and certificate leaf[subject.CN] = "Developer ID Application: NanoSoft LY LLC (UC2824B99G)"'
+  if ! codesign --verify --strict --verbose=2 \
+    --test-requirement "$MACOS_AGENT_PUBLISHER_REQUIREMENT" "$STAGED"; then
+    echo "Downloaded artifact publisher signature is not trusted." >&2
     exit 66
   fi
 fi


### PR DESCRIPTION
## Problem / Goal

Sanad Client 1.0.5 can reject the correctly signed and notarized raw macOS Agent because the local notarization-ticket lookup is nondeterministic for standalone CLI executables. `spctl --type execute` also rejects raw executables as non-app bundles.

## Technical Changes

- Replace runtime notarization-ticket lookup with an exact Apple-anchored Developer ID requirement.
- Require NanoSoft Team ID `UC2824B99G` and the exact certificate common name.
- Apply the same publisher boundary in the shared Dart release contract and POSIX installer.
- Keep notarization and exact ticket/`cdhash` validation mandatory in protected release CI.
- Add focused success/fail-closed tests and update release documentation.

## Verification

- `fvm dart analyze` — passed
- `fvm flutter analyze` — passed
- Agent release/installer tests — 23 passed, 1 platform skip
- Client bootstrap tests — 12 passed
- `bash -n scripts/install.sh` — passed
- `git diff --check` — passed
- Official v1.0.5 macOS arm64 Agent passed the new runtime verifier
- Non-publisher local Agent was rejected
- `graphify update .` completed

## Protected Review

This changes release and platform trust boundaries and requires maintainer-provided `security-reviewed` and `release-reviewed` labels before merge.
