### PR TITLE
fix(agent): prevent controlled restart replay of active provider requests (#67)

### DIFF
--- a/agent/lib/engine/agent_runner.dart
+++ b/agent/lib/engine/agent_runner.dart
@@ -64,9 +64,20 @@ class AgentRunner {
   int _currentTurnStartIndex = 0;
   bool _stopRequested = false;
   bool _allowManualAmbiguousToolRecovery = false;
+  bool _providerRequestInFlight = false;
   Completer<void>? _restartDrainRelease;
 
   bool get stopRequested => _stopRequested;
+  bool get providerRequestInFlight => _providerRequestInFlight;
+
+  void markProviderResponseTerminalCommitted() {
+    _settleProviderRequest();
+  }
+
+  void _settleProviderRequest() {
+    _checkpointCoordinator.markModelRequestSettled(ctx: _checkpointCtx);
+    _providerRequestInFlight = false;
+  }
 
   /// Allows one explicit user recovery command to continue past an ambiguous
   /// non-idempotent tool without replaying its side effect. Automatic startup
@@ -97,6 +108,7 @@ class AgentRunner {
 
   void requestStop() {
     _stopRequested = true;
+    _providerRequestInFlight = false;
     cancelControlledRestartDrain();
   }
 
@@ -1017,12 +1029,25 @@ class AgentRunner {
     while (true) {
       try {
         final route = _turnRoute.routeForTurn();
-        response = await route.adapter.generateResponse(
-          effectiveHistory,
-          tools: tools,
-          modelOverride: route.modelOverride,
-          options: _requestOptionsForTurn(provider),
+        await _waitForControlledRestartDrain();
+        if (_stopRequested) return Message(role: MessageRole.assistant);
+        _checkpointCoordinator.saveCheckpoint(
+          ctx: _checkpointCtx,
+          checkpointKind: ContinuationCheckpointCoordinator
+              .checkpointKindModelRequestInFlight,
+          resumeHistoryLength: history.length,
         );
+        _providerRequestInFlight = true;
+        try {
+          response = await route.adapter.generateResponse(
+            effectiveHistory,
+            tools: tools,
+            modelOverride: route.modelOverride,
+            options: _requestOptionsForTurn(provider),
+          );
+        } finally {
+          if (_stopRequested) _providerRequestInFlight = false;
+        }
         _lastSuccessfulLlmRoute = LLMRouteSnapshot(
           adapter: _providerAdapterForBackground(route.adapter),
           providerInstanceId: provider,
@@ -1031,6 +1056,7 @@ class AgentRunner {
         _clearResumingOnProviderProgress();
         break;
       } catch (e) {
+        _settleProviderRequest();
         _turnRoute.invalidateResolvedRoute();
         if (LLMRequestDumper.isEnabled) {
           await LLMRequestDumper.recordError(e);
@@ -1087,10 +1113,9 @@ class AgentRunner {
       await pluginManager.runPostExecution(responseMessage);
       _saveHistory();
     }
-
     if (responseMessage.toolCalls?.isNotEmpty ?? false) {
       final toolCalls = responseMessage.toolCalls!;
-      await _waitForControlledRestartDrain();
+      _settleProviderRequest();
       await _toolExecutionCoordinator.executeToolCalls(
         toolCalls,
         parallel: shouldParallelizeToolBatch(toolCalls),
@@ -1104,6 +1129,7 @@ class AgentRunner {
     }
 
     if (_steerCoordinator.hasPendingSteers) {
+      _settleProviderRequest();
       _steerCoordinator.markLastAssistantSupersededBySteer(
         _RunnerSteerCallbacks(this),
       );
@@ -1118,12 +1144,16 @@ class AgentRunner {
 
     if (responseMessage.finishReason == LLMFinishReason.incomplete &&
         continuation.claimIncompleteContinuation()) {
+      _settleProviderRequest();
       return await _getNextResponse(
         runtimeSystemPrompt: runtimeSystemPrompt,
         continuation: continuation,
       );
     }
 
+    if (_authoritativeRunId == null) {
+      markProviderResponseTerminalCommitted();
+    }
     _logger.info('🏁 [Agent] Final Answer: ${responseMessage.content ?? ''}');
     return responseMessage;
   }
@@ -1365,55 +1395,68 @@ class AgentRunner {
       if (_stopRequested) return;
       try {
         final route = _turnRoute.routeForTurn();
-        await for (final response in route.adapter.generateStream(
-          effectiveHistory,
-          tools: tools,
-          modelOverride: route.modelOverride,
-          options: _requestOptionsForTurn(provider),
-        )) {
-          if (_stopRequested) return;
-          _clearResumingOnProviderProgress();
-          // Any provider event makes a transparent retry unsafe: reasoning,
-          // metadata, or a partial tool call may already be visible or carry
-          // state even when no final-content text has arrived yet.
-          streamStarted = true;
-          _updateMetrics(response);
-          lastMessage = response.message;
-          if (response.finishReason != LLMFinishReason.unknown) {
-            finishReason = response.finishReason;
-          }
-          if (response.message.toolCalls?.isNotEmpty ?? false) {
-            isToolCall = true;
-            accumulatedToolCalls ??= [];
-            accumulatedToolCalls.addAll(response.message.toolCalls!);
-          }
+        await _waitForControlledRestartDrain();
+        if (_stopRequested) return;
+        _checkpointCoordinator.saveCheckpoint(
+          ctx: _checkpointCtx,
+          checkpointKind: ContinuationCheckpointCoordinator
+              .checkpointKindModelRequestInFlight,
+          resumeHistoryLength: history.length,
+        );
+        _providerRequestInFlight = true;
+        try {
+          await for (final response in route.adapter.generateStream(
+            effectiveHistory,
+            tools: tools,
+            modelOverride: route.modelOverride,
+            options: _requestOptionsForTurn(provider),
+          )) {
+            if (_stopRequested) return;
+            _clearResumingOnProviderProgress();
+            // Any provider event makes a transparent retry unsafe: reasoning,
+            // metadata, or a partial tool call may already be visible or carry
+            // state even when no final-content text has arrived yet.
+            streamStarted = true;
+            _updateMetrics(response);
+            lastMessage = response.message;
+            if (response.finishReason != LLMFinishReason.unknown) {
+              finishReason = response.finishReason;
+            }
+            if (response.message.toolCalls?.isNotEmpty ?? false) {
+              isToolCall = true;
+              accumulatedToolCalls ??= [];
+              accumulatedToolCalls.addAll(response.message.toolCalls!);
+            }
 
-          if (response.message.thought != null) {
-            final thoughtDelta = response.message.thought!;
-            thought = (thought ?? '') + thoughtDelta;
-            if (thoughtDelta.isNotEmpty && onThoughtDelta != null) {
-              await onThoughtDelta(thoughtDelta);
+            if (response.message.thought != null) {
+              final thoughtDelta = response.message.thought!;
+              thought = (thought ?? '') + thoughtDelta;
+              if (thoughtDelta.isNotEmpty && onThoughtDelta != null) {
+                await onThoughtDelta(thoughtDelta);
+              }
+            }
+            if (response.message.reasoning != null) {
+              final reasoningDelta = response.message.reasoning!;
+              reasoning = (reasoning ?? '') + reasoningDelta;
+              if (reasoningDelta.isNotEmpty && onReasoningDelta != null) {
+                await onReasoningDelta(reasoningDelta);
+              }
+            }
+            if (response.message.providerState != null) {
+              providerState = response.message.providerState;
+            }
+            if (response.message.metadata != null) {
+              accumulatedMessageMetadata.addAll(response.message.metadata!);
+            }
+
+            final chunk = response.message.content ?? '';
+            fullContent += chunk;
+            if (chunk.isNotEmpty) {
+              yield chunk;
             }
           }
-          if (response.message.reasoning != null) {
-            final reasoningDelta = response.message.reasoning!;
-            reasoning = (reasoning ?? '') + reasoningDelta;
-            if (reasoningDelta.isNotEmpty && onReasoningDelta != null) {
-              await onReasoningDelta(reasoningDelta);
-            }
-          }
-          if (response.message.providerState != null) {
-            providerState = response.message.providerState;
-          }
-          if (response.message.metadata != null) {
-            accumulatedMessageMetadata.addAll(response.message.metadata!);
-          }
-
-          final chunk = response.message.content ?? '';
-          fullContent += chunk;
-          if (chunk.isNotEmpty) {
-            yield chunk;
-          }
+        } finally {
+          if (_stopRequested) _providerRequestInFlight = false;
         }
         _lastSuccessfulLlmRoute = LLMRouteSnapshot(
           adapter: _providerAdapterForBackground(route.adapter),
@@ -1423,6 +1466,7 @@ class AgentRunner {
         if (_stopRequested) return;
         break;
       } catch (e) {
+        _settleProviderRequest();
         _turnRoute.invalidateResolvedRoute();
         if (LLMRequestDumper.isEnabled) {
           await LLMRequestDumper.recordError(e);
@@ -1491,11 +1535,10 @@ class AgentRunner {
         await pluginManager.runPostExecution(assistantMessage);
         _saveHistory();
       }
-
       if (isToolCall && assistantMessage.toolCalls != null) {
         if (_stopRequested) return;
         final toolCalls = assistantMessage.toolCalls!;
-        await _waitForControlledRestartDrain();
+        _settleProviderRequest();
         if (_stopRequested) return;
         await _toolExecutionCoordinator.executeToolCalls(
           toolCalls,
@@ -1515,6 +1558,7 @@ class AgentRunner {
         );
       } else {
         if (_steerCoordinator.hasPendingSteers) {
+          _settleProviderRequest();
           _steerCoordinator.markLastAssistantSupersededBySteer(
             _RunnerSteerCallbacks(this),
           );
@@ -1534,6 +1578,7 @@ class AgentRunner {
         }
         if (assistantMessage.finishReason == LLMFinishReason.incomplete &&
             continuation.claimIncompleteContinuation()) {
+          _settleProviderRequest();
           yield* _streamNextResponse(
             runtimeSystemPrompt: runtimeSystemPrompt,
             onToolEvent: onToolEvent,
@@ -1543,6 +1588,9 @@ class AgentRunner {
             onReasoningDelta: onReasoningDelta,
           );
           return;
+        }
+        if (_authoritativeRunId == null) {
+          _settleProviderRequest();
         }
         _logger.info('🏁 [Agent] Final Answer: $fullContent');
       }
@@ -1560,7 +1608,11 @@ class AgentRunner {
       await pluginManager.notifyMessage(assistantMessage);
       await pluginManager.runPostExecution(assistantMessage);
       _saveHistory();
+      if (_authoritativeRunId == null) {
+        _settleProviderRequest();
+      }
       if (_steerCoordinator.hasPendingSteers) {
+        _settleProviderRequest();
         _steerCoordinator.markLastAssistantSupersededBySteer(
           _RunnerSteerCallbacks(this),
         );

--- a/agent/lib/engine/runtime/AGENTS.md
+++ b/agent/lib/engine/runtime/AGENTS.md
@@ -18,7 +18,7 @@ This contract applies to `agent/lib/engine/runtime/`.
 ## Continuation Checkpoints
 - `ContinuationCheckpointCoordinator` owns checkpoint schema and read/write orchestration for the active work item.
 - Receive history/current-turn values through an immutable context and return restored values; do not own them.
-- Persist checkpoint kind, completed results, executing tools, replay safety, model step, and owner identity.
+- Persist checkpoint kind, completed results, executing tools, replay safety, model step, and owner identity. A provider invocation is durably marked `model_request_in_flight` until its response is saved or the live process receives a definitive request failure; known failures restore the previous safe checkpoint, while startup blocks a genuinely interrupted unknown outcome instead of replaying it automatically.
 - Persist sequential tool completion and executing-marker removal together.
 - A typed deferred tool result may keep one non-idempotent tool executing only
   when its requester-bound descriptor is durable. Startup resolves that

--- a/agent/lib/engine/runtime/continuation_checkpoint_coordinator.dart
+++ b/agent/lib/engine/runtime/continuation_checkpoint_coordinator.dart
@@ -22,6 +22,8 @@ import 'deferred_tool_result.dart';
 /// All public methods are no-ops when no `PersistedRuntimeStateRepository` is
 /// registered in DI (e.g. isolated unit tests that don't test durability).
 class ContinuationCheckpointCoordinator {
+  static const String checkpointKindModelRequestInFlight =
+      'model_request_in_flight';
   static const String checkpointKindInitialModelRequest =
       'initial_model_request';
   static const String checkpointKindAfterToolResult = 'after_tool_result';
@@ -79,6 +81,12 @@ class ContinuationCheckpointCoordinator {
       meta['model_step_id'] = ctx.currentModelStepId;
     }
     if (checkpointKind != null) {
+      if (checkpointKind == checkpointKindModelRequestInFlight &&
+          meta['checkpoint_kind'] != checkpointKindModelRequestInFlight) {
+        meta['checkpoint_before_model_request'] = meta['checkpoint_kind'];
+      } else if (checkpointKind != checkpointKindModelRequestInFlight) {
+        meta.remove('checkpoint_before_model_request');
+      }
       meta['checkpoint_kind'] = checkpointKind;
     }
     if (resumeHistoryLength != null) {
@@ -141,6 +149,39 @@ class ContinuationCheckpointCoordinator {
       meta['tool_replay_safety'] = replaySafety;
     }
 
+    repo.transitionWorkItemState(
+      workItemId: activeItem.workItemId,
+      fromState: activeItem.state,
+      toState: activeItem.state,
+      continuationMetadata: meta,
+    );
+  }
+
+  /// Restores the checkpoint that owned progression before the provider call.
+  ///
+  /// This is valid after either a durable provider response or a known request
+  /// failure. A restart-timeout interruption keeps the in-flight marker so its
+  /// unknown provider outcome cannot be mistaken for replay-safe work.
+  void markModelRequestSettled({required CheckpointContext ctx}) {
+    final repo = _repo;
+    if (repo == null) return;
+    final activeItem = repo.findActiveWorkItem(sessionId);
+    if (activeItem == null) return;
+    final meta = Map<String, dynamic>.from(activeItem.continuationMetadata);
+    if (meta['checkpoint_kind'] != checkpointKindModelRequestInFlight ||
+        meta['restart_interrupted_provider_request'] == true) {
+      return;
+    }
+    final previousKind = meta
+        .remove('checkpoint_before_model_request')
+        ?.toString();
+    meta['checkpoint_kind'] = previousKind == checkpointKindAfterToolResult
+        ? checkpointKindAfterToolResult
+        : checkpointKindInitialModelRequest;
+    meta['currentTurnStartIndex'] = ctx.currentTurnStartIndex;
+    if (ctx.currentModelStepId != null) {
+      meta['model_step_id'] = ctx.currentModelStepId;
+    }
     repo.transitionWorkItemState(
       workItemId: activeItem.workItemId,
       fromState: activeItem.state,

--- a/agent/lib/interfaces/runtime/AGENTS.md
+++ b/agent/lib/interfaces/runtime/AGENTS.md
@@ -42,7 +42,7 @@ This contract applies to `agent/lib/interfaces/runtime/`.
 
 ## Restart Recovery
 - Persist continuation checkpoint kind, completed tool results, executing tools, replay-safety metadata, and owner identity.
-- Controlled restart drains every active session for a bounded caller-selected timeout; ordinary timeout never exits, and force exit requires an explicit flag.
+- Controlled restart drains every active session for a bounded caller-selected timeout. An active provider request blocks exit until completion; provider-only timeout may cancel only the exact still-current work-item/run/generation owner, preserves blocked recovery, and exits without automatic replay. A stale timeout snapshot cannot cancel a completed or replaced owner. Other ordinary timeouts never exit, and force exit requires an explicit flag.
 - While restart drain owns admission, queue new work durably and do not promote queued, restored, retry, or auto-resume work until cancellation or the next process restores it.
 - A tool-origin restart may exempt only its exact requester identity before the single response and must await that tool's durable post-response checkpoint before normal exit.
 - A requester-bound deferred result is a valid post-response checkpoint only

--- a/agent/lib/interfaces/runtime/daemon_restart_coordinator.dart
+++ b/agent/lib/interfaces/runtime/daemon_restart_coordinator.dart
@@ -36,6 +36,8 @@ class DaemonRestartPreparation {
     'message': switch (outcome) {
       'safe' => 'Daemon reached a safe restart checkpoint.',
       'forced' => 'Restart timeout expired. Forced daemon restart accepted.',
+      'provider_requests_interrupted' =>
+        'Provider requests exceeded the restart timeout and were cancelled without automatic replay.',
       'already_in_progress' => 'Another daemon restart is already in progress.',
       'cancelled' =>
         'Daemon restart was cancelled by a higher-priority action.',
@@ -125,7 +127,21 @@ class DaemonRestartCoordinator {
       );
     }
 
-    if (!checkpoint.isSafe && !force) {
+    final providerOnlyTimeout =
+        !checkpoint.isSafe &&
+        checkpoint.blockers.isNotEmpty &&
+        checkpoint.blockers.every(
+          (blocker) =>
+              blocker.providerRequestInFlight &&
+              blocker.toolCallIds.isEmpty &&
+              blocker.checkpointRecognized,
+        );
+    if (providerOnlyTimeout || (!checkpoint.isSafe && force)) {
+      await orchestrator?.interruptProviderRequestsForRestart(
+        checkpoint.blockers,
+      );
+    }
+    if (!checkpoint.isSafe && !providerOnlyTimeout && !force) {
       orchestrator?.cancelControlledRestartDrain();
       _restartInProgress = false;
       return DaemonRestartPreparation(
@@ -146,7 +162,11 @@ class DaemonRestartCoordinator {
       requesterSessionId: requesterSessionId,
       requesterToolCallId: requesterToolCallId,
       blockers: checkpoint.blockers,
-      outcome: checkpoint.isSafe ? 'safe' : 'forced',
+      outcome: checkpoint.isSafe
+          ? 'safe'
+          : providerOnlyTimeout
+          ? 'provider_requests_interrupted'
+          : 'forced',
     );
     _activePreparation = preparation;
     return preparation;

--- a/agent/lib/interfaces/runtime/session_recovery_restorer.dart
+++ b/agent/lib/interfaces/runtime/session_recovery_restorer.dart
@@ -5,6 +5,7 @@ import 'package:sanad_agent/core/provider_runtime/runtime_recovery_service.dart'
 import 'package:sanad_agent/core/provider_runtime/runtime_failure_reason.dart';
 import 'package:sanad_agent/core/provider_runtime/runtime_notice.dart';
 import 'package:sanad_agent/engine/agent_runner.dart';
+import 'package:sanad_agent/engine/runtime/continuation_checkpoint_coordinator.dart';
 import 'package:sanad_agent/engine/runtime/deferred_tool_result.dart';
 import 'package:sanad_agent/core/models/message.dart';
 import 'package:sanad_agent/evolution/db/persisted_runtime_state_repository.dart';
@@ -121,6 +122,33 @@ class SessionRecoveryRestorer {
             fromState: SessionWorkState.running,
             toState: SessionWorkState.waiting,
           );
+          continue;
+        }
+
+        if (checkpointKind ==
+            ContinuationCheckpointCoordinator
+                .checkpointKindModelRequestInFlight) {
+          _logger.warning(
+            'Provider request outcome is unknown for work item '
+            '${running.workItemId}; blocking automatic replay.',
+          );
+          store.transitionWorkItemState(
+            workItemId: running.workItemId,
+            fromState: SessionWorkState.running,
+            toState: SessionWorkState.blocked,
+          );
+          if (getIt.isRegistered<RuntimeRecoveryService>()) {
+            getIt<RuntimeRecoveryService>().reportFailure(
+              sessionId: sessionId,
+              reason: RuntimeFailureReason.unknown,
+              requestId: running.requestId,
+              providerInstanceId: running.providerInstanceId,
+              title: 'Provider request was interrupted',
+              message:
+                  'The provider request outcome is unknown and it will not be sent again automatically. Retry, change provider, or stop the session.',
+              forceBlocked: true,
+            );
+          }
           continue;
         }
 

--- a/agent/lib/interfaces/runtime/session_run_orchestrator.dart
+++ b/agent/lib/interfaces/runtime/session_run_orchestrator.dart
@@ -9,6 +9,7 @@ import 'package:sanad_agent/core/provider_runtime/runtime_notice.dart';
 import 'package:sanad_agent/core/provider_runtime/runtime_failure_reason.dart';
 import 'package:sanad_agent/core/provider_runtime/provider_instance_repository.dart';
 import 'package:sanad_agent/engine/agent_runner.dart';
+import 'package:sanad_agent/engine/runtime/continuation_checkpoint_coordinator.dart';
 import 'package:sanad_agent/engine/runtime/deferred_tool_result.dart';
 import 'package:sanad_agent/core/models/message.dart';
 import 'package:sanad_agent/evolution/session_manager.dart';
@@ -46,6 +47,7 @@ class SuspendedRun {
 
 class SessionRunOrchestrator implements SessionQueueProviderOverride {
   static const controlledRestartCheckpointTimeout = Duration(minutes: 1);
+  static const providerRestartCancellationTimeout = Duration(seconds: 5);
   static const controlledRestartCheckpointPollInterval = Duration(
     milliseconds: 25,
   );
@@ -519,6 +521,78 @@ class SessionRunOrchestrator implements SessionQueueProviderOverride {
     }
   }
 
+  /// Cancels provider streams that exhausted the controlled-restart timeout
+  /// without terminally stopping or replaying their durable work.
+  Future<void> interruptProviderRequestsForRestart(
+    Iterable<ControlledRestartBlocker> blockers,
+  ) async {
+    final providerBlockers = blockers.where(
+      (blocker) => blocker.providerRequestInFlight,
+    );
+    await Future.wait(
+      providerBlockers.map((blocker) async {
+        final activeRun = _turnExecutor.getActiveRun(blocker.sessionId);
+        if (activeRun == null ||
+            !_turnExecutor.ownsRun(activeRun) ||
+            activeRun.workItemId != blocker.workItemId ||
+            activeRun.runId != blocker.runId ||
+            activeRun.generation != blocker.generation ||
+            !activeRun.agentRunner.providerRequestInFlight) {
+          return;
+        }
+
+        final item = blocker.workItemId == null
+            ? null
+            : persistedState?.findWorkItem(blocker.workItemId!);
+        if (item == null ||
+            (item.state != SessionWorkState.running &&
+                item.state != SessionWorkState.resuming) ||
+            item.continuationMetadata['owner_run_id'] != blocker.runId ||
+            item.continuationMetadata['owner_generation'] !=
+                blocker.generation ||
+            item.continuationMetadata['checkpoint_kind'] !=
+                ContinuationCheckpointCoordinator
+                    .checkpointKindModelRequestInFlight) {
+          return;
+        }
+
+        final metadata = Map<String, dynamic>.from(item.continuationMetadata)
+          ..['restart_interrupted_provider_request'] = true;
+        persistedState?.transitionWorkItemState(
+          workItemId: item.workItemId,
+          fromState: item.state,
+          toState: SessionWorkState.blocked,
+          continuationMetadata: metadata,
+        );
+
+        if (getIt.isRegistered<RuntimeRecoveryService>()) {
+          getIt<RuntimeRecoveryService>().reportFailure(
+            sessionId: blocker.sessionId,
+            reason: RuntimeFailureReason.unknown,
+            requestId: item.requestId,
+            providerInstanceId: item.providerInstanceId,
+            title: 'Provider request interrupted for restart',
+            message:
+                'The provider did not finish before the restart timeout. The request was cancelled and will not be sent again automatically. Retry, change provider, or stop the session.',
+            forceBlocked: true,
+            runId: activeRun.runId,
+          );
+        }
+
+        try {
+          await activeRun.requestStop().timeout(
+            providerRestartCancellationTimeout,
+          );
+        } on TimeoutException {
+          _logger.warning(
+            'Provider stream cancellation exceeded the restart cleanup timeout '
+            'for session ${blocker.sessionId}; publication remains invalidated.',
+          );
+        }
+      }),
+    );
+  }
+
   /// Stops all daemon-owned work before a controlled restart.
   Future<void> requestStopAll() async {
     final sessionIds = <String>{
@@ -582,9 +656,17 @@ class SessionRunOrchestrator implements SessionQueueProviderOverride {
           continue;
         }
         final metadata = item.continuationMetadata;
+        final activeRun = _turnExecutor.getActiveRun(sessionId);
+        final providerRequestInFlight =
+            activeRun != null &&
+            _turnExecutor.ownsRun(activeRun) &&
+            activeRun.agentRunner.providerRequestInFlight;
         final checkpointKind = metadata['checkpoint_kind']?.toString();
         final recognizedCheckpoint =
             checkpointKind == AgentRunner.checkpointKindInitialModelRequest ||
+            checkpointKind ==
+                ContinuationCheckpointCoordinator
+                    .checkpointKindModelRequestInFlight ||
             checkpointKind == AgentRunner.checkpointKindAfterToolResult;
         final completedResults = Map<String, dynamic>.from(
           metadata['completed_tool_results'] as Map? ?? const {},
@@ -622,6 +704,7 @@ class SessionRunOrchestrator implements SessionQueueProviderOverride {
             (requesterToolCallId != null &&
                 hasValidDeferredResult(requesterToolCallId));
         if (!recognizedCheckpoint ||
+            providerRequestInFlight ||
             executingTools.isNotEmpty ||
             !requesterCompletionSafe) {
           blockers.add(
@@ -629,6 +712,10 @@ class SessionRunOrchestrator implements SessionQueueProviderOverride {
               sessionId: sessionId,
               toolCallIds: executingTools,
               checkpointRecognized: recognizedCheckpoint,
+              providerRequestInFlight: providerRequestInFlight,
+              workItemId: item.workItemId,
+              runId: activeRun?.runId,
+              generation: activeRun?.generation,
             ),
           );
         }
@@ -1645,16 +1732,26 @@ class ControlledRestartBlocker {
     required this.sessionId,
     required this.toolCallIds,
     required this.checkpointRecognized,
+    this.providerRequestInFlight = false,
+    this.workItemId,
+    this.runId,
+    this.generation,
   });
 
   final String sessionId;
   final List<String> toolCallIds;
   final bool checkpointRecognized;
+  final bool providerRequestInFlight;
+  final String? workItemId;
+  final String? runId;
+  final int? generation;
 
   Map<String, dynamic> toJson() => {
     'session_id': sessionId,
     'tool_call_ids': toolCallIds,
-    'reason': checkpointRecognized
+    'reason': providerRequestInFlight
+        ? 'active_provider_request'
+        : checkpointRecognized
         ? 'active_tool_execution'
         : 'unrecognized_checkpoint',
   };

--- a/agent/lib/interfaces/runtime/session_turn_executor.dart
+++ b/agent/lib/interfaces/runtime/session_turn_executor.dart
@@ -451,6 +451,7 @@ class SessionTurnExecutor {
         return;
       }
 
+      agentRunner.markProviderResponseTerminalCommitted();
       sessionManager.clearInFlightSnapshot(event.sessionId);
       emitResponse(
         GatewayResponse(

--- a/agent/test/engine/agent_runner_test.dart
+++ b/agent/test/engine/agent_runner_test.dart
@@ -1892,6 +1892,7 @@ void main() {
 
         final chunksFuture = runner.streamMessage('Start then stop').toList();
         await adapter.started.future;
+        expect(runner.providerRequestInFlight, isTrue);
         runner.requestStop();
         adapter.release.complete();
 
@@ -1899,6 +1900,7 @@ void main() {
         expect(toolExecutions, 0);
         expect(adapter.callCount, 1);
         expect(runner.stopRequested, isTrue);
+        expect(runner.providerRequestInFlight, isFalse);
       },
     );
 
@@ -4113,6 +4115,7 @@ void main() {
               .continuationMetadata;
           expect(metadata['currently_executing_tools'], isNull);
           expect(metadata['checkpoint_kind'], 'after_tool_result');
+          expect(metadata['checkpoint_before_model_request'], isNull);
           expect(metadata['resume_history_length'], 5);
           final completedResults =
               metadata['completed_tool_results'] as Map<String, dynamic>;

--- a/agent/test/interfaces/interfaces_test.dart
+++ b/agent/test/interfaces/interfaces_test.dart
@@ -165,6 +165,9 @@ Use the review skill.''',
       ),
     ).thenReturn(null);
     when(mockAgentRunner.requestStop()).thenReturn(null);
+    when(
+      mockAgentRunner.markProviderResponseTerminalCommitted(),
+    ).thenReturn(null);
     when(mockAgentRunner.beginAuthoritativeRun(any)).thenReturn(null);
     when(mockAgentRunner.endAuthoritativeRun(any)).thenReturn(null);
 
@@ -324,6 +327,118 @@ Use the review skill.''',
       verify(mockPlatform.initialize()).called(1);
       verify(mirrorPlatform.initialize()).called(1);
       verify(mirrorPlatform.eventStream).called(1);
+    },
+  );
+
+  test(
+    'provider restart interruption rejects stale ownership before blocking',
+    () async {
+      final stateDb = AgentStateDatabase.inMemory();
+      final repo = PersistedRuntimeStateRepository(stateDb.db);
+      getIt.registerSingleton<AgentStateDatabase>(stateDb);
+      getIt.registerSingleton<PersistedRuntimeStateRepository>(repo);
+      final recoveryService = RuntimeRecoveryService(
+        MockProviderInstanceRepository(),
+        ProviderRateLimiter(),
+      )..attachPersistedState(repo);
+      getIt.registerSingleton<RuntimeRecoveryService>(recoveryService);
+      addTearDown(() {
+        getIt.unregister<AgentStateDatabase>();
+        getIt.unregister<PersistedRuntimeStateRepository>();
+        getIt.unregister<RuntimeRecoveryService>();
+        stateDb.dispose();
+      });
+      final now = DateTime.now().toUtc().toIso8601String();
+      stateDb.db.execute(
+        '''INSERT INTO sessions (
+          session_id, model, title, metadata, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?)''',
+        [
+          'restart-owner-session',
+          'test-model',
+          'Restart owner',
+          '{}',
+          now,
+          now,
+        ],
+      );
+
+      final providerStream = StreamController<String>();
+      addTearDown(providerStream.close);
+      when(mockAgentRunner.providerRequestInFlight).thenReturn(true);
+      when(
+        mockAgentRunner.streamMessage(
+          any,
+          runtimeSystemPrompt: anyNamed('runtimeSystemPrompt'),
+          providerId: anyNamed('providerId'),
+          model: anyNamed('model'),
+          thinkingMode: anyNamed('thinkingMode'),
+          receivedAt: anyNamed('receivedAt'),
+          onToolEvent: anyNamed('onToolEvent'),
+          onSteerContinuation: anyNamed('onSteerContinuation'),
+          onThoughtDelta: anyNamed('onThoughtDelta'),
+          onReasoningDelta: anyNamed('onReasoningDelta'),
+        ),
+      ).thenAnswer((_) => providerStream.stream);
+
+      final orchestrator = getIt<SessionRunOrchestrator>();
+      unawaited(
+        orchestrator.handleEvent(
+          GatewayEvent(
+            sessionId: 'restart-owner-session',
+            platformId: 'test-platform',
+            message: Message(role: MessageRole.user, content: 'wait'),
+          ),
+        ),
+      );
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      final item = repo.findActiveWorkItem('restart-owner-session')!;
+      final metadata = Map<String, dynamic>.from(item.continuationMetadata)
+        ..['checkpoint_kind'] = 'model_request_in_flight';
+      repo.transitionWorkItemState(
+        workItemId: item.workItemId,
+        fromState: item.state,
+        toState: item.state,
+        continuationMetadata: metadata,
+      );
+
+      final checkpoint = await orchestrator.waitForControlledRestartCheckpoint(
+        timeout: Duration.zero,
+      );
+      final blocker = checkpoint.blockers.single;
+      expect(blocker.workItemId, item.workItemId);
+      expect(blocker.runId, isNotNull);
+      expect(blocker.generation, isNotNull);
+
+      await orchestrator.interruptProviderRequestsForRestart([
+        ControlledRestartBlocker(
+          sessionId: blocker.sessionId,
+          toolCallIds: blocker.toolCallIds,
+          checkpointRecognized: blocker.checkpointRecognized,
+          providerRequestInFlight: true,
+          workItemId: blocker.workItemId,
+          runId: 'stale-run',
+          generation: blocker.generation,
+        ),
+      ]);
+      expect(repo.findWorkItem(item.workItemId)!.state, item.state);
+      verifyNever(mockAgentRunner.requestStop());
+
+      await orchestrator.interruptProviderRequestsForRestart([blocker]);
+      final interrupted = repo.findWorkItem(item.workItemId)!;
+      expect(interrupted.state, SessionWorkState.blocked);
+      expect(
+        interrupted
+            .continuationMetadata['restart_interrupted_provider_request'],
+        isTrue,
+      );
+      expect(
+        recoveryService.activeNotice('restart-owner-session')?.status,
+        RuntimeNoticeStatus.blocked,
+      );
+      expect(repo.findNotice('restart-owner-session')?.status, 'blocked');
+      verify(mockAgentRunner.requestStop()).called(1);
     },
   );
 
@@ -2327,7 +2442,10 @@ Use the review skill.''',
       await Future<void>.delayed(Duration.zero);
 
       expect(orchestrator.isSessionBusy('session-stop-rate-limit'), isFalse);
-      expect(orchestrator.hasSuspendedEvent('session-stop-rate-limit'), isFalse);
+      expect(
+        orchestrator.hasSuspendedEvent('session-stop-rate-limit'),
+        isFalse,
+      );
       expect(
         responses.where(
           (response) =>
@@ -2596,6 +2714,80 @@ Use the review skill.''',
   );
 
   group('Gate E: Runtime Restoration and FIFO', () {
+    test(
+      'startup blocks an interrupted provider request without replaying it',
+      () async {
+        final stateDb = AgentStateDatabase.inMemory();
+        final repo = PersistedRuntimeStateRepository(stateDb.db);
+        getIt.registerSingleton<AgentStateDatabase>(stateDb);
+        getIt.registerSingleton<PersistedRuntimeStateRepository>(repo);
+        final recoveryService = RuntimeRecoveryService(
+          MockProviderInstanceRepository(),
+          ProviderRateLimiter(),
+        )..attachPersistedState(repo);
+        getIt.registerSingleton<RuntimeRecoveryService>(recoveryService);
+        addTearDown(() {
+          getIt.unregister<AgentStateDatabase>();
+          getIt.unregister<PersistedRuntimeStateRepository>();
+          getIt.unregister<RuntimeRecoveryService>();
+          stateDb.dispose();
+        });
+
+        stateDb.db.execute(
+          "INSERT INTO sessions (session_id, model, created_at, updated_at) VALUES ('provider-crash-session', 'gpt-4o', '2026-08-19', '2026-08-19')",
+        );
+        final now = DateTime.now();
+        repo.insertWorkItem(
+          SessionWorkItem(
+            workItemId: 'provider-crash-work',
+            sessionId: 'provider-crash-session',
+            requestId: 'provider-crash-request',
+            sequence: 1,
+            providerInstanceId: 'provider-a',
+            modelId: 'gpt-4o',
+            state: SessionWorkState.running,
+            attempt: 0,
+            payload: const {'message': 'do not replay this request'},
+            continuationMetadata: const {
+              'owner_run_id': 'provider-crash-run',
+              'owner_generation': 3,
+              'checkpoint_kind': 'model_request_in_flight',
+              'checkpoint_before_model_request': 'initial_model_request',
+              'resume_history_length': 1,
+              'currentTurnStartIndex': 0,
+            },
+            createdAt: now,
+            updatedAt: now,
+          ),
+        );
+
+        final orchestrator = SessionRunOrchestrator();
+        await orchestrator.restorePersistedState();
+
+        expect(
+          repo.findWorkItem('provider-crash-work')?.state,
+          SessionWorkState.blocked,
+        );
+        expect(
+          recoveryService.activeNotice('provider-crash-session')?.status,
+          RuntimeNoticeStatus.blocked,
+        );
+        expect(
+          orchestrator.hasSuspendedEvent('provider-crash-session'),
+          isTrue,
+        );
+        verifyNever(
+          mockAgentRunner.resumeStream(
+            runtimeSystemPrompt: anyNamed('runtimeSystemPrompt'),
+            onToolEvent: anyNamed('onToolEvent'),
+            onSteerContinuation: anyNamed('onSteerContinuation'),
+            onThoughtDelta: anyNamed('onThoughtDelta'),
+            onReasoningDelta: anyNamed('onReasoningDelta'),
+          ),
+        );
+      },
+    );
+
     test(
       'restart restores a suspended ask-user tool as waiting, not blocked',
       () async {

--- a/agent/test/interfaces/interfaces_test.mocks.dart
+++ b/agent/test/interfaces/interfaces_test.mocks.dart
@@ -286,6 +286,14 @@ class MockAgentRunner extends _i1.Mock implements _i18.AgentRunner {
           as bool);
 
   @override
+  bool get providerRequestInFlight =>
+      (super.noSuchMethod(
+            Invocation.getter(#providerRequestInFlight),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
   _i9.AgentContextAssembler get contextAssembler =>
       (super.noSuchMethod(
             Invocation.getter(#contextAssembler),
@@ -357,6 +365,30 @@ class MockAgentRunner extends _i1.Mock implements _i18.AgentRunner {
   @override
   set runStartTime(DateTime? value) => super.noSuchMethod(
     Invocation.setter(#runStartTime, value),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void markProviderResponseTerminalCommitted() => super.noSuchMethod(
+    Invocation.method(#markProviderResponseTerminalCommitted, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void allowManualAmbiguousToolRecovery() => super.noSuchMethod(
+    Invocation.method(#allowManualAmbiguousToolRecovery, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void beginControlledRestartDrain() => super.noSuchMethod(
+    Invocation.method(#beginControlledRestartDrain, []),
+    returnValueForMissingStub: null,
+  );
+
+  @override
+  void cancelControlledRestartDrain() => super.noSuchMethod(
+    Invocation.method(#cancelControlledRestartDrain, []),
     returnValueForMissingStub: null,
   );
 
@@ -776,6 +808,14 @@ class MockSessionManager extends _i1.Mock implements _i5.SessionManager {
           as bool);
 
   @override
+  List<_i12.SessionState> getPendingTitleSessions() =>
+      (super.noSuchMethod(
+            Invocation.method(#getPendingTitleSessions, []),
+            returnValue: <_i12.SessionState>[],
+          )
+          as List<_i12.SessionState>);
+
+  @override
   void deleteSession(String? sessionId) => super.noSuchMethod(
     Invocation.method(#deleteSession, [sessionId]),
     returnValueForMissingStub: null,
@@ -1059,6 +1099,30 @@ class MockSessionDB extends _i1.Mock implements _i11.SessionDB {
           as bool);
 
   @override
+  bool finalizePendingSessionTitle(
+    String? sessionId, {
+    required String? expectedTitle,
+    required String? title,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(
+              #finalizePendingSessionTitle,
+              [sessionId],
+              {#expectedTitle: expectedTitle, #title: title},
+            ),
+            returnValue: false,
+          )
+          as bool);
+
+  @override
+  List<_i12.SessionState> getPendingTitleSessions() =>
+      (super.noSuchMethod(
+            Invocation.method(#getPendingTitleSessions, []),
+            returnValue: <_i12.SessionState>[],
+          )
+          as List<_i12.SessionState>);
+
+  @override
   void deleteSession(String? sessionId) => super.noSuchMethod(
     Invocation.method(#deleteSession, [sessionId]),
     returnValueForMissingStub: null,
@@ -1219,4 +1283,12 @@ class MockTitleService extends _i1.Mock implements _i22.TitleService {
             ),
           )
           as _i16.Future<String>);
+
+  @override
+  _i16.Future<int> recoverPendingTitles() =>
+      (super.noSuchMethod(
+            Invocation.method(#recoverPendingTitles, []),
+            returnValue: _i16.Future<int>.value(0),
+          )
+          as _i16.Future<int>);
 }

--- a/agent/test/interfaces/runtime/daemon_restart_coordinator_test.dart
+++ b/agent/test/interfaces/runtime/daemon_restart_coordinator_test.dart
@@ -132,6 +132,78 @@ void main() {
   );
 
   test(
+    'provider-only timeout cancels the request and permits restart without force',
+    () async {
+      int? exitCode;
+      final blocker = const ControlledRestartBlocker(
+        sessionId: 'provider-session',
+        toolCallIds: [],
+        checkpointRecognized: true,
+        providerRequestInFlight: true,
+      );
+      final orchestrator = _BoundaryOrchestrator(
+        result: ControlledRestartCheckpointResult(
+          isSafe: false,
+          blockers: [blocker],
+        ),
+      );
+      final coordinator = DaemonRestartCoordinator(
+        sessionOrchestrator: orchestrator,
+        exitDaemon: (code) => exitCode = code,
+      );
+
+      final preparation = await coordinator.prepareRestart(
+        timeout: const Duration(seconds: 7),
+      );
+
+      expect(preparation.accepted, isTrue);
+      expect(preparation.force, isFalse);
+      expect(preparation.outcome, 'provider_requests_interrupted');
+      expect(orchestrator.interruptedBlockers, [blocker]);
+      expect(orchestrator.drainCancelled, isFalse);
+      expect(exitCode, isNull);
+
+      await coordinator.completePreparedRestart(preparation);
+      expect(exitCode, 0);
+    },
+  );
+
+  test(
+    'mixed provider and tool timeout remains rejected without force',
+    () async {
+      final orchestrator = _BoundaryOrchestrator(
+        result: const ControlledRestartCheckpointResult(
+          isSafe: false,
+          blockers: [
+            ControlledRestartBlocker(
+              sessionId: 'provider-session',
+              toolCallIds: [],
+              checkpointRecognized: true,
+              providerRequestInFlight: true,
+            ),
+            ControlledRestartBlocker(
+              sessionId: 'tool-session',
+              toolCallIds: ['unsafe-tool'],
+              checkpointRecognized: true,
+            ),
+          ],
+        ),
+      );
+      final coordinator = DaemonRestartCoordinator(
+        sessionOrchestrator: orchestrator,
+        exitDaemon: (_) {},
+      );
+
+      final preparation = await coordinator.prepareRestart();
+
+      expect(preparation.accepted, isFalse);
+      expect(preparation.outcome, 'timeout');
+      expect(orchestrator.interruptedBlockers, isEmpty);
+      expect(orchestrator.drainCancelled, isTrue);
+    },
+  );
+
+  test(
     'concurrent restart is rejected until active preparation completes',
     () async {
       final coordinator = DaemonRestartCoordinator(
@@ -269,6 +341,14 @@ class _BoundaryOrchestrator extends SessionRunOrchestrator {
   bool drainStarted = false;
   bool drainCancelled = false;
   bool stopAllRequested = false;
+  final List<ControlledRestartBlocker> interruptedBlockers = [];
+
+  @override
+  Future<void> interruptProviderRequestsForRestart(
+    Iterable<ControlledRestartBlocker> blockers,
+  ) async {
+    interruptedBlockers.addAll(blockers);
+  }
 
   @override
   Future<void> requestStopAll() async {

--- a/docs/plans/tasks/67-restart-provider-request-resource-safety.md
+++ b/docs/plans/tasks/67-restart-provider-request-resource-safety.md
@@ -1,0 +1,77 @@
+---
+title: "Restart Provider Request Resource Safety"
+description: "Prevent controlled daemon restart from silently replaying an interrupted provider request and consuming duplicate tokens."
+status: "ready_for_review"
+progress: "95%"
+scope: "agent engine and runtime interfaces"
+related_to: "Task 34 partial stream recovery; Plan 50 run cancellation"
+---
+
+# Task 67: Restart Provider Request Resource Safety
+
+## Goal
+
+Prevent controlled daemon restart from replaying an interrupted provider request while preserving established rate-limit recovery, tool-origin restart checkpoints, queued input, and unsafe-tool behavior.
+
+## Locked Decisions and Scope
+
+- A live provider request blocks controlled restart while the caller-selected timeout remains.
+- If the response becomes durable before timeout, restart proceeds normally.
+- If timeout expires and every blocker is an active provider request, cancel only the exact still-owning streams, preserve blocked recovery, and restart.
+- Startup never automatically replays a provider request whose outcome is unknown because of process interruption.
+- A provider request that ends in a known runtime failure restores its previous safe checkpoint before normal waiting, failover, or blocked-recovery policy runs.
+- Tool-origin restart retains its exact `after_tool_result` completion boundary.
+- Unsafe executing tools retain the existing timeout and force policy.
+- Queued input remains durable while restart drain owns admission.
+
+## Gates
+
+### G0 — Review and Regression Triage
+
+- [x] Review the complete worktree diff and owning runtime contracts.
+- [x] Run analyzer, focused tests, full fast tests, and daemon-backed recovery E2E.
+- [x] Identify checkpoint-lifecycle, tool-origin restart, and stale-blocker race risks.
+
+### G1 — Checkpoint Lifecycle Safety
+
+- [x] Restore the previous safe checkpoint when a live provider request ends without a durable model response.
+- [x] Settle persisted intermediate provider responses before tool execution or semantic continuation.
+- [x] Preserve the terminal response marker until authoritative terminal commit.
+- [x] Preserve `after_tool_result` for tool-origin restart completion.
+
+### G2 — Exact-Owner Restart Interruption
+
+- [x] Bind restart blockers to exact work-item, run, and generation ownership.
+- [x] Revalidate active provider ownership synchronously before blocking or cancelling.
+- [x] Emit blocked recovery only after the exact durable owner transitions successfully.
+
+### G3 — Verification and Documentation
+
+- [x] Add focused checkpoint and stale-owner regression coverage.
+- [x] Pass analyzer and focused engine/interface tests.
+- [x] Pass the full fast agent suite.
+- [x] Pass daemon-backed durable restart E2E with sequential execution.
+- [x] Update technical/runtime documentation and Graphify output.
+
+## Acceptance Criteria
+
+- [x] Given an active provider request, controlled restart waits while the request remains active.
+- [x] Given completion before timeout, the response is persisted and no interruption or replay occurs.
+- [x] Given provider-only timeout, only the exact active provider owners become blocked and restart may proceed.
+- [x] Given a stale timeout snapshot after provider completion, the completed run is not cancelled or given a blocked notice.
+- [x] Given a known provider error such as rate limit, restart recovery retains the established waiting/change-provider/stop behavior.
+- [x] Given a tool-origin restart, the requester result reaches `after_tool_result` and restart can complete safely.
+- [x] Given an interrupted provider request on startup, automatic replay does not occur and Retry, Change Provider, and Stop remain available.
+- [x] Unsafe-tool timeout behavior and queued-input durability remain unchanged.
+
+## Definition of Done
+
+- [x] Analyzer, focused tests, full fast suite, and daemon-backed restart E2E pass.
+- [x] Code, contracts, technical design, and this task status agree.
+- [x] `graphify update .` completes after code changes.
+- [x] Final diff contains no formatting errors, secrets, dependency drift, or unrelated files.
+- [x] No commit or push is performed without explicit user authorization.
+
+## Current Status
+
+G0-G3 are complete. Automated review evidence is green; the remaining 5% is maintainer review and PR delivery after explicit commit/push authorization.

--- a/docs/qa_maintenance/plan30_runtime_recovery_matrix.md
+++ b/docs/qa_maintenance/plan30_runtime_recovery_matrix.md
@@ -22,6 +22,7 @@ This matrix owns verification for:
   - `agent/test/interfaces/interfaces_test.dart`
   - `agent/test/interfaces/gateway_manager_error_containment_test.dart`
   - `agent/test/interfaces/runtime/session_restart_checkpoint_test.dart`
+  - `agent/e2e_test/durable_recovery_restart_e2e_test.dart`
   - `agent/test/core/provider_runtime/runtime_recovery_service_test.dart`
   - `agent/test/evolution/persisted_runtime_state_repository_test.dart` (Gate C)
 - Client:
@@ -110,6 +111,9 @@ This matrix owns verification for:
 68. **Resumable component shutdown**: `sanad-dev stop agent` closes admission, waits for the global safe checkpoint, exits the source supervisor without `requestStopAll()`, and leaves the launcher plus Clients active. `sanad-dev run agent` reclaims checkpoint-safe work exactly once and preserves queued FIFO input. A timeout leaves all components running; `stop agent --force` uses terminal cancellation and produces no later resume.
 69. **Bounded multi-provider failover**: one model invocation records every provider instance that fails before streaming. With three qualified same-model instances, failures on A and B route exactly once to C; no failed instance becomes eligible again within that invocation. If every candidate fails, the session reaches its normal controllable recovery state instead of producing an unbounded route-transition cycle.
 70. **Staged route label coherence**: when the composer stages a provider/model pair that differs from the selected session route, the chip resolves the staged provider through daemon-owned instance metadata and never pairs the staged model with stale session provider display metadata. An unknown UUID remains hidden.
+71. **Known provider failure checkpoint settlement**: a definitive live failure such as HTTP 429 clears `model_request_in_flight`, restores the preceding safe checkpoint, and retains established waiting, Change Provider, Retry, and Stop behavior across daemon restart.
+72. **Provider-only restart timeout ownership**: timeout interruption binds to the exact work-item, run, and generation. A stale blocker cannot cancel or block a completed/replaced owner; a matching owner transitions to blocked recovery before its stream is cancelled.
+73. **Unknown provider outcome replay prevention**: a process interruption while `model_request_in_flight` remains durable restores as blocked, makes Retry, Change Provider, and Stop available, and issues no automatic provider request.
 
 ## Current Status
 

--- a/docs/technical/agent_interface_runtime.md
+++ b/docs/technical/agent_interface_runtime.md
@@ -49,10 +49,21 @@ side effect.
 Controlled restart establishes a global drain across every active session.
 New turns are queued durably, while queued successors, restored work, retries,
 and automatic resumes cannot claim execution until the drain is cancelled or
-the replacement process restores them.
+the replacement process restores them. A provider request already in flight is
+a restart blocker: the daemon waits for it to complete and persist. If every
+remaining blocker at timeout is a provider request, the daemon revalidates the
+exact work-item, run, and generation owner before cancelling that stream,
+records blocked recovery, and proceeds with restart. A stale timeout snapshot
+cannot cancel a request that already completed. Startup never replays an
+interrupted request automatically. The durable `model_request_in_flight` marker
+makes an unexpected crash or forced exit fail closed rather than silently
+replaying an unknown provider outcome; a definitive live failure such as rate
+limit restores the preceding safe checkpoint and retains its normal recovery
+policy. Retry or Change Provider is explicit.
 The default safety timeout is 60 seconds and callers may provide
-`timeout_seconds` between 1 and 3600. A timeout fails without exiting unless
-`force=true` was explicitly supplied.
+`timeout_seconds` between 1 and 3600. A provider-only timeout follows the
+bounded cancellation policy above. Any other timeout fails without exiting
+unless `force=true` was explicitly supplied.
 
 The restart endpoint emits one response. For ordinary callers it waits until
 all active work is restart-safe, flushes the success response, then exits. If

--- a/scripts/sanad_dev/cli.dart
+++ b/scripts/sanad_dev/cli.dart
@@ -134,7 +134,10 @@ void main(List<String> args) async {
   }
 
   if (command == 'status') {
-    await handleRuntimeStatus(portOverride: portOverride);
+    await handleRuntimeStatus(
+      portOverride: portOverride,
+      sanadHomePath: sanadHomePath,
+    );
     return;
   }
 
@@ -197,7 +200,11 @@ void main(List<String> args) async {
     }
   } else if (command == 'restart') {
     if (target == 'client') {
-      await handleClientAttachAction('R', portOverride); // R = Hot Restart
+      await handleClientAttachAction(
+        'R',
+        portOverride,
+        sanadHomePath: sanadHomePath,
+      ); // R = Hot Restart
     } else if (target == 'agent') {
       if (restartTimeoutSeconds < 1 || restartTimeoutSeconds > 3600) {
         stderr.writeln('--timeout must be between 1 and 3600 seconds.');
@@ -208,6 +215,7 @@ void main(List<String> args) async {
         portOverride,
         force: forceRestart,
         timeoutSeconds: restartTimeoutSeconds,
+        sanadHomePath: sanadHomePath,
       );
     } else {
       print('Unknown target: $target. Supported targets: client, agent');
@@ -215,7 +223,11 @@ void main(List<String> args) async {
     }
   } else if (command == 'reload') {
     if (target == 'client') {
-      await handleClientAttachAction('r', portOverride); // r = Hot Reload
+      await handleClientAttachAction(
+        'r',
+        portOverride,
+        sanadHomePath: sanadHomePath,
+      ); // r = Hot Reload
     } else {
       print('Unknown target: $target. Supported targets: client');
       exit(1);

--- a/scripts/sanad_dev/developer_actions.dart
+++ b/scripts/sanad_dev/developer_actions.dart
@@ -382,14 +382,24 @@ Future<void> handleClientLogs(
   exit(0);
 }
 
-Future<void> handleClientAttachAction(String action, int? portOverride) async {
-  final instance = await selectClientInstance(portOverride);
+Future<void> handleClientAttachAction(
+  String action,
+  int? portOverride, {
+  String? sanadHomePath,
+}) async {
+  final instance = await selectClientInstance(
+    portOverride,
+    sanadHomePath: sanadHomePath,
+  );
   if (instance == null) exit(1);
 
   final vmUrl = instance.token.isEmpty
       ? 'http://127.0.0.1:${instance.port}/'
       : 'http://127.0.0.1:${instance.port}/${instance.token}/';
-  final runtime = await _currentRuntime();
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomePath,
+  );
   final expectedClientDirectory =
       '${runtime.repositoryRoot}${Platform.pathSeparator}client';
   if (!_samePath(instance.path, expectedClientDirectory)) {
@@ -410,7 +420,9 @@ Future<void> handleClientAttachAction(String action, int? portOverride) async {
     exitCode = 1;
     return;
   }
-  final activeAgents = await discoverAgentInstances();
+  final activeAgents = await discoverAgentInstances(
+    sanadHomeOverride: sanadHomePath,
+  );
   final workspaceHash = runtime.worktreeId.split('-').last;
   final matchingAgents = activeAgents
       .where((agent) => agent.workspaceHash == workspaceHash)
@@ -850,13 +862,18 @@ Future<void> handleAgentRestart(
   int? portOverride, {
   bool force = false,
   int timeoutSeconds = 60,
+  String? sanadHomePath,
 }) async {
   final instance = await selectAgentInstance(
     portOverride,
     allowStartupGrace: true,
+    sanadHomePath: sanadHomePath,
   );
   if (instance == null) exit(1);
-  final runtime = await _currentRuntime();
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomePath,
+  );
   final workspaceHash = runtime.worktreeId.split('-').last;
   if (instance.workspaceHash != workspaceHash) {
     stderr.writeln(

--- a/scripts/sanad_dev/instance_discovery.dart
+++ b/scripts/sanad_dev/instance_discovery.dart
@@ -354,12 +354,20 @@ class AgentInstance {
   });
 }
 
-Future<List<AgentInstance>> discoverAgentInstances() async {
+Future<List<AgentInstance>> discoverAgentInstances({
+  String? sanadHomeOverride,
+}) async {
   final client = HttpClient();
   client.connectionTimeout = const Duration(milliseconds: 150);
   final instances = <AgentInstance>[];
-  final runtime = await _currentRuntime();
-  final candidateHomes = await discoverLocalGatewayCandidateHomes(runtime);
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomeOverride,
+  );
+  final candidateHomes = await discoverLocalGatewayCandidateHomes(
+    runtime,
+    sanadHomeOverride: sanadHomeOverride,
+  );
   final credentials = <({String home, String value})>[];
   for (final home in candidateHomes) {
     try {
@@ -430,10 +438,16 @@ Future<List<AgentInstance>> discoverAgentInstances() async {
 }
 
 Future<Set<String>> discoverLocalGatewayCandidateHomes(
-  SanadDevRuntime runtime,
-) async {
+  SanadDevRuntime runtime, {
+  String? sanadHomeOverride,
+}) async {
   final primaryHome = resolveDefaultUserSanadHome(Platform.environment);
-  final homes = <String>{runtime.sanadHome, primaryHome};
+  final homes = <String>{
+    runtime.sanadHome,
+    primaryHome,
+    if (sanadHomeOverride != null && sanadHomeOverride.isNotEmpty)
+      sanadHomeOverride,
+  };
 
   final linkedHomes = Directory(
     '$primaryHome${Platform.pathSeparator}dev${Platform.pathSeparator}homes',
@@ -473,7 +487,10 @@ Future<Set<String>> discoverLocalGatewayCandidateHomes(
   return homes;
 }
 
-Future<ClientInstance?> selectClientInstance(int? portOverride) async {
+Future<ClientInstance?> selectClientInstance(
+  int? portOverride, {
+  String? sanadHomePath,
+}) async {
   final instances = await discoverClientInstances();
   if (instances.isEmpty) {
     print(
@@ -498,9 +515,14 @@ Future<ClientInstance?> selectClientInstance(int? portOverride) async {
     exit(1);
   }
 
-  final runtime = await _currentRuntime();
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomePath,
+  );
   final state = selectRuntimeProcessState(
-    activeAgents: await discoverAgentInstances(),
+    activeAgents: await discoverAgentInstances(
+      sanadHomeOverride: sanadHomePath,
+    ),
     activeClients: instances,
     runtime: runtime,
   );
@@ -572,13 +594,18 @@ Future<ClientInstance?> _recordedClientInstance(int port) async {
 Future<AgentInstance?> selectAgentInstance(
   int? portOverride, {
   bool allowStartupGrace = false,
+  String? sanadHomePath,
 }) async {
-  var instances = await discoverAgentInstances();
+  var instances = await discoverAgentInstances(
+    sanadHomeOverride: sanadHomePath,
+  );
   if (instances.isEmpty && allowStartupGrace) {
     final deadline = DateTime.now().add(const Duration(seconds: 5));
     while (DateTime.now().isBefore(deadline) && instances.isEmpty) {
       await Future<void>.delayed(const Duration(milliseconds: 500));
-      instances = await discoverAgentInstances();
+      instances = await discoverAgentInstances(
+        sanadHomeOverride: sanadHomePath,
+      );
     }
   }
   if (instances.isEmpty) {
@@ -603,7 +630,10 @@ Future<AgentInstance?> selectAgentInstance(
   }
 
   // Filter instances matching the current worktree's workspace root hash
-  final runtime = await _currentRuntime();
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomePath,
+  );
   final currentWorkspaceHash = runtime.worktreeId.split('-').last;
   var matchingInstances = instances
       .where((inst) => inst.workspaceHash == currentWorkspaceHash)
@@ -613,7 +643,9 @@ Future<AgentInstance?> selectAgentInstance(
     final deadline = DateTime.now().add(const Duration(seconds: 5));
     while (DateTime.now().isBefore(deadline) && matchingInstances.isEmpty) {
       await Future<void>.delayed(const Duration(milliseconds: 500));
-      instances = await discoverAgentInstances();
+      instances = await discoverAgentInstances(
+        sanadHomeOverride: sanadHomePath,
+      );
       matchingInstances = instances
           .where((inst) => inst.workspaceHash == currentWorkspaceHash)
           .toList();

--- a/scripts/sanad_dev/runtime_commands.dart
+++ b/scripts/sanad_dev/runtime_commands.dart
@@ -759,9 +759,17 @@ String _newRuntimeOwnershipToken() {
   return base64Url.encode(bytes).replaceAll('=', '');
 }
 
-Future<void> handleRuntimeStatus({int? portOverride}) async {
-  final runtime = await _currentRuntime();
-  final activeAgents = await discoverAgentInstances();
+Future<void> handleRuntimeStatus({
+  int? portOverride,
+  String? sanadHomePath,
+}) async {
+  final runtime = await discoverSanadDevRuntime(
+    callerDirectory: _callerDirectory,
+    sanadHomeOverride: sanadHomePath,
+  );
+  final activeAgents = await discoverAgentInstances(
+    sanadHomeOverride: sanadHomePath,
+  );
   final activeClients = await discoverClientInstances();
   final processState = selectRuntimeProcessState(
     activeAgents: activeAgents,


### PR DESCRIPTION
## Problem / Goal
Prevent controlled daemon restart from silently replaying an interrupted provider request and consuming duplicate tokens, while preserving established rate-limit recovery, tool-origin restart checkpoints, queued input, and unsafe-tool behavior.

## Technical Changes
- **Checkpoint Lifecycle Safety:** Restores previous safe checkpoints when live provider requests end without a durable model response; preserves terminal markers and tool-origin completions (`after_tool_result`).
- **Exact-Owner Restart Interruption:** Binds restart blockers to exact work-item/run/generation ownership, canceling only still-owning streams on provider-only timeout, and avoiding stale blocker cancellation.
- **Recovery & Durability:** Preserves blocked recovery on startup without auto-replaying interrupted provider requests.
- **Documentation & Contracts:** Updated `docs/technical/agent_interface_runtime.md`, `docs/qa_maintenance/plan30_runtime_recovery_matrix.md`, and completed `docs/plans/tasks/67-restart-provider-request-resource-safety.md`.

## Verification
- `fvm dart analyze` (agent package): 0 errors / clean.
- `fvm dart test` (agent suite): 1142 tests passed.
- Focused regression tests for `daemon_restart_coordinator_test.dart` and `interfaces_test.dart`: passed cleanly.