### PR TITLE
fix(ci): grant pull-requests read permission for Discord notifications

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   notify:


### PR DESCRIPTION
### Problem / Goal
The Discord community notification workflow failed with `gh: Not Found (HTTP 404)` on pushes to `main` when querying associated PRs via `gh api` because `GITHUB_TOKEN` lacked the explicit `pull-requests: read` permission.

### Changes
- Added `pull-requests: read` to the `permissions` declaration in `.github/workflows/discord-notifications.yml`.

### Verification
- Verified workflow YAML syntax.
- Post-merge verification on `main` will confirm the Discord notification job runs successfully.