### PR TITLE
fix(ci): resolve squash PR number reliably for Discord notifications

### DIFF
--- a/.github/workflows/discord-notifications.yml
+++ b/.github/workflows/discord-notifications.yml
@@ -28,14 +28,20 @@ jobs:
             url="$(jq -r '.release.html_url' "$GITHUB_EVENT_PATH")"
             description="Published by @$(jq -r '.release.author.login' "$GITHUB_EVENT_PATH")."
           else
-            associated_pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-              --jq 'map(select(.merged_at != null and .base.ref == "main")) | first')"
-            if [[ "$associated_pull_request" == "null" ]]; then
+            commit_message="$(jq -r '.head_commit.message // ""' "$GITHUB_EVENT_PATH")"
+            number="$(grep -oE '\(#[0-9]+\)' <<<"$commit_message" | grep -oE '[0-9]+' | tail -1 || true)"
+            if [[ -z "$number" ]]; then
+              associated_pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+                --jq 'map(select(.merged_at != null and .base.ref == "main")) | first' 2>/dev/null || echo "null")"
+              if [[ "$associated_pull_request" != "null" && -n "$associated_pull_request" ]]; then
+                number="$(jq -r '.number // empty' <<<"$associated_pull_request")"
+              fi
+            fi
+            if [[ -z "$number" ]]; then
               echo "No merged pull request is associated with this main push."
               echo "send=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            number="$(jq -r '.number' <<<"$associated_pull_request")"
             pull_request="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${number}")"
             title="Merged PR #${number}: $(jq -r '.title' <<<"$pull_request")"
             url="$(jq -r '.html_url' <<<"$pull_request")"


### PR DESCRIPTION
### Problem / Goal
On immediate push triggers following a squash merge, GitHub's commit-to-PR association index on `/commits/{sha}/pulls` is not immediately available, causing queries to return 404/422.

### Changes
- Extract PR number directly from `.head_commit.message` (matching GitHub squash commit convention `(#123)`).
- Fallback gracefully to `/commits/{sha}/pulls` if not found in the commit message.
- Query `/pulls/{number}` directly to build the notification payload.

### Verification
- Tested regex extraction and PR payload hydration locally.
- Verified CI checks pass.