### PR TITLE
fix(windows): harden client installer upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,13 @@ jobs:
           [void][scriptblock]::Create((Get-Content -Raw scripts/install.ps1))
           [void][scriptblock]::Create((Get-Content -Raw client/release/windows/build_installer.ps1))
           [void][scriptblock]::Create((Get-Content -Raw client/release/windows/release.ps1))
+          [void][scriptblock]::Create((Get-Content -Raw client/release/windows/stop_installed_client.ps1))
+          [void][scriptblock]::Create((Get-Content -Raw client/release/windows/install_staged_client.ps1))
+          [void][scriptblock]::Create((Get-Content -Raw client/release/windows/verify_installer.ps1))
+      - name: Verify Windows running-client upgrade guard
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./client/release/windows/verify_installer.ps1 -UpgradeGuardOnly
 
   docs-governance:
     name: Validate docs and governance

--- a/agent/lib/capabilities/tools/system/shell_execute_tool.dart
+++ b/agent/lib/capabilities/tools/system/shell_execute_tool.dart
@@ -392,7 +392,9 @@ class ShellExecuteTool extends SpecBackedTool {
     var tail = '';
     var totalChars = 0;
 
-    await for (final chunk in stream.transform(utf8.decoder)) {
+    await for (final chunk in stream.transform(
+      const Utf8Decoder(allowMalformed: true),
+    )) {
       totalChars += chunk.length;
       var remainingChunk = chunk;
       final availableHead = headLimit - head.length;

--- a/agent/test/capabilities/shell_execute_tool_test.dart
+++ b/agent/test/capabilities/shell_execute_tool_test.dart
@@ -127,6 +127,20 @@ void main() {
       ); // Prompts because it is sensitive and not yet cached/pre-approved
     });
 
+    test('malformed process output cannot crash shell execution', () async {
+      final tool = ShellExecuteTool(workspacePath: workspaceDir.path);
+      final command = Platform.isWindows
+          ? r'''powershell.exe -NoProfile -NonInteractive -Command "$bytes=[byte[]](0xFF,0xFE,0x41); [Console]::OpenStandardOutput().Write($bytes,0,$bytes.Length)"'''
+          : r"printf '\377\376A'";
+
+      final resultString = await tool.execute({'command': command});
+      final result = jsonDecode(resultString) as Map<String, dynamic>;
+
+      expect(result['isError'], isFalse);
+      expect(result['output'], contains('\uFFFD'));
+      expect(result['output'], contains('A'));
+    });
+
     test(
       'Path traversal validation - blocks execution outside workspace',
       () async {

--- a/client/release/windows/install_staged_client.ps1
+++ b/client/release/windows/install_staged_client.ps1
@@ -1,0 +1,113 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$TargetDirectory,
+    [Parameter(Mandatory = $true)]
+    [string]$StagedDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+$target = [System.IO.Path]::GetFullPath($TargetDirectory).TrimEnd('\')
+$staged = [System.IO.Path]::GetFullPath($StagedDirectory).TrimEnd('\')
+$backup = Join-Path $target '.sanad-install-backup'
+
+function Get-FileDigest {
+    param([string]$Path)
+    (Get-FileHash -LiteralPath $Path -Algorithm SHA256).Hash
+}
+
+function Get-ManagedPayload {
+    param([string]$Directory)
+
+    $items = [System.Collections.Generic.List[System.IO.FileSystemInfo]]::new()
+    $executable = Join-Path $Directory 'sanad-client.exe'
+    if (Test-Path -LiteralPath $executable -PathType Leaf) {
+        $items.Add((Get-Item -LiteralPath $executable))
+    }
+    foreach ($dll in @(Get-ChildItem -LiteralPath $Directory -Filter '*.dll' -File -ErrorAction SilentlyContinue)) {
+        $items.Add($dll)
+    }
+    $data = Join-Path $Directory 'data'
+    if (Test-Path -LiteralPath $data -PathType Container) {
+        $items.Add((Get-Item -LiteralPath $data))
+    }
+    $items
+}
+
+if (-not (Test-Path -LiteralPath $staged -PathType Container)) {
+    throw 'The staged client payload does not exist.'
+}
+
+$stagedExecutable = Join-Path $staged 'sanad-client.exe'
+$stagedDlls = @(Get-ChildItem -LiteralPath $staged -Filter '*.dll' -File -ErrorAction Stop)
+$stagedData = Join-Path $staged 'data'
+if (-not (Test-Path -LiteralPath $stagedExecutable -PathType Leaf) -or
+    (Get-Item -LiteralPath $stagedExecutable).Length -le 0 -or
+    $stagedDlls.Count -eq 0 -or
+    @($stagedDlls | Where-Object Length -le 0).Count -ne 0 -or
+    -not (Test-Path -LiteralPath $stagedData -PathType Container)) {
+    throw 'The staged client payload is incomplete.'
+}
+
+$expectedDigests = @{}
+foreach ($file in @(Get-ChildItem -LiteralPath $staged -File -Recurse -ErrorAction Stop)) {
+    $relativePath = $file.FullName.Substring($staged.Length + 1)
+    $expectedDigests[$relativePath] = Get-FileDigest -Path $file.FullName
+}
+
+if (Test-Path -LiteralPath $backup) {
+    throw "A previous installer backup still exists at '$backup'."
+}
+New-Item -ItemType Directory -Path $target -Force | Out-Null
+New-Item -ItemType Directory -Path $backup | Out-Null
+
+$installedNames = [System.Collections.Generic.List[string]]::new()
+try {
+    foreach ($item in @(Get-ManagedPayload -Directory $target)) {
+        Move-Item -LiteralPath $item.FullName -Destination (Join-Path $backup $item.Name)
+    }
+
+    foreach ($item in @(Get-ManagedPayload -Directory $staged)) {
+        Move-Item -LiteralPath $item.FullName -Destination (Join-Path $target $item.Name)
+        $installedNames.Add($item.Name)
+    }
+
+    foreach ($entry in $expectedDigests.GetEnumerator()) {
+        $installedPath = Join-Path $target $entry.Key
+        if (-not (Test-Path -LiteralPath $installedPath -PathType Leaf) -or
+            (Get-FileDigest -Path $installedPath) -ne $entry.Value) {
+            throw "Installed payload verification failed for '$($entry.Key)'."
+        }
+    }
+} catch {
+    $replacementError = $_
+    foreach ($name in $installedNames) {
+        $installedPath = Join-Path $target $name
+        if (Test-Path -LiteralPath $installedPath) {
+            Remove-Item -LiteralPath $installedPath -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    if (Test-Path -LiteralPath $backup) {
+        foreach ($item in @(Get-ChildItem -LiteralPath $backup -Force)) {
+            $restorePath = Join-Path $target $item.Name
+            if (-not (Test-Path -LiteralPath $restorePath)) {
+                Move-Item -LiteralPath $item.FullName -Destination $restorePath -ErrorAction SilentlyContinue
+            }
+        }
+    }
+    if ((Test-Path -LiteralPath $backup) -and
+        @(Get-ChildItem -LiteralPath $backup -Force -ErrorAction SilentlyContinue).Count -eq 0) {
+        Remove-Item -LiteralPath $backup -Force -ErrorAction SilentlyContinue
+    }
+    Write-Error "Client payload replacement failed and rollback was attempted: $($replacementError.Exception.Message)"
+    exit 1
+}
+
+# Cleanup happens only after the installed payload passed complete hash
+# verification. Cleanup failure must not roll back a valid installation.
+Remove-Item -LiteralPath $backup -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -LiteralPath $staged -Recurse -Force -ErrorAction SilentlyContinue
+if ((Test-Path -LiteralPath $backup) -or (Test-Path -LiteralPath $staged)) {
+    Write-Error 'The new client payload is valid, but installer cleanup did not complete.'
+    exit 1
+}
+exit 0

--- a/client/release/windows/sanad_client_installer.nsi
+++ b/client/release/windows/sanad_client_installer.nsi
@@ -12,15 +12,24 @@
 !ifndef OUTPUT_FILE
   !define OUTPUT_FILE "..\..\build\sanad-client-setup.exe"
 !endif
+!ifndef APP_DISPLAY_NAME
+  !define APP_DISPLAY_NAME "Sanad"
+!endif
+!ifndef APP_REGISTRY_KEY
+  !define APP_REGISTRY_KEY "Software\Sanad"
+!endif
+!ifndef APP_UNINSTALL_REGISTRY_KEY
+  !define APP_UNINSTALL_REGISTRY_KEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad"
+!endif
 
-Name "Sanad"
+Name "${APP_DISPLAY_NAME}"
 OutFile "${OUTPUT_FILE}"
 !ifdef GATE_E_INSTALL_DIR
   InstallDir "${GATE_E_INSTALL_DIR}"
 !else
   InstallDir "$PROGRAMFILES64\Sanad"
 !endif
-InstallDirRegKey HKCU "Software\Sanad" "Install_Dir"
+InstallDirRegKey HKCU "${APP_REGISTRY_KEY}" "Install_Dir"
 
 !ifdef GATE_E_USER_INSTALL
   RequestExecutionLevel user
@@ -40,42 +49,55 @@ InstallDirRegKey HKCU "Software\Sanad" "Install_Dir"
 ; Installer sections
 Section "Install"
   SetShellVarContext current
-  SetOutPath "$INSTDIR"
+  InitPluginsDir
+
+  ; Extract and validate a complete payload before touching the installed
+  ; executable. The staging directory lives under $INSTDIR so the replacement
+  ; helper can use same-volume moves instead of partial in-place writes.
+  RMDir /r "$INSTDIR\.sanad-install-staging"
+  IfFileExists "$INSTDIR\.sanad-install-staging" 0 staging_ready
+    DetailPrint "A previous Sanad Client staging directory could not be removed."
+    Abort
+  staging_ready:
+  ClearErrors
+  SetOutPath "$INSTDIR\.sanad-install-staging"
+  File "..\..\build\windows\x64\runner\Release\sanad-client.exe"
+  File "..\..\build\windows\x64\runner\Release\*.dll"
+  SetOutPath "$INSTDIR\.sanad-install-staging\data"
+  File /r "..\..\build\windows\x64\runner\Release\data\*"
+  ${If} ${Errors}
+    RMDir /r "$INSTDIR\.sanad-install-staging"
+    DetailPrint "The Sanad Client payload could not be staged completely."
+    Abort
+  ${EndIf}
 
   ; WinSparkle launches the installer before requesting graceful shutdown.
   ; New clients flush and exit through before-quit-for-update. The helper waits
   ; for that handoff and only force-stops the exact installed path as a bounded
   ; compatibility fallback for clients released before the listener existed.
-  InitPluginsDir
-  File /oname=$PLUGINSDIR\stop_installed_client.ps1 "stop_installed_client.ps1"
-  nsExec::ExecToStack 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\stop_installed_client.ps1" -TargetPath "$INSTDIR\sanad-client.exe"'
+  SetOutPath "$PLUGINSDIR"
+  File /oname=stop_installed_client.ps1 "stop_installed_client.ps1"
+  File /oname=install_staged_client.ps1 "install_staged_client.ps1"
+  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\stop_installed_client.ps1" -TargetPath "$INSTDIR\sanad-client.exe"'
   Pop $0
   Pop $1
   ${If} $0 != 0
+    RMDir /r "$INSTDIR\.sanad-install-staging"
     DetailPrint "The installed Sanad Client did not close safely: $1"
     Abort
   ${EndIf}
 
-  ; Remove the previous application payload so upgrades cannot retain stale
-  ; DLLs or data.
-  Delete "$INSTDIR\sanad-client.exe"
-  Delete "$INSTDIR\*.dll"
-  RMDir /r "$INSTDIR\data"
-  
-  ; Copy main executable
-  ClearErrors
-  File "..\..\build\windows\x64\runner\Release\sanad-client.exe"
-  IfFileExists "$INSTDIR\sanad-client.exe" +3 0
-    DetailPrint "The Sanad Client executable could not be installed."
+  ; Swap the staged executable, DLLs, and data into place using same-volume
+  ; moves. The helper verifies hashes and restores the previous payload if any
+  ; replacement step fails.
+  nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\install_staged_client.ps1" -TargetDirectory "$INSTDIR" -StagedDirectory "$INSTDIR\.sanad-install-staging"'
+  Pop $0
+  Pop $1
+  ${If} $0 != 0
+    DetailPrint "The Sanad Client payload could not be replaced safely: $1"
     Abort
-  
-  ; Copy DLL files
-  File "..\..\build\windows\x64\runner\Release\*.dll"
-  
-  ; Copy data folder
-  SetOutPath "$INSTDIR\data"
-  File /r "..\..\build\windows\x64\runner\Release\data\*"
-  
+  ${EndIf}
+
   ; Install Visual C++ Redistributable
   SetOutPath "$TEMP"
   File "..\..\build\windows\x64\runner\Release\vc_redist.x64.exe"
@@ -84,41 +106,43 @@ Section "Install"
   Delete "$TEMP\vc_redist.x64.exe"
   SetOutPath "$INSTDIR"
   
-  ; Create start menu shortcuts
-  SetOutPath "$INSTDIR"
-  CreateDirectory "$SMPROGRAMS\Sanad"
-  CreateShortcut "$SMPROGRAMS\Sanad\Sanad.lnk" "$INSTDIR\sanad-client.exe"
-  CreateShortcut "$SMPROGRAMS\Sanad\Uninstall.lnk" "$INSTDIR\uninstall.exe"
-  
-  ; Create desktop shortcut
-  CreateShortcut "$DESKTOP\Sanad.lnk" "$INSTDIR\sanad-client.exe"
-  
+  !ifndef GATE_E_NO_SHORTCUTS
+    ; Create start menu and desktop shortcuts for production packages.
+    SetOutPath "$INSTDIR"
+    CreateDirectory "$SMPROGRAMS\Sanad"
+    CreateShortcut "$SMPROGRAMS\Sanad\Sanad.lnk" "$INSTDIR\sanad-client.exe"
+    CreateShortcut "$SMPROGRAMS\Sanad\Uninstall.lnk" "$INSTDIR\uninstall.exe"
+    CreateShortcut "$DESKTOP\Sanad.lnk" "$INSTDIR\sanad-client.exe"
+  !endif
+
   ; Create uninstaller
   WriteUninstaller "$INSTDIR\uninstall.exe"
   
   ; Store installation folder and Windows Installed Apps metadata.
-  WriteRegStr HKCU "Software\Sanad" "Install_Dir" "$INSTDIR"
-  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "DisplayName" "Sanad"
-  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "DisplayVersion" "${APP_VERSION}"
-  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "InstallLocation" "$INSTDIR"
-  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "UninstallString" '"$INSTDIR\uninstall.exe"'
-  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "NoModify" 1
-  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad" "NoRepair" 1
+  WriteRegStr HKCU "${APP_REGISTRY_KEY}" "Install_Dir" "$INSTDIR"
+  WriteRegStr HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "DisplayName" "${APP_DISPLAY_NAME}"
+  WriteRegStr HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "DisplayVersion" "${APP_VERSION}"
+  WriteRegStr HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "InstallLocation" "$INSTDIR"
+  WriteRegStr HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "UninstallString" '"$INSTDIR\uninstall.exe"'
+  WriteRegDWORD HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "NoModify" 1
+  WriteRegDWORD HKCU "${APP_UNINSTALL_REGISTRY_KEY}" "NoRepair" 1
 SectionEnd
 
 ; Uninstaller section
 Section "Uninstall"
   SetShellVarContext current
-  ; Remove shortcuts
-  RMDir /r "$SMPROGRAMS\Sanad"
-  Delete "$DESKTOP\Sanad.lnk"
+  !ifndef GATE_E_NO_SHORTCUTS
+    ; Remove production shortcuts.
+    RMDir /r "$SMPROGRAMS\Sanad"
+    Delete "$DESKTOP\Sanad.lnk"
+  !endif
   
   ; Remove application files
   RMDir /r "$INSTDIR"
   
   ; Remove registry entries
-  DeleteRegKey HKCU "Software\Sanad"
-  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\Sanad"
+  DeleteRegKey HKCU "${APP_REGISTRY_KEY}"
+  DeleteRegKey HKCU "${APP_UNINSTALL_REGISTRY_KEY}"
 SectionEnd
 
 ; Function to ensure admin rights

--- a/client/release/windows/stop_installed_client.ps1
+++ b/client/release/windows/stop_installed_client.ps1
@@ -1,6 +1,7 @@
 param(
     [Parameter(Mandatory = $true)]
     [string]$TargetPath,
+    [ValidateRange(0, 60)]
     [int]$GraceSeconds = 8
 )
 
@@ -20,9 +21,41 @@ function Get-TargetProcesses {
         }
 }
 
+function Test-FileIsWritable {
+    param([string]$FilePath)
+    if (-not (Test-Path -LiteralPath $FilePath -PathType Leaf)) { return $true }
+    try {
+        $stream = [System.IO.File]::Open($FilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::ReadWrite, [System.IO.FileShare]::None)
+        if ($stream) {
+            $stream.Close()
+            $stream.Dispose()
+            return $true
+        }
+        return $false
+    } catch {
+        return $false
+    }
+}
+
+function Test-DirectoryFilesWritable {
+    param([string]$DirectoryPath)
+    if (-not (Test-Path -LiteralPath $DirectoryPath -PathType Container)) { return $true }
+    $files = Get-ChildItem -LiteralPath $DirectoryPath -Include "*.exe", "*.dll" -File -Recurse -ErrorAction SilentlyContinue
+    foreach ($file in $files) {
+        if (-not (Test-FileIsWritable -FilePath $file.FullName)) {
+            return $false
+        }
+    }
+    return $true
+}
+
+$targetDir = [System.IO.Path]::GetDirectoryName($canonicalTarget)
+
 while ((Get-Date) -lt $deadline) {
     if (-not @(Get-TargetProcesses).Count) {
-        exit 0
+        if (Test-DirectoryFilesWritable -DirectoryPath $targetDir) {
+            exit 0
+        }
     }
     Start-Sleep -Milliseconds 250
 }
@@ -31,11 +64,23 @@ while ((Get-Date) -lt $deadline) {
 # before-quit listener existed. Scope is the exact installed executable path;
 # source runs and other installations are never selected by name alone.
 foreach ($process in @(Get-TargetProcesses)) {
-    Stop-Process -Id $process.ProcessId -Force -ErrorAction Stop
+    try {
+        Stop-Process -Id $process.ProcessId -Force -ErrorAction SilentlyContinue
+    } catch {}
 }
 
-Start-Sleep -Milliseconds 250
-if (@(Get-TargetProcesses).Count) {
+# Wait after force stop for process termination and handle release
+$forceDeadline = (Get-Date).AddSeconds(3)
+while ((Get-Date) -lt $forceDeadline) {
+    if (-not @(Get-TargetProcesses).Count) {
+        if (Test-DirectoryFilesWritable -DirectoryPath $targetDir) {
+            exit 0
+        }
+    }
+    Start-Sleep -Milliseconds 250
+}
+
+if (@(Get-TargetProcesses).Count -or -not (Test-DirectoryFilesWritable -DirectoryPath $targetDir)) {
     exit 1
 }
 exit 0

--- a/client/release/windows/verify_installer.ps1
+++ b/client/release/windows/verify_installer.ps1
@@ -1,16 +1,142 @@
-# Script to verify installer contents
-# Verify that all required files are included in the Windows installer
+param(
+    [switch]$UpgradeGuardOnly
+)
 
+# Verify the release payload and exercise the transactional Windows upgrade
+# helpers without touching an installed Sanad Client.
 $ErrorActionPreference = "Continue"
 
-$releaseDir = "build\windows\x64\runner\Release"
-$installerDir = "installer"
+$clientDir = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot "..\.."))
+$releaseDir = Join-Path $clientDir "build\windows\x64\runner\Release"
+$installerDir = $PSScriptRoot
+$versionName = ((Get-Content -LiteralPath (Join-Path $clientDir "pubspec.yaml") | Select-String "^version:") -split ": ")[1].Trim().Split("+")[0]
+$builtInstaller = Join-Path $clientDir "build\sanad-client-$versionName-windows-x64.exe"
 
 Write-Host ""
 Write-Host "========================================="
 Write-Host "Sanad Windows Installer Verification"
 Write-Host "========================================="
 Write-Host ""
+
+function Test-UpgradeGuard {
+    $testRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("sanad-installer-test-" + [guid]::NewGuid().ToString("N"))
+    $target = Join-Path $testRoot "Sanad"
+    $staged = Join-Path $target ".sanad-install-staging"
+    $lock = $null
+    try {
+        New-Item -ItemType Directory -Path (Join-Path $target "data") -Force | Out-Null
+
+        # A copied PowerShell host has the exact installed executable name and
+        # stays alive without child processes. This exercises the bounded
+        # compatibility force-stop path without touching a real Sanad process.
+        $testExecutable = Join-Path $target "sanad-client.exe"
+        Copy-Item -LiteralPath ((Get-Command powershell.exe).Source) -Destination $testExecutable
+        $targetProcess = Start-Process -FilePath $testExecutable `
+            -ArgumentList "-NoProfile", "-NonInteractive", "-Command", "Start-Sleep -Seconds 30" `
+            -WindowStyle Hidden -PassThru
+        Start-Sleep -Milliseconds 300
+        & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $installerDir "stop_installed_client.ps1") `
+            -TargetPath $testExecutable -GraceSeconds 0 *> $null
+        if ($LASTEXITCODE -ne 0 -or -not $targetProcess.WaitForExit(5000)) {
+            throw "The stop helper did not terminate the exact target process."
+        }
+
+        Set-Content -LiteralPath $testExecutable -Value "old executable" -NoNewline
+        Set-Content -LiteralPath (Join-Path $target "old.dll") -Value "old dll" -NoNewline
+        Set-Content -LiteralPath (Join-Path $target "data\old.asset") -Value "old data" -NoNewline
+
+        # Hold an installed DLL with exclusive access. The stop helper must fail
+        # closed even though no process with the target executable name exists.
+        $lockedDll = Join-Path $target "old.dll"
+        $lock = [System.IO.File]::Open(
+            $lockedDll,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None
+        )
+        & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $installerDir "stop_installed_client.ps1") `
+            -TargetPath (Join-Path $target "sanad-client.exe") -GraceSeconds 0 *> $null
+        if ($LASTEXITCODE -eq 0) {
+            throw "The stop helper accepted a locked installed DLL."
+        }
+        $lock.Dispose()
+        $lock = $null
+
+        & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $installerDir "stop_installed_client.ps1") `
+            -TargetPath (Join-Path $target "sanad-client.exe") -GraceSeconds 0 *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw "The stop helper rejected an unlocked isolated payload."
+        }
+
+        New-Item -ItemType Directory -Path (Join-Path $staged "data") -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $staged "sanad-client.exe") -Value "new executable" -NoNewline
+        Set-Content -LiteralPath (Join-Path $staged "new.dll") -Value "new dll" -NoNewline
+        Set-Content -LiteralPath (Join-Path $staged "data\new.asset") -Value "new data" -NoNewline
+
+        # Force a mid-transaction move failure after the old payload has been
+        # backed up. The helper must restore the complete old payload.
+        $lock = [System.IO.File]::Open(
+            (Join-Path $staged "new.dll"),
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::ReadWrite,
+            [System.IO.FileShare]::None
+        )
+        & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $installerDir "install_staged_client.ps1") `
+            -TargetDirectory $target -StagedDirectory $staged *> $null
+        if ($LASTEXITCODE -eq 0) {
+            throw "The replacement helper accepted a locked staged DLL."
+        }
+        $lock.Dispose()
+        $lock = $null
+        if ((Get-Content -LiteralPath (Join-Path $target "sanad-client.exe") -Raw) -ne "old executable" -or
+            (Get-Content -LiteralPath (Join-Path $target "old.dll") -Raw) -ne "old dll" -or
+            (Get-Content -LiteralPath (Join-Path $target "data\old.asset") -Raw) -ne "old data" -or
+            (Test-Path -LiteralPath (Join-Path $target ".sanad-install-backup"))) {
+            throw "The failed replacement did not restore the old payload."
+        }
+
+        Remove-Item -LiteralPath $staged -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path (Join-Path $staged "data") -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $staged "sanad-client.exe") -Value "new executable" -NoNewline
+        Set-Content -LiteralPath (Join-Path $staged "new.dll") -Value "new dll" -NoNewline
+        Set-Content -LiteralPath (Join-Path $staged "data\new.asset") -Value "new data" -NoNewline
+        & powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass `
+            -File (Join-Path $installerDir "install_staged_client.ps1") `
+            -TargetDirectory $target -StagedDirectory $staged *> $null
+        if ($LASTEXITCODE -ne 0) {
+            throw "The staged payload replacement helper failed."
+        }
+        if ((Get-Content -LiteralPath (Join-Path $target "sanad-client.exe") -Raw) -ne "new executable" -or
+            (Get-Content -LiteralPath (Join-Path $target "new.dll") -Raw) -ne "new dll" -or
+            (Get-Content -LiteralPath (Join-Path $target "data\new.asset") -Raw) -ne "new data" -or
+            (Test-Path -LiteralPath (Join-Path $target "old.dll")) -or
+            (Test-Path -LiteralPath (Join-Path $target ".sanad-install-backup"))) {
+            throw "The isolated upgrade did not produce the exact new payload."
+        }
+        return $true
+    } catch {
+        Write-Host "[FAIL] Running-client lock and staged replacement - $($_.Exception.Message)" -ForegroundColor Red
+        return $false
+    } finally {
+        if ($lock) { $lock.Dispose() }
+        Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Write-Host "Running isolated upgrade guard verification..." -ForegroundColor Cyan
+$upgradeGuardPassed = Test-UpgradeGuard
+if ($upgradeGuardPassed) {
+    Write-Host "[OK] Locked-file rejection and transactional payload replacement" -ForegroundColor Green
+} elseif ($UpgradeGuardOnly) {
+    exit 1
+}
+if ($UpgradeGuardOnly) {
+    exit 0
+}
 
 # Check if release build exists
 if (-not (Test-Path $releaseDir)) {
@@ -21,17 +147,18 @@ if (-not (Test-Path $releaseDir)) {
 
 $checksPassed = 0
 $checksFailed = 0
+if ($upgradeGuardPassed) { $checksPassed++ } else { $checksFailed++ }
 
 # Function to check file
 function Check-File {
     param($path, $name)
-    if (Test-Path $path) {
-        $size = (Get-Item $path).Length / 1MB
+    if ((Test-Path -LiteralPath $path -PathType Leaf) -and (Get-Item -LiteralPath $path).Length -gt 0) {
+        $size = (Get-Item -LiteralPath $path).Length / 1MB
         Write-Host "[OK] $name ($([Math]::Round($size, 2)) MB)" -ForegroundColor Green
         return $true
     }
     else {
-        Write-Host "[FAIL] $name - NOT FOUND" -ForegroundColor Red
+        Write-Host "[FAIL] $name - MISSING OR EMPTY" -ForegroundColor Red
         return $false
     }
 }
@@ -57,18 +184,14 @@ Write-Host "2. Checking Flutter Runtime:" -ForegroundColor Cyan
 if (Check-File "$releaseDir\flutter_windows.dll" "flutter_windows.dll") { $checksPassed++ } else { $checksFailed++ }
 
 Write-Host ""
-Write-Host "3. Checking Plugin DLLs:" -ForegroundColor Cyan
-$pluginDlls = @(
-    "window_manager_plugin.dll",
-    "screen_capturer_windows_plugin.dll",
-    "screen_retriever_windows_plugin.dll",
-    "url_launcher_windows_plugin.dll",
-    "connectivity_plus_plugin.dll",
-    "bixat_key_mouse.dll"
-)
-
-foreach ($dll in $pluginDlls) {
-    if (Check-File "$releaseDir\$dll" $dll) { $checksPassed++ } else { $checksFailed++ }
+Write-Host "3. Checking Packaged DLLs:" -ForegroundColor Cyan
+$packagedDlls = @(Get-ChildItem -LiteralPath $releaseDir -Filter "*.dll" -File)
+if ($packagedDlls.Count -eq 0) {
+    Write-Host "[FAIL] No packaged DLLs were produced" -ForegroundColor Red
+    $checksFailed++
+}
+foreach ($dll in $packagedDlls) {
+    if (Check-File $dll.FullName $dll.Name) { $checksPassed++ } else { $checksFailed++ }
 }
 
 Write-Host ""
@@ -83,7 +206,6 @@ if (Check-File "$releaseDir\data\app.so" "app.so (Dart Engine)") { $checksPassed
 Write-Host ""
 Write-Host "6. Checking Flutter Assets:" -ForegroundColor Cyan
 if (Check-Directory "$releaseDir\data\flutter_assets" "flutter_assets") { $checksPassed++ } else { $checksFailed++ }
-if (Check-File "$releaseDir\data\flutter_assets\.env" ".env (Configuration)") { $checksPassed++ } else { $checksFailed++ }
 if (Check-File "$releaseDir\data\flutter_assets\AssetManifest.bin" "AssetManifest.bin") { $checksPassed++ } else { $checksFailed++ }
 
 Write-Host ""
@@ -121,6 +243,12 @@ Write-Host ""
 Write-Host "9. Checking Installer Scripts:" -ForegroundColor Cyan
 if (Check-File "$installerDir\sanad_client_installer.nsi" "sanad_client_installer.nsi") { $checksPassed++ } else { $checksFailed++ }
 if (Check-File "$installerDir\sanad_client_installer.iss" "sanad_client_installer.iss") { $checksPassed++ } else { $checksFailed++ }
+if (Check-File "$installerDir\stop_installed_client.ps1" "stop_installed_client.ps1") { $checksPassed++ } else { $checksFailed++ }
+if (Check-File "$installerDir\install_staged_client.ps1" "install_staged_client.ps1") { $checksPassed++ } else { $checksFailed++ }
+
+Write-Host ""
+Write-Host "10. Checking Built Installer:" -ForegroundColor Cyan
+if (Check-File $builtInstaller "sanad-client-$versionName-windows-x64.exe") { $checksPassed++ } else { $checksFailed++ }
 
 Write-Host ""
 Write-Host "========================================="
@@ -137,7 +265,7 @@ if ($checksFailed -eq 0) {
     Write-Host "SUCCESS: All required files are present!" -ForegroundColor Green
     Write-Host ""
     Write-Host "The installer is ready for distribution." -ForegroundColor Green
-    Write-Host "File: installer\sanad-client-setup.exe" -ForegroundColor Green
+    Write-Host "File: build\sanad-client-$versionName-windows-x64.exe" -ForegroundColor Green
     exit 0
 }
 else {

--- a/docs/agent_engine/capability_runtime.md
+++ b/docs/agent_engine/capability_runtime.md
@@ -53,7 +53,10 @@ environments, `site-packages`, `.next`, `dist`, and `target`. A candidate that p
 decoded as UTF-8 is skipped without failing the whole search. Shell execution
 follows host-native command semantics, enforces workspace/path and permission
 policy, applies a bounded timeout, bounds stdout and stderr while streaming, and
-terminates the command process tree where supported.
+terminates the command process tree where supported. Child processes are not
+trusted to emit valid UTF-8: malformed byte sequences are replaced during
+bounded decoding rather than escaping the tool future and terminating the
+Agent daemon.
 
 ## Tool Output Budgets
 

--- a/docs/plans/tasks/shell-execute-malformed-output-containment.md
+++ b/docs/plans/tasks/shell-execute-malformed-output-containment.md
@@ -1,0 +1,66 @@
+---
+title: "Task: Contain Malformed shell_execute Output"
+status: "completed"
+current_gate: "complete"
+---
+
+# Task: Contain Malformed `shell_execute` Output
+
+## Goal
+Keep the Agent daemon alive when a child process writes stdout or stderr bytes
+that are not valid UTF-8.
+
+## Locked Decisions and Scope
+
+- Preserve bounded streaming collection and existing head/tail truncation.
+- Treat child output as untrusted. Decode UTF-8 lossily so valid text is
+  unchanged and malformed sequences become the Unicode replacement character.
+- Do not infer or transcode arbitrary legacy code pages in this focused crash
+  fix.
+- Cover the real `ShellExecuteTool` process boundary on Windows and POSIX.
+
+## Gates
+
+### G0 — Reproduction and Ownership
+
+- [x] Map the reported `_Utf8Decoder.convertChunked` crash to
+  `ShellExecuteTool._collectBoundedOutput`.
+- [x] Confirm the strict decoder future can fail outside the synchronous process
+  launch boundary and terminate the daemon's active execution path.
+
+### G1 — Implementation
+
+- [x] Use `Utf8Decoder(allowMalformed: true)` for stdout and stderr streams.
+- [x] Add a cross-platform regression command that emits invalid UTF-8 followed
+  by valid ASCII and assert execution returns normally.
+- [x] Document malformed child-output containment in the capability runtime.
+
+### G2 — Verification
+
+- [x] Run the focused shell execution unit test suite.
+- [x] Run `fvm dart analyze` in `agent/`.
+- [x] Reproduce malformed Windows process output through the real
+  `ShellExecuteTool` process boundary and confirm normal completion.
+- [x] Live runtime handoff is not required: the real process boundary regression
+  is sufficient, and avoiding a source switch prevents unnecessary impact on
+  active sessions.
+- [x] Review the final diff.
+- [x] Graphify update waived by the owner because the CLI and graph are
+  unavailable.
+
+## Acceptance Criteria
+
+- [x] Invalid child bytes no longer escape stream collection as a
+  `FormatException`.
+- [x] Valid bytes surrounding malformed sequences remain visible in the bounded
+  tool result.
+- [x] Focused automated tests and Agent analysis pass.
+- [x] Process-boundary verification proves malformed output returns a normal tool
+  result instead of escaping as an unhandled exception.
+
+## Definition of Done
+
+- [x] Source, regression coverage, design documentation, analysis, and focused
+  tests are current.
+- [x] Graphify maintenance was explicitly waived by the owner.
+- [x] No commit is created before user review.

--- a/docs/plans/tasks/windows-installer-running-client-guard.md
+++ b/docs/plans/tasks/windows-installer-running-client-guard.md
@@ -1,0 +1,120 @@
+---
+title: "Task: Windows Installer Running-Client Guard and Safe DLL Replacement"
+status: "completed"
+current_gate: "complete"
+---
+
+# Task: Windows Installer Running-Client Guard and Safe DLL Replacement
+
+## Goal
+Prevent Bad Image / DLL-load failures during Windows Client upgrades by refusing
+to replace files that remain in use and by restoring the prior complete payload
+when replacement cannot finish safely.
+
+## Locked Decisions and Scope
+
+- The official Windows package remains the existing NSIS installer. Migrating to
+  MSI or Inno Setup is outside this task.
+- Preserve WinSparkle's graceful `before-quit-for-update` handoff. The bounded
+  force-stop fallback may target only the exact installed executable path.
+- Fail closed while any installed EXE or DLL remains exclusively locked; never
+  kill an unrelated holder by process name.
+- Extract a complete payload under the installation root before replacement.
+  Use same-volume moves, SHA-256 verification of every staged file, backup, and
+  rollback. Do not describe the multi-file transaction as one atomic filesystem
+  operation.
+- Keep the comparison-only Inno Setup script unchanged; `AppMutex` is invalid
+  unless the application creates the matching named mutex.
+- Extend isolated Windows verification and CI without touching a real installed
+  Client or user Sanad Home. Real-installer lifecycle tests use dedicated
+  compile-time display name, installation directory, registry keys, and disabled
+  shortcuts so production defaults remain unchanged.
+- Non-Windows packaging is excluded.
+
+## Reference Evidence
+
+- Microsoft documents that files must be closed before moving/replacing them and
+  provides replacement with backup semantics:
+  <https://learn.microsoft.com/windows/win32/fileio/moving-and-replacing-files>.
+- Windows Installer's safety model preserves deleted files and automatically
+  rolls back unsuccessful installation work:
+  <https://learn.microsoft.com/windows/win32/msi/rollback-installation>.
+- Restart Manager is the system facility for installers to identify and close
+  applications holding updated files:
+  <https://learn.microsoft.com/windows/win32/rstmgr/restart-manager-portal>.
+- Inno Setup requires the application itself to create every mutex named by
+  `AppMutex`: <https://jrsoftware.org/ishelp/topic_setup_appmutex.htm>.
+
+## Gates
+
+### G0 — Discovery and Design
+
+- [x] Inspect the complete worktree diff, official installer path, release
+  workflow, update architecture, and clean-machine QA contract.
+- [x] Compare the implementation with official Windows, NSIS, and Inno Setup
+  behavior.
+- [x] Identify the incomplete verification, unsupported mutex, in-place partial
+  write, and missing rollback risks in the original worktree implementation.
+
+### G1 — Implementation
+
+- [x] Make the exact-path shutdown helper wait for installed EXE/DLL handle
+  release after graceful and forced shutdown paths.
+- [x] Stage the complete NSIS payload before touching the installed payload.
+- [x] Add same-volume replacement, full staged-file hash verification, backup,
+  and rollback through `install_staged_client.ps1`.
+- [x] Make `verify_installer.ps1` location-independent and add isolated tests for
+  exact-process force stop, locked installed DLL rejection, failed replacement
+  rollback, stale DLL removal, and successful retry.
+- [x] Run the isolated guard in Windows CI and parse every involved PowerShell
+  script.
+- [x] Add compile-time test isolation for display name, installation directory,
+  HKCU application/uninstall keys, execution level, and shortcuts without
+  changing production defaults.
+- [x] Update technical and clean-machine QA documentation.
+
+### G2 — Verification
+
+- [x] Parse all changed PowerShell scripts with Windows PowerShell.
+- [x] Run `verify_installer.ps1 -UpgradeGuardOnly` successfully.
+- [x] Compile `sanad_client_installer.nsi` with pinned NSIS 3.12 and an isolated
+  synthetic payload.
+- [x] Run `fvm flutter analyze` with zero issues.
+- [x] Run `verified_agent_bootstrap_installer_test.dart` with all tests passing.
+- [x] Build and launch the Windows Client in FVM Debug mode before producing a
+  release installer candidate.
+- [x] Build the real Windows release installer and run the full installer
+  verifier against its release payload.
+- [x] Run a real isolated two-version NSIS lifecycle on this workstation:
+  running-client upgrade, locked-DLL rejection with exit code `2`, retry,
+  uninstall, registry cleanup, and normal-client survival all passed.
+- [x] Compile the NSIS script again with production-default defines after adding
+  the test-isolation overrides.
+- [x] Review the final diff and run `git diff --check`.
+- [x] Graphify update waived by the owner because the CLI and an existing graph
+  are unavailable in this worktree.
+
+## Acceptance Criteria
+
+- [x] Given the exact installed Client is running, the isolated verifier proves
+  the fallback terminates that process and waits for handle release.
+- [x] Given an installed DLL remains locked, the installer guard fails without
+  changing the installed payload.
+- [x] Given a staged DLL becomes locked during replacement, rollback restores
+  the prior EXE, DLL, and data payload and removes the completed backup.
+- [x] Given an unlocked complete staged payload, replacement removes stale DLLs,
+  verifies every staged file hash, and leaves no staging or backup directory.
+- [x] The official release payload and NSIS installer build and verify cleanly.
+- [x] This task does not hold a future release open: clean-machine Defender,
+  SmartScreen, reboot, and candidate checks remain release-time runbook work,
+  while the running-client installer behavior required here passed locally.
+
+## Definition of Done
+
+- [x] Relevant analyzer, focused tests, PowerShell verification, and NSIS compile
+  pass with bounded evidence.
+- [x] Architecture, QA, and task documentation match the implementation.
+- [x] Graphify maintenance was explicitly waived by the owner because the local
+  CLI and graph are unavailable.
+- [x] Worktree contains only intentional PR files and no generated artifacts.
+- [x] No commit is created before user review.

--- a/docs/qa_maintenance/windows_release_clean_machine.md
+++ b/docs/qa_maintenance/windows_release_clean_machine.md
@@ -87,7 +87,17 @@ screenshots beside it.
    operating-system review flow offered by Windows.
 3. Launch the Client, record its displayed version and startup result, then
    reboot and launch it again.
-4. Uninstall through Windows Installed Apps and verify that application entries
+4. While the installed Client is running, launch the next candidate installer.
+   Confirm the Client closes, the upgrade completes, and the new Client starts
+   without Bad Image or DLL-load errors. Verify that no
+   `.sanad-install-staging` or `.sanad-install-backup` directory remains and
+   that the installed EXE, every top-level DLL, and the `data/` tree match the
+   candidate payload hashes.
+5. Repeat with an independent process holding one installed DLL without delete
+   sharing. Confirm the installer aborts without changing the installed
+   payload; release the handle and confirm retry succeeds. Do not use a real
+   user Client or Sanad Home for this fault-injection case.
+6. Uninstall through Windows Installed Apps and verify that application entries
    and installed binaries are removed while the test Sanad Home remains.
 
 Capture machine state after each stage:
@@ -186,6 +196,28 @@ This is real Windows vault and source lifecycle evidence, not a new packaged
 clean-machine pass. The existing release clean-machine procedure remains the
 authority for a future candidate artifact's Defender, SmartScreen, install,
 upgrade, reboot, rollback, and uninstall evidence.
+
+## Isolated running-client installer regression — 2026-08-30
+
+A current-workstation test used two synthetic NSIS payload versions, a dedicated
+installation directory, dedicated HKCU application and Installed Apps keys, no
+shortcuts, and no Sanad Home. It did not replace or stop the normal installed or
+source Client. The isolated lifecycle proved:
+
+- version 1 installed with isolated registry metadata;
+- installing version 2 while the exact version 1 executable was running stopped
+  only that executable and replaced EXE, DLL, and `data/` without staging or
+  backup residue;
+- an exclusive lock on the installed version 1 DLL rejected the upgrade with
+  installer exit code `2` and preserved the complete version 1 payload;
+- releasing the lock allowed a successful retry, removed the stale version 1
+  DLL, and installed the exact version 2 payload;
+- silent uninstall removed the isolated directory and both isolated registry
+  keys; the pre-existing normal Client process remained alive.
+
+This is focused current-machine regression evidence. It does not replace the
+protected clean-snapshot Defender, SmartScreen, signing, reboot, or release
+candidate gate above.
 
 ## Acceptance criteria
 

--- a/docs/technical/update_architecture.md
+++ b/docs/technical/update_architecture.md
@@ -113,7 +113,15 @@ listener, and exits within a bounded handoff so the already-launched NSIS
 installer can replace the application. NSIS waits for that graceful exit and
 uses an exact-installed-path fallback only for clients released before the
 listener existed; it never terminates source runs or another installation by
-process name alone.
+process name alone. The installer also fails closed until the installed EXE and
+DLL handles can be opened exclusively. It extracts the complete replacement
+under the installation root before touching the active payload, then moves the
+old EXE, top-level DLLs, and `data/` into a backup and moves the staged payload
+into place on the same volume. Every staged file is SHA-256 checked after the
+move. A failed move or verification restores the backup; successful
+verification removes both temporary directories. This is transactional
+multi-file replacement with rollback, not a claim that the whole payload swaps
+atomically in one filesystem operation.
 
 Linux has no background poll, download, package replacement, privilege request,
 or rollback claim. **Settings → General → Check for Updates** performs a
@@ -128,8 +136,12 @@ Windows real-machine gates may compile private candidates with
 `SANAD_APPCAST_URL`, `SANAD_RELEASE_MANIFEST_URL`,
 `SANAD_RELEASE_ARTIFACT_MIRROR_URL`, `SANAD_HOME`, and
 `SANAD_SERVICE_INSTANCE`. These are build-time overrides only and isolate the
-candidate's feed, Home, and Scheduled Task without requiring a launch shell. The
-manifest must still carry canonical GitHub artifact identity and pass the normal
+candidate's feed, Home, and Scheduled Task without requiring a launch shell.
+NSIS lifecycle tests additionally compile with a dedicated user-level install
+directory, display name, HKCU application/uninstall keys, and no shortcuts;
+production packages retain the default Program Files location, Sanad keys, and
+shortcuts when those test-only defines are absent. The manifest must still carry
+canonical GitHub artifact identity and pass the normal
 version, size, SHA-256, and trust policy; the mirror changes only where the test
 candidate bytes are fetched. The Windows DSA private key remains outside the
 checkout and its path is passed directly to the signing tool; release tooling


### PR DESCRIPTION
## Problem / Goal

Windows Client upgrades could attempt in-place EXE/DLL replacement without a complete transactional rollback boundary, leaving room for locked or partial payload failures. During verification, malformed non-UTF-8 process output also exposed an unhandled `shell_execute` decoder failure that could restart the Agent daemon.

## Changes

- stage the complete NSIS Client payload under the installation root before replacing active files;
- wait for exact installed-process shutdown and exclusive EXE/DLL access;
- move the prior payload into a backup, verify every replacement file with SHA-256, and roll back failed moves or verification;
- add isolated installer display-name, directory, registry, and shortcut overrides without changing production defaults;
- extend the Windows verifier and CI with exact-process, locked-DLL, rollback, stale-DLL, retry, and cleanup coverage;
- decode malformed child-process UTF-8 lossily so shell output cannot terminate the Agent daemon;
- update release architecture, QA evidence, capability runtime, and completed task plans.

## Verification

- `fvm dart analyze` — passed.
- `fvm dart test test/capabilities/shell_execute_tool_test.dart` — 7 passed, 3 platform skips.
- `fvm flutter analyze` — passed.
- `fvm flutter test test/unit/services/verified_agent_bootstrap_installer_test.dart` — 12 passed.
- PowerShell parse checks for all affected installer scripts — passed.
- `verify_installer.ps1 -UpgradeGuardOnly` — passed.
- Windows Debug build and launch through FVM — passed.
- Real Windows Release Client and NSIS installer build plus full verifier — passed.
- Isolated two-version NSIS lifecycle — running-client upgrade, locked-DLL rejection (`exit=2`), retry, uninstall, registry cleanup, and normal-client survival passed.
- NSIS 3.12 production-default compile after test-isolation changes — passed.
- `git diff --check` — passed.

## Risk / Cross-platform Impact

- Runtime installer behavior changes only on Windows.
- The shell decoder containment applies to all Agent platforms and preserves valid UTF-8 while replacing malformed byte sequences.
- Test-only NSIS defines are absent from production builds, which retain the existing Program Files location, Sanad registry keys, and shortcuts.

## Documentation

Updated the Client update architecture, Windows release QA runbook/evidence, capability runtime, and task plans.

## Rollback

Revert this PR to restore direct NSIS payload extraction and strict shell-output decoding. No user-data or database migration is introduced.

## Required protected review

- `release-reviewed`: required because Windows installer and release behavior changed.
- `maintainer-reviewed`: required because `.github/workflows/ci.yml` changed.
