### PR TITLE
fix(auth): prevent post-login route loop

### DIFF
--- a/client/lib/core/navigation/app_router.dart
+++ b/client/lib/core/navigation/app_router.dart
@@ -245,8 +245,10 @@ class AppRouter {
     // 1. Authenticated state
     if (authState is AuthAuthenticated) {
       if (isLoggingIn) {
-        final requestedLocation = currentUri.queryParameters['from'];
-        if (requestedLocation != null && requestedLocation.isNotEmpty) {
+        final requestedLocation = _authenticatedAppLocation(
+          currentUri.queryParameters['from'],
+        );
+        if (requestedLocation != null) {
           return _debugRedirect(
             Uri(
               path: AppRoutes.splash,
@@ -259,7 +261,7 @@ class AppRouter {
           );
         }
         return _debugRedirect(
-          _authLocationWithReturnTo(AppRoutes.splash, currentUri),
+          AppRoutes.splash,
           authState: authState,
           uri: currentUri,
           matchedLocation: matchedLocation,
@@ -274,10 +276,13 @@ class AppRouter {
             ? (gatewayStatus?.isLocalConnected == true || gatewayStatus?.isCloudReady == true)
             : (gatewayStatus?.isCloudReady == true || gatewayStatus?.sanadGateway == SanadGatewayStatus.disconnected);
         if (isReady) {
-          final requestedLocation = currentUri.queryParameters['from'];
-          final target = (requestedLocation != null && requestedLocation.isNotEmpty)
-              ? requestedLocation
-              : (gatewayStatus?.recommendedRoute ?? AppRoutes.home);
+          final requestedLocation = _authenticatedAppLocation(
+            currentUri.queryParameters['from'],
+          );
+          final recommendedLocation = _authenticatedAppLocation(
+            gatewayStatus?.recommendedRoute,
+          );
+          final target = requestedLocation ?? recommendedLocation ?? AppRoutes.home;
           return _debugRedirect(
             target,
             authState: authState,
@@ -392,6 +397,17 @@ class AppRouter {
       'uriPath=${uri.path} redirectPath=$redirectPath reason=$reason',
     );
     return redirect;
+  }
+
+  static String? _authenticatedAppLocation(String? location) {
+    if (location == null || location.isEmpty) return null;
+    final uri = Uri.tryParse(location);
+    if (uri == null || uri.hasScheme || uri.host.isNotEmpty) return null;
+    final path = uri.path;
+    if (path.isEmpty || path == AppRoutes.splash || path == AppRoutes.login) {
+      return null;
+    }
+    return uri.toString();
   }
 
   static String _authLocationWithReturnTo(String authPath, Uri currentUri) {

--- a/client/test/unit/core/navigation/app_router_test.dart
+++ b/client/test/unit/core/navigation/app_router_test.dart
@@ -261,7 +261,7 @@ void main() {
       );
       expect(
         AppRouter.handleRedirect(authState, uri: Uri.parse(AppRoutes.login), matchedLocation: AppRoutes.login),
-        '/?from=%2Flogin',
+        AppRoutes.splash,
       );
 
       // Should not redirect if at any other authenticated route
@@ -303,6 +303,36 @@ void main() {
           uri: Uri.parse(AppRoutes.splash),
           matchedLocation: AppRoutes.splash,
           gatewayStatus: readyStatus,
+        ),
+        AppRoutes.home,
+      );
+    });
+
+    test('post-login bootstrap rejects stale auth-only destinations', () {
+      final authState = _authenticatedState();
+      const staleStatus = GatewayConnectionStatus(
+        localGateway: LocalGatewayStatus.disconnected,
+        sanadGateway: SanadGatewayStatus.disconnected,
+        actions: [],
+        recommendedRoute: AppRoutes.login,
+        isDesktop: false,
+      );
+
+      expect(
+        AppRouter.handleRedirect(
+          authState,
+          uri: Uri.parse('/?from=%2Flogin'),
+          matchedLocation: AppRoutes.splash,
+          gatewayStatus: staleStatus,
+        ),
+        AppRoutes.home,
+      );
+      expect(
+        AppRouter.handleRedirect(
+          authState,
+          uri: Uri.parse('/?from=https%3A%2F%2Fevil.example'),
+          matchedLocation: AppRoutes.splash,
+          gatewayStatus: staleStatus,
         ),
         AppRoutes.home,
       );

--- a/docs/qa_maintenance/mobile_oauth_callback_qa.md
+++ b/docs/qa_maintenance/mobile_oauth_callback_qa.md
@@ -24,7 +24,7 @@ description: "Regression and physical-device gates for PKCE callback delivery th
 | Entitlements | Exactly the intended Client Associated Domains are present; old Portal claims are absent. |
 | iOS lifecycle | AppDelegate registers plugins and calls `super.application(...didFinishLaunching...)`; no override swallows `continue userActivity` or scene delivery. |
 | Callback filtering | Wrong scheme, host, port, path, user-info, or fragment is ignored; exact callback with non-empty code/state is delivered once. The Development custom scheme is accepted only by a Debug iOS build compiled for Development and never by Profile/Release or Production config. |
-| Router ownership | `FlutterDeepLinkingEnabled=false`; callback query cannot become a GoRouter location or diagnostic. |
+| Router ownership | `FlutterDeepLinkingEnabled=false`; callback query cannot become a GoRouter location or diagnostic. After redemption, `/login` redirects to bootstrap without preserving `/login` as `from`; stale auth-only or external bootstrap destinations fall back to `/home` instead of creating a redirect loop or 404. |
 | Portal redirect | Mobile transaction registration is exact and OAuth completion redirects iOS from Portal to the configured Client host while retaining one-time PKCE code/state semantics. |
 | AASA | Every Client host returns `200`, JSON, no redirect, exact app ID, and only `/oauth/ios`; Apple CDN matches. |
 | HTTP fallback | Exact callback location has `access_log off`, strips the query with a no-store redirect, and does not proxy to app-site or Portal. |

--- a/docs/technical/client_authentication.md
+++ b/docs/technical/client_authentication.md
@@ -98,7 +98,11 @@ pin a public commit reachable from public `main`, not a content-equivalent PR
 head after squash merge. `app_links` subscribes before the system browser opens,
 accepts cold-start and warm-link events, and filters exact scheme, host, port,
 and path before code/state validation. Flutter's competing built-in Android
-deep-link handler is disabled to prevent duplicate callback delivery.
+deep-link handler is disabled to prevent duplicate callback delivery. After
+successful redemption, authenticated navigation enters the bootstrap route
+without preserving `/login` as a return destination. Bootstrap rejects stale
+auth-only, malformed, or external destinations and falls back to `/home`,
+preventing `/login` ↔ `/` redirect loops and a post-login 404.
 
 ## Headless Agent Device Authorization
 


### PR DESCRIPTION
## Problem

After successful iOS Debug OAuth redemption, the authenticated `/login` guard redirected to `/?from=/login`. Bootstrap then reused the auth-only return location, or a stale Gateway recommendation of `/login`, producing a `/login` ↔ `/` loop and eventually the 404 screen.

## Changes

- Redirect authenticated `/login` to bootstrap without preserving `/login` as `from`.
- Accept only relative non-authenticated application destinations after login.
- Reject `/`, `/login`, malformed, and external return/recommended destinations.
- Fall back deterministically to `/home` when bootstrap has no safe authenticated destination.
- Add focused regression coverage and update the mobile OAuth routing contract.

## Verification

- `fvm flutter analyze` — passed.
- `fvm flutter test test/unit/core/navigation/app_router_test.dart` — 16 passed.
- Real iPhone 17 Simulator Development login — passed:
  - Google authentication completed through `sanad://oauth/ios-development`.
  - PKCE redemption loaded the authenticated profile.
  - Route sequence was `/login` → `/` → `/home`.
  - The New Task/Home surface rendered directly with no 404.
- No callback parameters or credentials were retained in evidence.
