### PR TITLE
feat(client): preserve compact window positions and hover navigation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,3 @@
+analyzer:
+  exclude:
+    - scripts/flutter_driver_cli/**

--- a/client/lib/features/conversations/presentation/widgets/conversation_app_bar.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_app_bar.dart
@@ -9,12 +9,13 @@ import 'package:window_manager/window_manager.dart';
 
 import 'sidebar/sidebar_composition.dart';
 
-class ConversationAppBar extends StatelessWidget
-    implements PreferredSizeWidget {
+class ConversationAppBar extends StatelessWidget implements PreferredSizeWidget {
   final String? sessionTitle;
   final DeviceWorkspace? workspace;
   final bool isMobile;
   final VoidCallback? onMenuPressed;
+  final VoidCallback? onMenuHoverEnter;
+  final VoidCallback? onMenuHoverExit;
 
   const ConversationAppBar({
     super.key,
@@ -22,6 +23,8 @@ class ConversationAppBar extends StatelessWidget
     this.workspace,
     this.isMobile = false,
     this.onMenuPressed,
+    this.onMenuHoverEnter,
+    this.onMenuHoverExit,
   });
 
   @override
@@ -42,9 +45,7 @@ class ConversationAppBar extends StatelessWidget
           filter: ImageFilter.blur(sigmaX: 15, sigmaY: 15),
           child: Container(
             padding: EdgeInsets.only(
-              top: alignsWithMacOSTitleBar
-                  ? 3
-                  : MediaQuery.of(context).padding.top + 8,
+              top: alignsWithMacOSTitleBar ? 3 : MediaQuery.of(context).padding.top + 8,
               left: alignsWithMacOSTitleBar ? 0 : (isMobile ? 4 : 16),
               right: 16,
               bottom: 8,
@@ -56,9 +57,7 @@ class ConversationAppBar extends StatelessWidget
                 color: theme.colorScheme.outline.withValues(alpha: 0.3),
               ),
             ),
-            child: isMobile
-                ? _buildMobileLayout(theme)
-                : _buildDesktopLayout(theme),
+            child: isMobile ? _buildMobileLayout(theme) : _buildDesktopLayout(theme),
           ),
         ),
       ),
@@ -81,12 +80,8 @@ class ConversationAppBar extends StatelessWidget
   Widget _buildDesktopLayout(ThemeData theme) {
     final hasWorkspace = workspace != null;
     final titleDirection = TextUtils.getTextDirection(sessionTitle);
-    final workspaceDirection = hasWorkspace
-        ? TextUtils.getTextDirection(workspace!.name)
-        : TextDirection.ltr;
-    final isRtl =
-        titleDirection == TextDirection.rtl ||
-        workspaceDirection == TextDirection.rtl;
+    final workspaceDirection = hasWorkspace ? TextUtils.getTextDirection(workspace!.name) : TextDirection.ltr;
+    final isRtl = titleDirection == TextDirection.rtl || workspaceDirection == TextDirection.rtl;
 
     return Row(
       // textDirection: isRtl ? TextDirection.rtl : TextDirection.ltr,
@@ -134,32 +129,28 @@ class ConversationAppBar extends StatelessWidget
 
   Widget _buildMobileLayout(ThemeData theme) {
     final titleDirection = TextUtils.getTextDirection(sessionTitle);
-    final workspaceDirection = workspace != null
-        ? TextUtils.getTextDirection(workspace!.name)
-        : TextDirection.ltr;
-    final isRtl =
-        titleDirection == TextDirection.rtl ||
-        workspaceDirection == TextDirection.rtl;
+    final workspaceDirection = workspace != null ? TextUtils.getTextDirection(workspace!.name) : TextDirection.ltr;
+    final isRtl = titleDirection == TextDirection.rtl || workspaceDirection == TextDirection.rtl;
 
     return Row(
       textDirection: TextDirection.ltr,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ConversationHeaderActions(onMenuPressed: onMenuPressed),
+        ConversationHeaderActions(
+          onMenuPressed: onMenuPressed,
+          onMenuHoverEnter: onMenuHoverEnter,
+          onMenuHoverExit: onMenuHoverExit,
+        ),
         const SizedBox(width: 4),
         Expanded(
           child: Column(
-            crossAxisAlignment: isRtl
-                ? CrossAxisAlignment.end
-                : CrossAxisAlignment.start,
+            crossAxisAlignment: isRtl ? CrossAxisAlignment.end : CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: [
               Text(
                 sessionTitle ?? 'Conversation',
                 textDirection: titleDirection,
-                textAlign: titleDirection == TextDirection.rtl
-                    ? TextAlign.right
-                    : TextAlign.left,
+                textAlign: titleDirection == TextDirection.rtl ? TextAlign.right : TextAlign.left,
                 style: theme.textTheme.titleSmall?.copyWith(
                   fontWeight: FontWeight.w600,
                   color: theme.colorScheme.onSurface,
@@ -173,9 +164,7 @@ class ConversationAppBar extends StatelessWidget
                   child: Text(
                     workspace!.name,
                     textDirection: workspaceDirection,
-                    textAlign: workspaceDirection == TextDirection.rtl
-                        ? TextAlign.right
-                        : TextAlign.left,
+                    textAlign: workspaceDirection == TextDirection.rtl ? TextAlign.right : TextAlign.left,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant.withValues(
                         alpha: 0.8,

--- a/client/lib/features/conversations/presentation/widgets/conversation_header_actions.dart
+++ b/client/lib/features/conversations/presentation/widgets/conversation_header_actions.dart
@@ -10,10 +10,14 @@ import 'package:sanad_client/utils/app_platform.dart';
 /// application actions begin after that reserved platform-owned area.
 class ConversationHeaderActions extends StatelessWidget {
   final VoidCallback? onMenuPressed;
+  final VoidCallback? onMenuHoverEnter;
+  final VoidCallback? onMenuHoverExit;
 
   const ConversationHeaderActions({
     super.key,
     this.onMenuPressed,
+    this.onMenuHoverEnter,
+    this.onMenuHoverExit,
   });
 
   @override
@@ -35,19 +39,24 @@ class ConversationHeaderActions extends StatelessWidget {
           textDirection: TextDirection.ltr,
           children: [
             if (onMenuPressed != null)
-              IconButton(
-                key: const Key('conversation_header_menu_btn'),
-                icon: Icon(
-                  AppPlatform.isDesktop ? Symbols.dock_to_right : Icons.menu,
-                  size: AppPlatform.isDesktop ? 16 : null,
-                  color: AppPlatform.isDesktop
-                      ? theme.colorScheme.onSurface.withValues(alpha: 0.6)
-                      : theme.colorScheme.onSurface,
+              MouseRegion(
+                key: const Key('conversation_menu_hover_region'),
+                onEnter: (_) => onMenuHoverEnter?.call(),
+                onExit: (_) => onMenuHoverExit?.call(),
+                child: IconButton(
+                  key: const Key('conversation_header_menu_btn'),
+                  icon: Icon(
+                    AppPlatform.isDesktop ? Symbols.dock_to_right : Icons.menu,
+                    size: AppPlatform.isDesktop ? 16 : null,
+                    color: AppPlatform.isDesktop
+                        ? theme.colorScheme.onSurface.withValues(alpha: 0.6)
+                        : theme.colorScheme.onSurface,
+                  ),
+                  constraints: AppPlatform.isDesktop ? const BoxConstraints(minWidth: 24, minHeight: 24) : null,
+                  padding: AppPlatform.isDesktop ? EdgeInsets.zero : null,
+                  onPressed: onMenuPressed,
+                  tooltip: 'Open navigation menu',
                 ),
-                constraints: AppPlatform.isDesktop ? const BoxConstraints(minWidth: 24, minHeight: 24) : null,
-                padding: AppPlatform.isDesktop ? EdgeInsets.zero : null,
-                onPressed: onMenuPressed,
-                tooltip: 'Open navigation menu',
               ),
             if (onMenuPressed != null && AppPlatform.isDesktop) const SizedBox(width: 4),
             if (AppPlatform.isDesktop)

--- a/client/lib/features/home/presentation/screens/home_screen.dart
+++ b/client/lib/features/home/presentation/screens/home_screen.dart
@@ -36,7 +36,9 @@ import 'package:sanad_client/features/provider_setup/data/models/provider_readin
 import 'package:sanad_client/features/provider_setup/presentation/widgets/provider_setup_flow.dart';
 import 'package:sanad_client/infrastructure/local_tools/local_tool_runtime_service.dart';
 import 'package:sanad_client/infrastructure/local_tools/workspace_tool_runtime_context.dart';
+import 'package:sanad_client/infrastructure/platform/window_manager_service.dart';
 import 'package:sanad_client/infrastructure/socket/sanad_socket_service.dart';
+import 'package:sanad_client/utils/app_platform.dart';
 
 import 'package:sanad_client/features/home/presentation/widgets/status_bar.dart';
 
@@ -177,6 +179,11 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
   String? _lastCheckedDeviceId;
   String? _skippedDeviceId;
   StreamSubscription<DeletedSessionIdentity>? _deletedSessionSubscription;
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+  Timer? _hoverDrawerCloseTimer;
+  bool _isMenuButtonHovered = false;
+  bool _isDrawerHovered = false;
+  bool _drawerOpenedByHover = false;
 
   @override
   void initState() {
@@ -199,8 +206,53 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
 
   @override
   void dispose() {
+    _hoverDrawerCloseTimer?.cancel();
     unawaited(_deletedSessionSubscription?.cancel());
     super.dispose();
+  }
+
+  void _onCompactMenuButtonEnter() {
+    _hoverDrawerCloseTimer?.cancel();
+    _isMenuButtonHovered = true;
+    final scaffold = _scaffoldKey.currentState;
+    if (scaffold == null || scaffold.isDrawerOpen) return;
+    _drawerOpenedByHover = true;
+    scaffold.openDrawer();
+  }
+
+  void _onCompactMenuButtonExit() {
+    _isMenuButtonHovered = false;
+    _scheduleHoverDrawerClose();
+  }
+
+  void _onCompactDrawerEnter() {
+    _hoverDrawerCloseTimer?.cancel();
+    _isDrawerHovered = true;
+  }
+
+  void _onCompactDrawerExit() {
+    _isDrawerHovered = false;
+    _scheduleHoverDrawerClose();
+  }
+
+  void _scheduleHoverDrawerClose() {
+    _hoverDrawerCloseTimer?.cancel();
+    if (!_drawerOpenedByHover) return;
+    _hoverDrawerCloseTimer = Timer(const Duration(milliseconds: 150), () {
+      if (!mounted || _isMenuButtonHovered || _isDrawerHovered) return;
+      final scaffold = _scaffoldKey.currentState;
+      if (scaffold?.isDrawerOpen ?? false) {
+        scaffold!.closeDrawer();
+      }
+    });
+  }
+
+  void _onDrawerChanged(bool isOpened) {
+    if (isOpened) return;
+    _hoverDrawerCloseTimer?.cancel();
+    _isMenuButtonHovered = false;
+    _isDrawerHovered = false;
+    _drawerOpenedByHover = false;
   }
 
   @override
@@ -449,39 +501,57 @@ class _HomeScreenContentState extends State<_HomeScreenContent> {
           builder: (context, constraints) {
             final isDesktop = constraints.maxWidth > _tabletBreakpoint;
 
-            return Scaffold(
-              drawer: isDesktop ? null : const _SidebarDrawer(),
-              body: Column(
-                children: [
-                  Expanded(
-                    child: Stack(
-                      children: [
-                        if (isDesktop)
-                          ConversationWorkspaceLayout(
-                            child: Container(
-                              color: theme.scaffoldBackgroundColor,
-                              child: const _MainContent(isMobile: false),
-                            ),
-                          )
-                        else
-                          Container(
-                            color: theme.scaffoldBackgroundColor,
-                            child: const _MainContent(isMobile: true),
-                          ),
-                        if (_providerSetupDevice != null)
-                          _ProviderSetupGate(
-                            device: _providerSetupDevice!,
-                            onReady: (readiness) => _dismissProviderSetupGate(
-                              readiness: readiness,
-                            ),
-                            onSkip: () => _dismissProviderSetupGate(skipped: true),
-                          ),
-                      ],
-                    ),
+            return ValueListenableBuilder<bool>(
+              valueListenable: WindowManagerService.compactModeListenable,
+              builder: (context, isCompactWindow, _) {
+                final enableHoverDrawer = AppPlatform.isDesktop && !isDesktop && isCompactWindow;
+                return Scaffold(
+                  key: _scaffoldKey,
+                  drawer: isDesktop
+                      ? null
+                      : _SidebarDrawer(
+                          enableHover: enableHoverDrawer,
+                          onHoverEnter: _onCompactDrawerEnter,
+                          onHoverExit: _onCompactDrawerExit,
+                        ),
+                  onDrawerChanged: _onDrawerChanged,
+                  body: Column(
+                    children: [
+                      Expanded(
+                        child: Stack(
+                          children: [
+                            if (isDesktop)
+                              ConversationWorkspaceLayout(
+                                child: Container(
+                                  color: theme.scaffoldBackgroundColor,
+                                  child: const _MainContent(isMobile: false),
+                                ),
+                              )
+                            else
+                              Container(
+                                color: theme.scaffoldBackgroundColor,
+                                child: _MainContent(
+                                  isMobile: true,
+                                  onMenuHoverEnter: enableHoverDrawer ? _onCompactMenuButtonEnter : null,
+                                  onMenuHoverExit: enableHoverDrawer ? _onCompactMenuButtonExit : null,
+                                ),
+                              ),
+                            if (_providerSetupDevice != null)
+                              _ProviderSetupGate(
+                                device: _providerSetupDevice!,
+                                onReady: (readiness) => _dismissProviderSetupGate(
+                                  readiness: readiness,
+                                ),
+                                onSkip: () => _dismissProviderSetupGate(skipped: true),
+                              ),
+                          ],
+                        ),
+                      ),
+                      const DesktopOnlyStatusBar(),
+                    ],
                   ),
-                  const DesktopOnlyStatusBar(),
-                ],
-              ),
+                );
+              },
             );
           },
         ),
@@ -577,7 +647,14 @@ class _ProviderSetupGate extends StatelessWidget {
 
 class _MainContent extends StatelessWidget {
   final bool isMobile;
-  const _MainContent({required this.isMobile});
+  final VoidCallback? onMenuHoverEnter;
+  final VoidCallback? onMenuHoverExit;
+
+  const _MainContent({
+    required this.isMobile,
+    this.onMenuHoverEnter,
+    this.onMenuHoverExit,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -614,6 +691,8 @@ class _MainContent extends StatelessWidget {
                           workspace: _workspaceFromSession(presentedSession),
                           isMobile: isMobile,
                           onMenuPressed: isMobile ? () => Scaffold.of(context).openDrawer() : null,
+                          onMenuHoverEnter: onMenuHoverEnter,
+                          onMenuHoverExit: onMenuHoverExit,
                         ),
                       ),
                   ],
@@ -765,20 +844,38 @@ class _HistoryTransitionOverlay extends StatelessWidget {
 // ─── Sidebar drawer (mobile) ───────────────────────────────────────────────
 
 class _SidebarDrawer extends StatelessWidget {
-  const _SidebarDrawer();
+  final bool enableHover;
+  final VoidCallback? onHoverEnter;
+  final VoidCallback? onHoverExit;
+
+  const _SidebarDrawer({
+    this.enableHover = false,
+    this.onHoverEnter,
+    this.onHoverExit,
+  });
 
   @override
   Widget build(BuildContext context) {
+    Widget content = SessionSidebar(
+      isDrawerMode: true,
+      onClose: () => Navigator.pop(context),
+    );
+    if (enableHover) {
+      content = MouseRegion(
+        key: const Key('compact_sidebar_hover_region'),
+        onEnter: (_) => onHoverEnter?.call(),
+        onExit: (_) => onHoverExit?.call(),
+        child: content,
+      );
+    }
+
     return Drawer(
       backgroundColor: Theme.of(context).colorScheme.surface,
       width: (MediaQuery.of(context).size.width * SidebarBreakpoints.drawerWidthFactor).clamp(
         SidebarBreakpoints.minWidth,
         MediaQuery.of(context).size.width,
       ),
-      child: SessionSidebar(
-        isDrawerMode: true,
-        onClose: () => Navigator.pop(context),
-      ),
+      child: content,
     );
   }
 }

--- a/client/lib/infrastructure/platform/window_manager_service.dart
+++ b/client/lib/infrastructure/platform/window_manager_service.dart
@@ -19,6 +19,15 @@ class WindowManagerService with WindowListener {
   );
   WindowManagerService._();
 
+  static const _widthKey = 'window_width';
+  static const _heightKey = 'window_height';
+  static const _legacyXKey = 'window_x';
+  static const _legacyYKey = 'window_y';
+  static const _expandedXKey = 'window_expanded_x';
+  static const _expandedYKey = 'window_expanded_y';
+  static const _compactXKey = 'window_compact_x';
+  static const _compactYKey = 'window_compact_y';
+
   static bool _isInitialized = false;
   static Timer? _saveTimer;
   static Rect? _restoreBounds;
@@ -44,27 +53,43 @@ class WindowManagerService with WindowListener {
   static bool isCompactWidth(double width) => width <= compactWindowSize.width + 1.0;
 
   @visibleForTesting
-  static Rect compactBoundsFor(Rect currentBounds) => Rect.fromLTWH(
-    currentBounds.left,
-    currentBounds.top,
+  static Rect compactBoundsFor(Rect currentBounds, {Offset? savedPosition}) => Rect.fromLTWH(
+    savedPosition?.dx ?? currentBounds.left,
+    savedPosition?.dy ?? currentBounds.top,
     compactWindowSize.width,
     compactWindowSize.height,
   );
 
   @visibleForTesting
-  static Rect restoreBoundsFor(Rect? previousBounds, {Rect? currentBounds}) {
-    final origin = previousBounds ?? currentBounds ?? Rect.zero;
+  static Rect restoreBoundsFor(
+    Rect? previousBounds, {
+    Rect? currentBounds,
+    Offset? savedPosition,
+  }) {
+    final origin = previousBounds?.topLeft ?? savedPosition ?? currentBounds?.topLeft ?? Offset.zero;
     if (previousBounds == null ||
         previousBounds.width < defaultWindowSize.width ||
         previousBounds.height < defaultWindowSize.height) {
       return Rect.fromLTWH(
-        origin.left,
-        origin.top,
+        origin.dx,
+        origin.dy,
         defaultWindowSize.width,
         defaultWindowSize.height,
       );
     }
     return previousBounds;
+  }
+
+  static Offset? _readPosition(
+    SharedPreferences prefs,
+    String xKey,
+    String yKey, {
+    double? fallbackX,
+    double? fallbackY,
+  }) {
+    final x = prefs.getDouble(xKey) ?? fallbackX;
+    final y = prefs.getDouble(yKey) ?? fallbackY;
+    return x == null || y == null ? null : Offset(x, y);
   }
 
   static Future<void> initialize() async {
@@ -75,25 +100,39 @@ class WindowManagerService with WindowListener {
 
     final prefs = await SharedPreferences.getInstance();
 
-    // Retrieve saved dimensions/position
-    final double? savedWidth = prefs.getDouble('window_width');
-    final double? savedHeight = prefs.getDouble('window_height');
-    final double? savedX = prefs.getDouble('window_x');
-    final double? savedY = prefs.getDouble('window_y');
-    final bool isMaximized = prefs.getBool('window_is_maximized') ?? false;
+    final savedWidth = prefs.getDouble(_widthKey);
+    final savedHeight = prefs.getDouble(_heightKey);
+    final legacyX = prefs.getDouble(_legacyXKey);
+    final legacyY = prefs.getDouble(_legacyYKey);
+    final expandedPosition = _readPosition(
+      prefs,
+      _expandedXKey,
+      _expandedYKey,
+      fallbackX: legacyX,
+      fallbackY: legacyY,
+    );
+    final compactPosition = _readPosition(
+      prefs,
+      _compactXKey,
+      _compactYKey,
+      fallbackX: expandedPosition?.dx,
+      fallbackY: expandedPosition?.dy,
+    );
+    final isMaximized = prefs.getBool('window_is_maximized') ?? false;
+    final startCompact = !isMaximized && savedWidth != null && isCompactWidth(savedWidth);
 
-    // Use default values if nothing is saved
-    final Size savedWindowSize = (savedWidth != null && savedHeight != null)
+    final savedExpandedSize = (savedWidth != null && savedHeight != null && !isCompactWidth(savedWidth))
         ? Size(savedWidth, savedHeight)
         : defaultWindowSize;
-    final Size windowSize = Size(
-      savedWindowSize.width < minimumWindowSize.width ? minimumWindowSize.width : savedWindowSize.width,
-      savedWindowSize.height < minimumWindowSize.height ? minimumWindowSize.height : savedWindowSize.height,
+    final expandedSize = Size(
+      savedExpandedSize.width < minimumWindowSize.width ? minimumWindowSize.width : savedExpandedSize.width,
+      savedExpandedSize.height < minimumWindowSize.height ? minimumWindowSize.height : savedExpandedSize.height,
     );
+    final windowSize = startCompact ? compactWindowSize : expandedSize;
+    final savedPosition = startCompact ? compactPosition : expandedPosition;
 
-    // Determine if we should center the window
-    final bool hasCentered = prefs.getBool('has_centered_window') ?? false;
-    final bool shouldCenter = !hasCentered && (savedX == null || savedY == null);
+    final hasCentered = prefs.getBool('has_centered_window') ?? false;
+    final shouldCenter = !hasCentered && savedPosition == null;
 
     final WindowOptions windowOptions = WindowOptions(
       size: windowSize,
@@ -107,8 +146,8 @@ class WindowManagerService with WindowListener {
 
     await windowManager.waitUntilReadyToShow(windowOptions, () async {
       await windowManager.setMinimumSize(minimumWindowSize);
-      if (savedX != null && savedY != null && !isMaximized) {
-        await windowManager.setPosition(Offset(savedX, savedY));
+      if (savedPosition != null && !isMaximized) {
+        await windowManager.setPosition(savedPosition);
       }
 
       await windowManager.show();
@@ -121,7 +160,7 @@ class WindowManagerService with WindowListener {
       // Mark as initialized so subsequent events are tracked.
       _isInitialized = true;
       if (!isMaximized) {
-        _isCompactMode.value = isCompactWidth(windowSize.width);
+        _isCompactMode.value = startCompact;
       }
       await _instance._refreshMaximizedOrFullScreenState();
 
@@ -134,13 +173,26 @@ class WindowManagerService with WindowListener {
   static Future<void> toggleCompactMode() async {
     if (!AppPlatform.isDesktop || !_isInitialized) return;
 
+    final prefs = await SharedPreferences.getInstance();
     if (_isCompactMode.value) {
+      await _saveCurrentBoundsForMode(prefs, isCompact: true);
       final currentBounds = await windowManager.getBounds();
-      final targetBounds = restoreBoundsFor(_restoreBounds, currentBounds: currentBounds);
+      final expandedPosition = _readPosition(
+        prefs,
+        _expandedXKey,
+        _expandedYKey,
+        fallbackX: prefs.getDouble(_legacyXKey),
+        fallbackY: prefs.getDouble(_legacyYKey),
+      );
+      final targetBounds = restoreBoundsFor(
+        _restoreBounds,
+        currentBounds: currentBounds,
+        savedPosition: expandedPosition,
+      );
       await _setBounds(targetBounds);
       _restoreBounds = null;
       _isCompactMode.value = false;
-      _instance._saveWindowState();
+      await _saveCurrentBoundsForMode(prefs, isCompact: false);
       return;
     }
 
@@ -152,10 +204,20 @@ class WindowManagerService with WindowListener {
     }
 
     final currentBounds = await windowManager.getBounds();
+    await _saveBoundsForMode(prefs, currentBounds, isCompact: false);
     _restoreBounds = currentBounds;
-    final compactBounds = compactBoundsFor(currentBounds);
+    final compactPosition = _readPosition(
+      prefs,
+      _compactXKey,
+      _compactYKey,
+    );
+    final compactBounds = compactBoundsFor(
+      currentBounds,
+      savedPosition: compactPosition,
+    );
     await _setBounds(compactBounds);
     _isCompactMode.value = true;
+    await _saveCurrentBoundsForMode(prefs, isCompact: true);
   }
 
   static Future<void> _setBounds(Rect bounds) async {
@@ -167,23 +229,44 @@ class WindowManagerService with WindowListener {
     }
   }
 
-  // Helper method to save state with a 500ms debounce
+  static Future<void> _saveCurrentBoundsForMode(
+    SharedPreferences prefs, {
+    required bool isCompact,
+  }) async {
+    final bounds = await windowManager.getBounds();
+    await _saveBoundsForMode(prefs, bounds, isCompact: isCompact);
+  }
+
+  static Future<void> _saveBoundsForMode(
+    SharedPreferences prefs,
+    Rect bounds, {
+    required bool isCompact,
+  }) async {
+    final xKey = isCompact ? _compactXKey : _expandedXKey;
+    final yKey = isCompact ? _compactYKey : _expandedYKey;
+    await prefs.setDouble(xKey, bounds.left);
+    await prefs.setDouble(yKey, bounds.top);
+
+    if (!isCompact) {
+      await prefs.setDouble(_widthKey, bounds.width);
+      await prefs.setDouble(_heightKey, bounds.height);
+      // Keep the legacy position synchronized for seamless downgrade/migration.
+      await prefs.setDouble(_legacyXKey, bounds.left);
+      await prefs.setDouble(_legacyYKey, bounds.top);
+    }
+  }
+
+  // Helper method to save state with a 500ms debounce.
   void _saveWindowState() {
     _saveTimer?.cancel();
     _saveTimer = Timer(const Duration(milliseconds: 500), () async {
-      if (!_isInitialized || _isCompactMode.value) return;
+      if (!_isInitialized || await windowManager.isMaximized()) return;
 
-      final isMaximized = await windowManager.isMaximized();
       final prefs = await SharedPreferences.getInstance();
-
-      if (!isMaximized) {
-        final size = await windowManager.getSize();
-        final pos = await windowManager.getPosition();
-        await prefs.setDouble('window_width', size.width);
-        await prefs.setDouble('window_height', size.height);
-        await prefs.setDouble('window_x', pos.dx);
-        await prefs.setDouble('window_y', pos.dy);
-      }
+      await _saveCurrentBoundsForMode(
+        prefs,
+        isCompact: _isCompactMode.value,
+      );
     });
   }
 

--- a/client/test/tool/desktop_window_contract_test.dart
+++ b/client/test/tool/desktop_window_contract_test.dart
@@ -25,7 +25,7 @@ void main() {
     expect(WindowManagerService.defaultWindowSize, const Size(1400, 900));
   });
 
-  test('compact bounds preserve the window top-left origin', () {
+  test('compact bounds preserve the current origin without a saved position', () {
     final bounds = WindowManagerService.compactBoundsFor(
       const Rect.fromLTWH(120, 80, 1400, 900),
     );
@@ -33,6 +33,16 @@ void main() {
     expect(bounds.left, 120);
     expect(bounds.top, 80);
     expect(bounds.size, const Size(450, 900));
+  });
+
+  test('compact bounds restore the independently saved compact position', () {
+    final bounds = WindowManagerService.compactBoundsFor(
+      const Rect.fromLTWH(120, 80, 1400, 900),
+      savedPosition: const Offset(680, 110),
+    );
+
+    expect(bounds.topLeft, const Offset(680, 110));
+    expect(bounds.size, WindowManagerService.compactWindowSize);
   });
 
   test('restore bounds preserves previous bounds when at least default window size', () {
@@ -65,6 +75,46 @@ void main() {
     expect(restored.left, 80);
     expect(restored.top, 40);
     expect(restored.size, WindowManagerService.defaultWindowSize);
+  });
+
+  test('restore bounds uses the independently saved expanded position after restart', () {
+    final restored = WindowManagerService.restoreBoundsFor(
+      null,
+      currentBounds: const Rect.fromLTWH(80, 40, 450, 900),
+      savedPosition: const Offset(40, 220),
+    );
+
+    expect(restored.topLeft, const Offset(40, 220));
+    expect(restored.size, WindowManagerService.defaultWindowSize);
+  });
+
+  test('window state declares separate compact and expanded position keys', () {
+    final service = File(
+      'lib/infrastructure/platform/window_manager_service.dart',
+    ).readAsStringSync();
+
+    expect(service, contains("'window_compact_x'"));
+    expect(service, contains("'window_compact_y'"));
+    expect(service, contains("'window_expanded_x'"));
+    expect(service, contains("'window_expanded_y'"));
+  });
+
+  test('compact desktop menu hover drawer is gated and tracks both hover regions', () {
+    final homeScreen = File(
+      'lib/features/home/presentation/screens/home_screen.dart',
+    ).readAsStringSync();
+
+    expect(
+      homeScreen,
+      contains('AppPlatform.isDesktop && !isDesktop && isCompactWindow'),
+    );
+    final headerActions = File(
+      'lib/features/conversations/presentation/widgets/conversation_header_actions.dart',
+    ).readAsStringSync();
+    expect(headerActions, contains("Key('conversation_menu_hover_region')"));
+    expect(homeScreen, contains("Key('compact_sidebar_hover_region')"));
+    expect(homeScreen, contains('_isMenuButtonHovered || _isDrawerHovered'));
+    expect(homeScreen, contains('scaffold!.closeDrawer()'));
   });
 
   test('custom caption tracks maximize and full-screen lifecycle events', () {

--- a/client/test/widget/conversation_app_bar_test.dart
+++ b/client/test/widget/conversation_app_bar_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/features/conversations/domain/models/device_workspace.dart';
@@ -103,6 +104,46 @@ void main() {
       alignment.transform.getTranslation().y,
       AppPlatform.isMacOS ? SidebarBreakpoints.macOSHeaderActionsVerticalOffset : 0,
     );
+  });
+
+  testWidgets('compact menu button reports pointer entry and exit', (tester) async {
+    var enterCount = 0;
+    var exitCount = 0;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(
+              height: 80,
+              child: ConversationAppBar(
+                sessionTitle: 'Conversation',
+                isMobile: true,
+                onMenuPressed: () {},
+                onMenuHoverEnter: () => enterCount += 1,
+                onMenuHoverExit: () => exitCount += 1,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+    await gesture.addPointer(location: const Offset(400, 400));
+    await gesture.moveTo(
+      tester.getCenter(
+        find.byKey(const Key('conversation_menu_hover_region')),
+      ),
+    );
+    await tester.pump();
+    expect(enterCount, 1);
+    expect(exitCount, 0);
+
+    await gesture.moveTo(const Offset(400, 400));
+    await tester.pump();
+    expect(exitCount, 1);
+    await gesture.removePointer();
   });
 
   testWidgets('app bar applies RTL text direction for Arabic titles in desktop layout', (

--- a/docs/plans/tasks/conversation-tool-groups-and-compact-desktop-window.md
+++ b/docs/plans/tasks/conversation-tool-groups-and-compact-desktop-window.md
@@ -27,8 +27,8 @@ Improve dense tool activity without weakening live conversation performance, fix
 - Group-scroll and timeline-scroll controllers/state are strictly independent.
 - Sending a new user message preserves the current minimal reveal behavior but grants timeline follow eligibility. Later streamed growth follows unless the user scrolls away; manually returning to the bottom restores follow.
 - The desktop-only compact-window button sits beside the sidebar pin button with the same 24px-class geometry.
-- The preferred compact size is `500 × 874` logical pixels, while the desktop minimum is `500 × 600`; the shared width remains the smallest supported by the responsive design, while the lower minimum height lets short desktop work areas resize safely.
-- The first compact toggle records the current normal window bounds and preserves its top-left `x/y`; resizing occurs only toward the right and bottom. The second restores the prior bounds. Maximized/full-screen state is exited safely before compacting, and manual enlargement clears compact mode so every compact/restore button updates.
+- The preferred compact size is `450 × 900` logical pixels, while the desktop minimum is `450 × 600`; the shared width remains the smallest supported by the responsive design, while the lower minimum height lets short desktop work areas resize safely.
+- Compact and expanded desktop modes persist independent `x/y` positions. The first compact toggle without a compact position inherits the current expanded origin; later toggles and relaunches restore each mode to its own last position. Legacy `window_x/window_y` preferences seed the expanded position during migration. Maximized/full-screen state is exited safely before compacting, and manual enlargement clears compact mode so every compact/restore button updates.
 - The compact/restore action remains visible in the narrow desktop conversation header beside the workspace/session identity after the wide sidebar header disappears.
 - A new-conversation composer requests focus on first presentation; clicking any non-control blank area of the composer focuses the text field.
 - Minimum-size enforcement applies in Dart and the native macOS, Windows, and Linux runners.
@@ -75,7 +75,7 @@ Improve dense tool activity without weakening live conversation performance, fix
 
 - [x] Add desktop-only compact/restore control beside sidebar pin.
 - [x] Add `WindowManagerService` compact/restore and saved-bounds behavior.
-- [x] Enforce the original `500 × 874` compact viewport in Dart and macOS/Windows/Linux native runners.
+- [x] Enforce the current `450 × 900` compact viewport in Dart and macOS/Windows/Linux native runners.
 - [x] Add service/widget/native contract tests where practical.
 
 ### G5 — Documentation, Verification, and Live Review
@@ -94,7 +94,7 @@ Improve dense tool activity without weakening live conversation performance, fix
 - [x] Remove collapsed group bodies from the widget tree and prevent cached metrics from replaying on scroll.
 - [x] Keep the aggregate operation/file/line summary only in the gray outer title, omit it from the expanded body, and place the chevron beside it.
 - [x] Collapse parallel running batches into a group plus only the latest standalone running tool.
-- [x] Preserve top-left window origin, adopt `500 × 874`, expose narrow-header restore, and reconcile manual enlargement.
+- [x] Preserve top-left window origin, adopt the compact viewport, expose narrow-header restore, and reconcile manual enlargement.
 - [x] Focus new-conversation input initially and focus it from blank composer clicks.
 - [x] Add focused regression coverage and pass analyzer/focused suites.
 - [x] Hot restart the client after the state-shape change and verify clean bounded startup logs.
@@ -152,6 +152,23 @@ Improve dense tool activity without weakening live conversation performance, fix
 - [x] Reduce expanded tool-group body padding to 4px horizontally and 8px vertically.
 - [x] Add focused widget regressions, update documentation, analyze the Client, refresh Graphify, and reload the main-worktree Client.
 
+### G13 — Independent Desktop Window Positions
+
+- [x] Persist separate compact and expanded `x/y` coordinates while retaining expanded dimensions.
+- [x] Restore the destination mode's saved position on toggle and on application relaunch.
+- [x] Migrate legacy `window_x/window_y` values without discarding an existing user position.
+- [x] Add focused bounds/persistence contract coverage and update product/QA documentation.
+- [x] Complete analyzer, focused tests, and Graphify refresh.
+
+### G14 — Compact Menu-Button Hover Sidebar
+
+- [x] Open the drawer when a desktop compact-window pointer enters the navigation menu button only.
+- [x] Keep the drawer open while the pointer is over either the menu button or drawer.
+- [x] Close the hover-opened drawer only after the pointer leaves both regions.
+- [x] Preserve click/touch drawer behavior outside native desktop compact mode.
+- [x] Add focused widget coverage, update product/QA docs, analyze, and refresh Graphify.
+- [x] User confirms the live compact menu-button → drawer → outside hover flow.
+
 ## Acceptance Criteria
 
 - [x] Given one completed/error tool, it renders with the existing standalone presentation; when a second contiguous completed/error tool arrives, both render as one collapsible group.
@@ -165,13 +182,15 @@ Improve dense tool activity without weakening live conversation performance, fix
 - [x] Scrolling the group never changes timeline follow state, and scrolling the timeline never changes group follow state.
 - [x] Given a stale running history row and a newer matching terminal live event, hydration retains the terminal status/output and the visible row updates immediately.
 - [x] Sending a user message performs only the existing minimal reveal, grants timeline follow eligibility, follows later streamed growth, and manual upward scrolling revokes follow until returning to bottom.
-- [x] On native desktop only, the compact button changes the window to `500 × 874` while preserving top-left origin; the narrow-header button restores prior bounds, and manual enlargement clears compact state.
-- [x] macOS, Windows, and Linux reject resize attempts below `500 × 600` while compact mode prefers `500 × 874`; mobile and web do not render the compact control or initialize desktop window APIs.
+- [x] On native desktop only, the compact button changes the window to the compact viewport; compact and expanded modes each restore their own last screen position, and manual enlargement clears compact state.
+- [x] macOS, Windows, and Linux reject resize attempts below `450 × 600` while compact mode prefers `450 × 900`; mobile and web do not render the compact control or initialize desktop window APIs.
 - [x] Focused automated tests prove grouping, aggregation, reconciliation, both scroll state machines, compact/restore intent, and platform guards.
 - [x] Given an active turn that waits, resumes, reconnects, or is reopened later, its execution snapshot and final response retain one accepted-turn origin and the visible timer resumes from a fresh elapsed baseline.
 - [x] Given an already-active conversation is opened, its current Activity and elapsed duration render on the first frame; only later Activity changes wait for the debounce.
 - [x] Given a tool group is expanded, its body uses 4px horizontal and 8px vertical internal padding.
 - [x] Given elapsed work below one hour, Activity shows seconds; at one hour or more it shows hours/minutes without visible second churn.
+- [x] Given different saved desktop coordinates for compact and expanded modes, toggling or relaunching and then selecting either mode restores that mode's own position without overwriting the other.
+- [x] Given native desktop compact-window mode, only menu-button hover opens the drawer, crossing into the drawer keeps it open, and leaving both closes it without changing mobile/web or click behavior.
 - [x] Given a desktop file drop at a caret or selection, paths insert at that selection, replace selected text, and leave the caret after the inserted paths.
 
 ## Definition of Done
@@ -181,7 +200,7 @@ Improve dense tool activity without weakening live conversation performance, fix
 - [x] Ask-user history has no generic tool header and never shows while running.
 - [x] Active-history hydration cannot regress a completed tool to running.
 - [x] Nested and timeline follow behavior pass independent regression tests.
-- [x] Desktop compact/restore preserves top-left origin and no supported desktop platform can resize below `500 × 600`.
+- [x] Desktop compact/restore persists independent compact and expanded positions; no supported desktop platform can resize below its native minimum.
 - [x] Analyzer and relevant tests pass; documentation and Graphify are current after final reload.
 - [x] No commit or push is performed without explicit user approval.
 
@@ -201,3 +220,5 @@ Improve dense tool activity without weakening live conversation performance, fix
 - 2026-08-16 — G10 short desktop minimum complete. Normal startup remains `1470 × 800`, compact mode uses `500 × 874`, and Dart plus all native runners enforce only `500 × 600` as the resize floor. Client analysis and 25 focused desktop-window/sidebar tests pass; Graphify is current. Implementation remaining: 0%; no commit or push performed.
 - 2026-08-16 — Group-title typography follow-up complete. All aggregate title text, including colored added/removed line metrics, now uses normal font weight. Six focused widget tests and client analysis pass; Graphify is current. Implementation remaining: 0%; no commit or push performed.
 - 2026-08-19 — G11/G12 copy and presentation follow-up complete. Grouped reads now say `file explore(s)`; modified-file and line totals wrap atomically; terminal headers distinguish `Running:` from `Ran:`; active-conversation Activity renders immediately on mount while later changes remain debounced; and expanded group content uses 4px horizontal/8px vertical padding. Twenty-three focused tests and Client analysis pass, Graphify is current, and the main-worktree Client was hot reloaded and reassembled. Implementation remaining: 0%; no commit or push performed.
+- 2026-08-28 — G13 complete. Desktop compact and expanded modes now persist separate screen coordinates, toggle into the destination mode's saved position, retain legacy expanded-position migration, and preserve the existing startup-size behavior. Thirteen focused window tests and Client analysis pass; product/QA docs and Graphify are current. Implementation remaining: 0%; no commit or push performed.
+- 2026-08-28 — G14 implementation complete. Native desktop compact mode now opens the drawer only from navigation-menu-button hover, preserves it across the button/drawer pointer handoff, and closes only after leaving both; other app-bar areas, platforms, and manual drawer behavior remain unchanged. Client analysis and 21 focused tests pass, Graphify is current, Hot Restart completed with clean startup logs, and the user approved the live behavior plus PR delivery. Remaining estimate: 0%; PR preparation authorized.

--- a/docs/product/client_interface.md
+++ b/docs/product/client_interface.md
@@ -63,9 +63,10 @@ including the macOS shell margin, and the selected desktop width is restored
 from local client preferences on the next launch. The native-desktop header also
 provides a phone-size toggle beside the sidebar pin control. A fresh normal
 window prefers `1400 × 900`; the toggle changes it to a `450 × 900` logical
-viewport, preserving its top-left screen origin
-so only the right and bottom edges move, and restores the previous normal bounds
-when pressed again. The minimum supported macOS, Windows, and Linux window size
+viewport. Compact and expanded modes persist independent screen positions, so
+each mode returns to the last place where the user moved it; the first toggle
+without a compact position inherits the expanded window's current origin. The
+minimum supported macOS, Windows, and Linux window size
 is `450 × 600`, allowing users on short desktop displays to reduce the height
 without narrowing below the responsive design floor. Manually enlarging the window exits compact mode and updates
 the toggle. In narrow native-desktop layout, the same restore action remains
@@ -73,7 +74,11 @@ beside navigation in both active-session and New Conversation headers; true
 mobile and web builds never expose desktop window controls. On macOS these
 application actions begin after the native traffic-light controls rather than
 overlapping their title-bar region. Narrow native-desktop actions retain the
-same neutral gray treatment as the wide sidebar controls. On Windows and Linux,
+same neutral gray treatment as the wide sidebar controls. In the native desktop
+compact-window mode, hovering the navigation menu button opens the navigation
+drawer; it remains open while the pointer is over either the button or drawer
+and closes shortly after the pointer leaves both. Click/touch drawer behavior
+outside that mode is unchanged. On Windows and Linux,
 the custom maximize caption observes native maximize and full-screen changes,
 switches to the restore glyph while either state is active, and restores rather
 than requesting maximize again.

--- a/docs/qa_maintenance/conversation_tool_groups_and_compact_window_qa.md
+++ b/docs/qa_maintenance/conversation_tool_groups_and_compact_window_qa.md
@@ -36,7 +36,10 @@ description: "Regression matrix for completed-tool grouping, nested and timeline
 | Scroll isolation | Scroll inside an expanded tool/group while conversation follow is active | Inner controllers and follow state remain independent and never opt the outer conversation timeline in or out |
 | Isolation | Scroll the group and the timeline separately | Each controller and follow state changes independently |
 | Desktop header | Native desktop vs mobile/web | Compact control appears only on desktop and matches pin geometry; the macOS narrow drawer begins below native traffic lights |
-| Window bounds | Compact, restore, then manual minimum resize | Compact uses `500 × 874`, top-left origin is preserved, previous bounds restore, and resizing stops at `500 × 600` |
+| Window bounds | Compact, restore, then manual minimum resize | Compact uses `450 × 900`, previous expanded bounds restore, and resizing stops at `450 × 600` |
+| Window positions | Move expanded and compact modes to different screen coordinates, toggle repeatedly, then relaunch | Each mode restores its own last position; existing legacy `window_x/window_y` values seed the expanded position and the first compact position |
+| Compact menu-button hover | In native desktop compact-window mode, move the pointer from content onto the navigation menu button, into the drawer, then back to content | Menu-button entry opens the drawer; crossing between button and drawer does not close it; leaving both closes it after the short handoff delay |
+| Hover platform guard | Repeat at a narrow viewport on mobile/web or outside compact-window mode | Hover automation is absent; existing menu click/touch behavior remains authoritative |
 | Window state | Enlarge manually from compact mode | Compact state clears and both wide/narrow toggle icons update |
 | Composer focus | Open New Conversation, then click blank composer padding | Input starts focused and blank clicks restore focus without stealing button actions |
 | Composer file drop | Drop one or more files with a collapsed caret, an active selection, and an invalid selection | Paths insert at the caret, replace the selected range, preserve separator spacing, and fall back to the end only for invalid selection |
@@ -64,7 +67,8 @@ Run the client analyzer and these focused suites through FVM:
 2. Confirm the collapsed title uses the existing tool title color and component styling.
 3. Expand the group, verify the 500px cap, and exercise independent nested follow.
 4. Confirm an active ask-user question appears only in the composer and its completed answer has no generic header.
-5. Press the desktop phone-size button, verify `500 × 874` while the top-left origin stays fixed, then use the narrow-header button to restore the prior bounds.
-6. On macOS, confirm the narrow header's Menu and restore actions begin after the native traffic lights; open New Conversation and confirm both actions remain available there.
-7. Attempt to resize below the minimum on the current desktop platform.
-8. Send a new message while not at the full tail; verify only the user row is revealed, then verify subsequent streamed growth follows until manual upward scrolling.
+5. Move the expanded window, enter compact mode, move it elsewhere, then toggle twice and relaunch; verify each mode returns to its own saved position and compact remains `450 × 900`.
+6. While compact, hover only the navigation menu button, move into the opened drawer, then leave both; verify other app-bar areas do not open it, the drawer stays open during the button-to-drawer handoff, and it closes after exit.
+7. On macOS, confirm the narrow header's Menu and restore actions begin after the native traffic lights; open New Conversation and confirm both actions remain available there.
+8. Attempt to resize below the minimum on the current desktop platform.
+9. Send a new message while not at the full tail; verify only the user row is revealed, then verify subsequent streamed growth follows until manual upward scrolling.

--- a/docs/technical/flutter_vm_driver_cli.md
+++ b/docs/technical/flutter_vm_driver_cli.md
@@ -35,3 +35,5 @@ Snapshot output is a flat list of typed elements with optional key, text, hint, 
 The interface is available only in driver builds and is not shipped as a production remote-control endpoint. VM Service access is equivalent to development-process control and must remain local or explicitly tunneled by the operator. No Local Gateway credential is sent to the VM Service.
 
 The host CLI supports macOS, Windows, and Linux through Dart/FVM. Flutter platform support depends on the target exposing a reachable VM Service and launching the driver entry point; `sanad-dev` automatic discovery is limited to its managed worktree clients.
+
+The repository-level Dart analyzer excludes `scripts/flutter_driver_cli/` because that controller intentionally resolves Flutter Driver dependencies through the Client package configuration rather than a root Dart package. Its source remains covered through the explicit Client-configured CLI and focused test paths.


### PR DESCRIPTION
## Problem / goal

Desktop compact and expanded windows shared one persisted position, so toggling modes could place one layout at the other layout's coordinates. Compact desktop navigation also required a click even when the pointer was already over the menu control.

Tracking plan: `docs/plans/tasks/conversation-tool-groups-and-compact-desktop-window.md` (G13–G14).

## Changes

- persist independent compact and expanded desktop window coordinates while retaining legacy `window_x/window_y` migration
- restore the destination mode's saved position when toggling without changing the normal startup-size behavior
- open the compact desktop drawer only while hovering the navigation menu button and keep it open across the button-to-drawer pointer handoff
- preserve mobile/web and manual click/touch drawer behavior
- add focused window and app-bar hover coverage
- add the repository analyzer boundary for the separately configured Flutter Driver CLI
- update product, technical, QA, and task documentation

## Verification

- `cd client && fvm flutter analyze` — passed
- `fvm dart analyze scripts` — passed
- `cd client && fvm flutter test test/widget/conversation_app_bar_test.dart test/tool/desktop_window_contract_test.dart` — 22 passed
- full `cd client && fvm flutter test` — 1083 passed, 1 skipped, 1 local-only failure because ignored `client/android/key.properties` exists on the development machine; the file is not tracked and will not exist in CI
- live macOS Hot Restart and user visual approval — passed
- `graphify update .` — completed

## Risk and cross-platform impact

- desktop-only window persistence keys are additive and retain fallback to legacy coordinates
- hover opening is gated to native desktop compact-window mode
- mobile and web keep their existing drawer interactions
- no protocol, authentication, release, signing, or dependency changes

## Documentation

Updated the product interface, compact-window QA matrix, Flutter VM Driver CLI architecture, and the owning implementation plan.

## Rollback

Revert the squash commit. Legacy `window_x/window_y` values remain synchronized, so rollback does not strand the expanded window position.
