### PR TITLE
docs(auth): record iOS Debug integration merge

### DIFF
--- a/docs/plans/tasks/77-ios-debug-development-oauth.md
+++ b/docs/plans/tasks/77-ios-debug-development-oauth.md
@@ -27,7 +27,8 @@ Allow any Debug iOS build targeting Development—including Simulator and physic
 - [x] Preserve claimed HTTPS callbacks for non-Debug builds.
 - [x] Add focused selection, callback, and platform contract tests.
 - [x] Pass formatting, analysis, and focused tests.
-- [ ] Merge the private Portal registration and complete a real Development login.
+- [x] Merge the private Portal registration and pin the merged public Client commit.
+- [ ] Complete a real Development login from an iOS Debug build.
 
 ## Definition of Done
 


### PR DESCRIPTION
## Summary

Record that the private Portal registration and merged public Client pin are complete. The real Development iOS Debug login remains the final open acceptance gate.

## Verification

- Documentation-only change.
- `git diff --check` passed.