### PR TITLE
fix(macos): disable Impeller pending upstream crash fix

### DIFF
--- a/client/macos/Runner/Info.plist
+++ b/client/macos/Runner/Info.plist
@@ -22,6 +22,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>FLTEnableImpeller</key>
+	<false/>
 	<key>NSHumanReadableCopyright</key>
 	<string>$(PRODUCT_COPYRIGHT)</string>
 	<key>NSMainNibFile</key>

--- a/client/release/macos/build_macos_dmg.sh
+++ b/client/release/macos/build_macos_dmg.sh
@@ -40,6 +40,16 @@ if [ "${SANAD_SKIP_BUILD:-0}" != "1" ]; then
 fi
 test -d "$APP_PATH"
 
+IMPELLER_SETTING="$(
+  /usr/libexec/PlistBuddy \
+    -c 'Print :FLTEnableImpeller' \
+    "$APP_PATH/Contents/Info.plist" 2>/dev/null || true
+)"
+if [ "$IMPELLER_SETTING" != "false" ]; then
+  echo "macOS release must disable Impeller while flutter/flutter#185394 remains unresolved." >&2
+  exit 1
+fi
+
 while IFS= read -r binary; do
   architectures="$(lipo -archs "$binary")"
   if [[ " $architectures " != *" arm64 "* ]] ||

--- a/client/test/tool/desktop_window_contract_test.dart
+++ b/client/test/tool/desktop_window_contract_test.dart
@@ -85,6 +85,18 @@ void main() {
     expect(titleBar, contains('WindowManagerService.toggleMaximized'));
   });
 
+  test('macOS deployment disables Impeller while the upstream crash remains unresolved', () {
+    final infoPlist = File('macos/Runner/Info.plist').readAsStringSync();
+
+    final releaseScript = File(
+      'release/macos/build_macos_dmg.sh',
+    ).readAsStringSync();
+
+    expect(infoPlist, contains('<key>FLTEnableImpeller</key>\n\t<false/>'));
+    expect(releaseScript, contains("-c 'Print :FLTEnableImpeller'"));
+    expect(releaseScript, contains(r'if [ "$IMPELLER_SETTING" != "false" ]'));
+  });
+
   test('supported native runners enforce the same minimum dimensions', () {
     final macOS = File('macos/Runner/MainFlutterWindow.swift').readAsStringSync();
     final windows = File('windows/runner/win32_window.cpp').readAsStringSync();

--- a/docs/plans/tasks/81-macos-impeller-crash-mitigation.md
+++ b/docs/plans/tasks/81-macos-impeller-crash-mitigation.md
@@ -1,0 +1,23 @@
+# Task 81: macOS Impeller Crash Mitigation
+
+## Goal
+
+Prevent the Flutter 3.47 macOS Client from using Impeller while upstream issue
+`flutter/flutter#185394` remains unresolved, restoring the prior Skia rendering
+path for installed macOS users.
+
+## Gates
+
+- [x] **G1 — Configuration:** Set `FLTEnableImpeller` to `false` in the macOS Client `Info.plist` without changing other platforms.
+- [x] **G2 — Regression Contract:** Add a focused source-level test that fails if the deployment opt-out is removed accidentally.
+- [x] **G3 — Documentation:** Record the temporary macOS release invariant and the condition for re-enabling Impeller.
+- [x] **G4 — Local Verification:** Pass the focused test and Flutter static analysis.
+- [ ] **G5 — Delivery:** Open a focused pull request, require hosted checks to pass, and merge it through the protected repository workflow.
+- [ ] **G6 — Post-Merge Soak and Release:** Before preparing a patch release, run the macOS Client for approximately one day across resize, compact/restore, background/foreground, and sleep/wake transitions without recurrence.
+
+## Acceptance Criteria
+
+- The built macOS application resolves `FLTEnableImpeller` to `false`.
+- Windows, Linux, Android, iOS, and Web rendering configuration is unchanged.
+- A focused automated test protects the source configuration.
+- Impeller is not re-enabled until an upstream stable Flutter engine fix is available and passes macOS soak verification.

--- a/docs/plans/tasks/81-macos-impeller-crash-mitigation.md
+++ b/docs/plans/tasks/81-macos-impeller-crash-mitigation.md
@@ -12,7 +12,7 @@ path for installed macOS users.
 - [x] **G2 — Regression Contract:** Add a focused source-level test that fails if the deployment opt-out is removed accidentally.
 - [x] **G3 — Documentation:** Record the temporary macOS release invariant and the condition for re-enabling Impeller.
 - [x] **G4 — Local Verification:** Pass the focused test and Flutter static analysis.
-- [ ] **G5 — Delivery:** Open a focused pull request, require hosted checks to pass, and merge it through the protected repository workflow.
+- [x] **G5 — Hosted PR Verification:** Open a focused pull request and require all hosted checks to pass before merge.
 - [ ] **G6 — Post-Merge Soak and Release:** Before preparing a patch release, run the macOS Client for approximately one day across resize, compact/restore, background/foreground, and sleep/wake transitions without recurrence.
 
 ## Acceptance Criteria

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -53,6 +53,12 @@ alternative.
 
 ## Platform matrix
 
+Until `flutter/flutter#185394` is fixed in a stable Flutter engine and passes a
+macOS foreground/resize soak, the macOS Client release must set
+`FLTEnableImpeller` to `false` in its resolved application `Info.plist`. Release
+verification must inspect the built `.app`, not only the source plist, so a
+build-setting override cannot silently re-enable the affected Metal path.
+
 | Target | Local evidence | Hosted or clean-machine evidence still required |
 |---|---|---|
 | Agent macOS arm64/x64 | compilation, version, architecture, Developer ID verification, accepted notary log with exact architecture/`cdhash` ticket match | both hosted runners, clean install, real upgrade and rollback |


### PR DESCRIPTION
## Problem / Goal

Flutter 3.47 enables Impeller by default on macOS, exposing the open P1 engine crash in flutter/flutter#185394. The failure invalidates a Metal texture when its descriptor size disagrees with the backing texture and can terminate the client during foreground, resize, or window lifecycle transitions.

## Technical Changes

- Set `FLTEnableImpeller` to `false` for the macOS Client, restoring the previously used Skia rendering path.
- Fail the macOS release build if the resolved application plist does not preserve that opt-out.
- Add a focused regression test for the source plist and release gate.
- Document the temporary release invariant and the condition for re-enabling Impeller.

Other platforms are unchanged.

## Verification

- `plutil -lint macos/Runner/Info.plist`
- `bash -n release/macos/build_macos_dmg.sh`
- `fvm flutter test test/tool/desktop_window_contract_test.dart` — 11 passed
- `fvm flutter analyze` — no issues
- `fvm flutter build macos --debug` — succeeded
- Resolved `Sanad.app/Contents/Info.plist` reports `FLTEnableImpeller = false`

## Follow-up

Run a one-day macOS soak before preparing the patch release. Re-enable Impeller only after an upstream stable engine fix and successful macOS soak verification.
