### PR TITLE
fix(conversations): reconcile hydrated message projections

### DIFF
--- a/client/lib/features/conversations/data/transport/conversation_commands.dart
+++ b/client/lib/features/conversations/data/transport/conversation_commands.dart
@@ -900,16 +900,40 @@ class ConversationCommands {
     List<CanonicalEvent> retained,
     List<CanonicalEvent> hydrated,
   ) {
+    final foldedHydrated = _foldCanonicalEvents(hydrated);
     final hydratedById = {
-      for (final event in hydrated) event.id: event,
+      for (final event in foldedHydrated) event.id: event,
     };
     final merged = <CanonicalEvent>[
-      for (final event in retained) hydratedById.remove(event.id) ?? event,
+      for (final event in retained)
+        switch (hydratedById.remove(event.id)) {
+          final hydratedEvent? => event.merge(hydratedEvent),
+          null => event,
+        },
     ];
     merged.addAll(
-      hydrated.where((event) => hydratedById.remove(event.id) != null),
+      foldedHydrated.where(
+        (event) => hydratedById.remove(event.id) != null,
+      ),
     );
     return merged;
+  }
+
+  List<CanonicalEvent> _foldCanonicalEvents(
+    Iterable<CanonicalEvent> events,
+  ) {
+    final folded = <CanonicalEvent>[];
+    final indexById = <String, int>{};
+    for (final event in events) {
+      final index = indexById[event.id];
+      if (index == null) {
+        indexById[event.id] = folded.length;
+        folded.add(event);
+      } else {
+        folded[index] = folded[index].merge(event);
+      }
+    }
+    return folded;
   }
 
   Future<List<CanonicalEvent>> loadAnchoredSessionHistory(

--- a/client/lib/features/conversations/domain/stores/device_conversation_store.dart
+++ b/client/lib/features/conversations/domain/stores/device_conversation_store.dart
@@ -410,29 +410,62 @@ class DeviceConversationStore {
     byRequest[record.requestId] = record;
     if (record.sessionId != _currentSessionId) return;
 
-    final eventId = 'user_${record.requestId}';
+    _reconcilePendingSteerProjection(record);
+    _emitMessages();
+  }
+
+  void _reconcilePendingSteerProjection(
+    PendingSteerRecord record, {
+    Map<String, dynamic> metadataOverrides = const {},
+  }) {
+    final transientEventId = 'user_${record.requestId}';
     if (record.state == PendingSteerState.cancelled || record.state == PendingSteerState.recovered) {
-      _conversation.removeById(eventId);
-      _emitMessages();
+      _conversation.removeById(transientEventId);
       return;
     }
+
+    final durableEvent = _conversation.events
+        .where(
+          (event) =>
+              event.id != transientEventId &&
+              event.kind == EventKind.userMessage &&
+              event.sessionId == record.sessionId &&
+              event.requestId == record.requestId,
+        )
+        .firstOrNull;
+    if (durableEvent != null) {
+      _conversation.removeById(transientEventId);
+    }
+    final base = durableEvent;
     _conversation.apply(
       CanonicalEvent(
-        id: eventId,
+        id: base?.id ?? transientEventId,
         kind: EventKind.userMessage,
-        text: record.text,
-        timestamp: record.receivedAt,
-        sessionId: record.sessionId,
-        runId: record.runId,
+        text: base?.text ?? record.text,
+        timestamp: base?.timestamp ?? record.receivedAt,
+        sessionId: base?.sessionId ?? record.sessionId,
+        runId: base?.runId ?? record.runId,
+        eventId: base?.eventId,
         metadata: {
+          ...?base?.metadata,
           'request_id': record.requestId,
           'pending_steer_state': record.state.name,
           'pending_steer_revision': record.revision,
           'generation': record.generation,
+          ...metadataOverrides,
         },
       ),
     );
-    _emitMessages();
+  }
+
+  void _reconcileCurrentPendingSteerProjections() {
+    final sessionId = _currentSessionId;
+    if (sessionId == null) return;
+    final records = _pendingSteersBySessionId[sessionId];
+    if (records == null) return;
+    for (final record in records.values) {
+      _reconcilePendingSteerProjection(record);
+    }
   }
 
   void hydratePendingSteers(
@@ -492,21 +525,9 @@ class DeviceConversationStore {
         .whereType<PendingSteerRecord>()
         .firstOrNull;
     if (record == null || record.sessionId != _currentSessionId) return;
-    _conversation.apply(
-      CanonicalEvent(
-        id: 'user_$requestId',
-        kind: EventKind.userMessage,
-        text: record.text,
-        timestamp: record.receivedAt,
-        sessionId: record.sessionId,
-        runId: record.runId,
-        metadata: {
-          'request_id': requestId,
-          'pending_steer_state': record.state.name,
-          'pending_steer_revision': record.revision,
-          'pending_cancel_outcome': outcome,
-        },
-      ),
+    _reconcilePendingSteerProjection(
+      record,
+      metadataOverrides: {'pending_cancel_outcome': outcome},
     );
     _emitMessages();
   }
@@ -533,6 +554,7 @@ class DeviceConversationStore {
     String? nextNewerCursor,
   }) {
     _conversation.setHistory(events);
+    _reconcileCurrentPendingSteerProjections();
     _historyHasMore = hasMore && nextCursor != null;
     _historyNextCursor = _historyHasMore ? nextCursor : null;
     _historyHasNewer = hasNewer && nextNewerCursor != null;
@@ -547,14 +569,13 @@ class DeviceConversationStore {
     required String requestedCursor,
   }) {
     if (_historyNextCursor != requestedCursor) return false;
-    final existingIds = _conversation.events.map((event) => event.id).toSet();
-    final older = events.where((event) => existingIds.add(event.id)).toList(growable: false);
-    _conversation.setHistory([...older, ..._conversation.events]);
+    _conversation.setHistory([...events, ..._conversation.events]);
+    _reconcileCurrentPendingSteerProjections();
     final advanced = nextCursor != null && nextCursor != requestedCursor;
     _historyHasMore = hasMore && advanced;
     _historyNextCursor = _historyHasMore ? nextCursor : null;
     _emitMessages();
-    return older.isNotEmpty || !_historyHasMore;
+    return events.isNotEmpty || !_historyHasMore;
   }
 
   bool appendHistory(
@@ -568,6 +589,7 @@ class DeviceConversationStore {
     for (final event in newer) {
       _conversation.apply(event);
     }
+    _reconcileCurrentPendingSteerProjections();
     final advanced = nextNewerCursor != null && nextNewerCursor != requestedCursor;
     _historyHasNewer = hasNewer && advanced;
     _historyNextNewerCursor = _historyHasNewer ? nextNewerCursor : null;

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -633,14 +633,21 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
 
   Widget _buildToolContent() {
     final toolName = widget.event.toolName ?? '';
+    final category = ToolPresentationHelper.cleanToolTitle(toolName);
+
+    // A terminal result can arrive before its matching tool-use input during
+    // live/history reconciliation. The specialized tile still unwraps and
+    // renders that result safely without requiring a command suffix.
+    if (category == 'Ran') {
+      return TerminalToolTile(event: widget.event);
+    }
+
     final details = ToolPresentationHelper.getToolDetailSuffix(widget.event);
 
     // If we could not extract any suffix details, fall back to the old GenericToolTile (input/output JSON)
     if (details.isEmpty) {
       return GenericToolTile(event: widget.event);
     }
-
-    final category = ToolPresentationHelper.cleanToolTitle(toolName);
 
     switch (category) {
       case 'Read':
@@ -652,8 +659,6 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
           event: widget.event,
           isFullyExpanded: _isExpanded && _expansionController.isCompleted,
         );
-      case 'Ran':
-        return TerminalToolTile(event: widget.event);
       case 'Search Web':
       case 'Fetch':
         return WebToolTile(event: widget.event);

--- a/client/test/unit/services/device_conversation_commands_test.dart
+++ b/client/test/unit/services/device_conversation_commands_test.dart
@@ -619,6 +619,106 @@ void main() {
     expect(store.currentMessages.single.text, 'done');
   });
 
+  test('history hydration reconciles a delivered steer by request id', () async {
+    Future<void> hydrateSteerHistory() async {
+      final future = commands.loadSessionHistory('session-1');
+      final payload = socket.capturedCommands.last['payload'] as Map<String, dynamic>;
+      socket.eventRouter.routeEvent({
+        'device_id': 'agent-1',
+        'event': 'session_history',
+        'payload': {
+          'request_id': payload['request_id'],
+          'has_more': false,
+          'messages': [
+            {
+              'event_id': 'history:session-1:10:tool_result:0',
+              'type': 'tool_result',
+              'tool': 'shell_execute',
+              'output': 'done',
+              'status': 'done',
+              'tool_call_id': 'tool-before-steer',
+              'session_id': 'session-1',
+              'created_at': '2026-09-02T13:59:58Z',
+            },
+            {
+              'event_id': 'history:session-1:10:user_message:1',
+              'type': 'user_message',
+              'content': 'show the secret timestamps',
+              'session_id': 'session-1',
+              'request_id': 'steer-request-1',
+              'created_at': '2026-09-02T13:59:59Z',
+              'metadata': {
+                'steer': true,
+                'input_kind': 'steer',
+                'request_id': 'steer-request-1',
+              },
+            },
+            {
+              'event_id': 'history:session-1:11:final_answer:0',
+              'type': 'final_answer',
+              'content': 'final response',
+              'session_id': 'session-1',
+              'created_at': '2026-09-02T14:00:10Z',
+            },
+          ],
+          'pending_steers': [
+            {
+              'session_id': 'session-1',
+              'request_id': 'steer-request-1',
+              'run_id': 'run-1',
+              'generation': 1,
+              'text': 'show the secret timestamps',
+              'received_at': '2026-09-02T13:59:59Z',
+              'updated_at': '2026-09-02T14:00:10Z',
+              'state': 'delivered',
+              'revision': 3,
+            },
+          ],
+        },
+      });
+      await future;
+    }
+
+    await hydrateSteerHistory();
+
+    expect(store.currentMessages, hasLength(3));
+    expect(store.currentMessages[1].id, 'history:session-1:10:user_message:1');
+    expect(store.currentMessages[1].requestId, 'steer-request-1');
+    expect(store.currentMessages[1].metadata?['pending_steer_state'], 'delivered');
+    expect(
+      store.currentMessages.where(
+        (event) => event.kind == EventKind.userMessage && event.requestId == 'steer-request-1',
+      ),
+      hasLength(1),
+    );
+
+    socket.clearCaptured();
+    final other = commands.loadSessionHistory('session-2');
+    final payload = socket.capturedCommands.single['payload'] as Map<String, dynamic>;
+    socket.eventRouter.routeEvent({
+      'device_id': 'agent-1',
+      'event': 'session_history',
+      'payload': {
+        'request_id': payload['request_id'],
+        'has_more': false,
+        'messages': const [],
+      },
+    });
+    await other;
+
+    socket.clearCaptured();
+    await hydrateSteerHistory();
+
+    expect(store.currentMessages, hasLength(3));
+    expect(store.currentMessages[1].id, 'history:session-1:10:user_message:1');
+    expect(
+      store.currentMessages.where(
+        (event) => event.kind == EventKind.userMessage && event.requestId == 'steer-request-1',
+      ),
+      hasLength(1),
+    );
+  });
+
   test('loadOlderSessionHistory coalesces and prepends stable unique events', () async {
     final initial = commands.loadSessionHistory('session-1');
     final initialPayload = socket.capturedCommands.single['payload'] as Map<String, dynamic>;
@@ -680,6 +780,64 @@ void main() {
     expect(store.historyNextCursor, isNull);
   });
 
+  test('older page merges tool-use into an existing terminal result', () async {
+    final initial = commands.loadSessionHistory('session-1');
+    var payload = socket.capturedCommands.single['payload'] as Map<String, dynamic>;
+    socket.eventRouter.routeEvent({
+      'device_id': 'agent-1',
+      'event': 'session_history',
+      'payload': {
+        'request_id': payload['request_id'],
+        'has_more': true,
+        'next_cursor': 'tool-older',
+        'messages': [
+          {
+            'type': 'tool_result',
+            'tool': 'shell_execute',
+            'output': '{"isError":false,"output":"done\\n"}',
+            'status': 'done',
+            'tool_call_id': 'call-result-first',
+            'session_id': 'session-1',
+            'created_at': '2026-09-02T00:00:01Z',
+          },
+        ],
+      },
+    });
+    await initial;
+    socket.clearCaptured();
+
+    final older = commands.loadOlderSessionHistory('session-1');
+    payload = socket.capturedCommands.single['payload'] as Map<String, dynamic>;
+    socket.eventRouter.routeEvent({
+      'device_id': 'agent-1',
+      'event': 'session_history',
+      'payload': {
+        'request_id': payload['request_id'],
+        'has_more': false,
+        'messages': [
+          {
+            'type': 'tool_use',
+            'tool': 'shell_execute',
+            'input': {'command': 'echo done'},
+            'status': 'done',
+            'tool_call_id': 'call-result-first',
+            'session_id': 'session-1',
+            'created_at': '2026-09-02T00:00:00Z',
+          },
+        ],
+      },
+    });
+    await older;
+
+    expect(store.currentMessages, hasLength(1));
+    expect(store.currentMessages.single.toolInput, {'command': 'echo done'});
+    expect(
+      store.currentMessages.single.toolOutput,
+      '{"isError":false,"output":"done\\n"}',
+    );
+    expect(store.currentMessages.single.status, EventStatus.done);
+  });
+
   test('complete loaded history survives session navigation and tail refresh', () async {
     store.activateSession('session-1');
     store.setHistory([
@@ -738,6 +896,65 @@ void main() {
     ]);
     expect(store.historyHasMore, isFalse);
     expect(store.historyNextCursor, isNull);
+  });
+
+  test('retained terminal result merges with both hydrated tool fragments', () async {
+    store.activateSession('session-1');
+    store.setHistory([
+      CanonicalEvent(
+        id: 'tool_call-hydration-race',
+        kind: EventKind.toolCall,
+        status: EventStatus.done,
+        tool: const {
+          'name': 'shell_execute',
+          'output': '{"isError":false,"output":"153\\n/path\\n"}',
+        },
+        timestamp: DateTime.utc(2026, 9, 2, 0, 0, 1),
+        toolCallId: 'call-hydration-race',
+      ),
+    ]);
+
+    final history = commands.loadSessionHistory('session-1');
+    final payload = socket.capturedCommands.single['payload'] as Map<String, dynamic>;
+    socket.eventRouter.routeEvent({
+      'device_id': 'agent-1',
+      'event': 'session_history',
+      'payload': {
+        'request_id': payload['request_id'],
+        'has_more': false,
+        'messages': [
+          {
+            'type': 'tool_use',
+            'tool': 'shell_execute',
+            'input': {'command': 'generate output'},
+            'status': 'done',
+            'tool_call_id': 'call-hydration-race',
+            'session_id': 'session-1',
+            'created_at': '2026-09-02T00:00:00Z',
+          },
+          {
+            'type': 'tool_result',
+            'tool': 'shell_execute',
+            'output': '{"isError":false,"output":"153\\n/path\\n"}',
+            'status': 'done',
+            'tool_call_id': 'call-hydration-race',
+            'session_id': 'session-1',
+            'created_at': '2026-09-02T00:00:01Z',
+          },
+        ],
+      },
+    });
+    await history;
+
+    expect(store.currentMessages, hasLength(1));
+    expect(store.currentMessages.single.toolInput, {
+      'command': 'generate output',
+    });
+    expect(
+      store.currentMessages.single.toolOutput,
+      '{"isError":false,"output":"153\\n/path\\n"}',
+    );
+    expect(store.currentMessages.single.status, EventStatus.done);
   });
 
   test('anchored history sends the stable event id and replaces only on success', () async {

--- a/client/test/widget/tool_group_tile_test.dart
+++ b/client/test/widget/tool_group_tile_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:sanad_client/features/conversations/domain/models/canonical_event.dart';
 import 'package:sanad_client/features/conversations/presentation/utils/conversation_timeline_projection.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/event_tile.dart';
+import 'package:sanad_client/features/conversations/presentation/widgets/tools/terminal_tool_tile.dart';
 import 'package:sanad_client/features/conversations/presentation/widgets/tools/tool_group_tile.dart';
 
 void main() {
@@ -48,6 +49,31 @@ void main() {
 
     expect(find.textContaining('Ask'), findsNothing);
     expect(find.byType(CircularProgressIndicator), findsNothing);
+  });
+
+  testWidgets('terminal result without input unwraps output in terminal tile', (
+    tester,
+  ) async {
+    final event = _tool(
+      'terminal-result-first',
+      'shell_execute',
+      output: jsonEncode({
+        'isError': false,
+        'output': '153 104.0 180.0\n/tmp/result.jsonl\n',
+      }),
+    );
+
+    await tester.pumpWidget(
+      _app(EventTile(event: event, isExpanded: true)),
+    );
+
+    expect(find.byType(TerminalToolTile), findsOneWidget);
+    expect(
+      find.text('153 104.0 180.0\n/tmp/result.jsonl\n'),
+      findsOneWidget,
+    );
+    expect(find.text('Output Result'), findsNothing);
+    expect(find.textContaining('"isError"'), findsNothing);
   });
 
   testWidgets('group reuses tool styling and caps its independent scroll body', (

--- a/docs/plans/tasks/84-conversation-history-pagination.md
+++ b/docs/plans/tasks/84-conversation-history-pagination.md
@@ -2,13 +2,13 @@
 
 ## الحالة
 
-- **الحالة:** اكتمل التحقق والتسليم؛ pagination لسجل المحادثات الطويلة جاهز ومختبر بالكامل.
-- **الفرع:** `docs/task-84-conversation-history-pagination`.
-- **البوابة الحالية:** G7 — التسليم والدمج.
+- **الحالة:** اكتمل إصلاح تكرار pending steer بعد hydration والتنقل بين المحادثات والتحقق منه.
+- **الفرع:** `fix/conversation-history-projections`.
+- **البوابة الحالية:** G9 — مغلقة.
 - **نسبة العمل المتبقي:** 0%.
 - **التأصيل المرجعي:** Evidence ID `84`، fingerprint
   `sha256:9aa23d0f3a0007890d9ef01643ee633ea618f5ca48704ad54492340d51df9e28`.
-- **حدود التسليم:** مصرح بالـ Commit والـ Push والـ PR والدمج بأمر المالك.
+- **حدود التسليم:** صرّح المالك بالـCommit والـPush وفتح PR ومتابعة CI والدمج إلى `main`.
 
 ## الهدف
 
@@ -299,6 +299,61 @@ Show later نفسها ظهرت قبل الإصلاح ثلاثة `EventTile` من
 اختبار offline يثبت ثلاثة إخفاقات متتالية كحد لكل اتجاه، توقف الطلب الرابع، ثم
 إعادة فتح الميزانية بعد recovery سلطوي. التُقطت لقطتان محليتان غير متتبعتين
 للجلسة الخاملة وtail الجلسة النشطة.
+
+### G8 — تكافؤ أجزاء الأداة عبر live/history وحدود الصفحات
+
+- [x] تشخيص السجل الحقيقي وإثبات سلامة صفّي `tool_use` و`tool_result` في قاعدة
+  البيانات مع فقدان الدمج في Client.
+- [x] دمج الأحداث المتكررة داخل hydration بالهوية canonical قبل مصالحتها مع
+  retained history، مع الاحتفاظ بـinput وoutput والحالة النهائية.
+- [x] دمج النصف الأقدم من الأداة عند prepend بدل إسقاطه كـID مكرر.
+- [x] توجيه `shell_execute` النهائي إلى عرض Terminal حتى إذا وصل بلا input
+  مؤقتًا، ومنع إظهار غلاف `isError`/`output` الخام.
+- [x] إضافة اختبارات regression للمسارات الثلاثة وتحديث QA، ثم تشغيل analyzer
+  والاختبارات المركزة وGraphify.
+
+#### قبول G8
+
+- [x] Given نتيجة Terminal حية ثم hydration يحوي `tool_use` و`tool_result`،
+  then يبقى command ويظهر stdout الداخلي فقط.
+- [x] Given `tool_result` في الصفحة الحالية و`tool_use` المطابق في الصفحة
+  الأقدم، when تُضم الصفحة، then يندمجان في حدث واحد مكتمل.
+- [x] Given نتيجة `shell_execute` بلا input، then يستخدم العرض المتخصص ولا يظهر
+  JSON envelope العام.
+
+**دليل G8:** قاعدة المستخدم أثبتت سلامة `tool_use` و`tool_result` وربطهما بنفس
+`tool_call_id`. نجح الاختباران المركزان (`58 passed`) وClient analyzer بلا
+مشكلات، ثم نجحت مجموعة Client كاملة (`1224 passed`, `1 skipped`). طُبق hot
+reload على runtime المملوك لـWorktree 84 وتأكدت هوية الـworktree والمحادثة، مع
+ترك عملية Terminal النشطة دون restart أو تدخل. نجح `git diff --check` وتحديث
+Graphify.
+
+### G9 — مصالحة pending steer مع رسالة التاريخ الدائمة
+
+- [x] إثبات أن قاعدة البيانات تحتوي steer واحدة وأن Client يعرض تمثيل التاريخ
+  وتمثيل lifecycle كفقاعتين بسبب اختلاف event ids رغم تطابق `request_id`.
+- [x] مصالحة projection المؤقت مع رسالة التاريخ الدائمة داخل
+  `DeviceConversationStore` مع الحفاظ على موضع ومعرّف رسالة التاريخ.
+- [x] إعادة المصالحة بعد استبدال التاريخ أو ضم صفحة أقدم أو أحدث حتى لا يعود
+  التكرار بعد navigation أو hydration لاحق.
+- [x] إضافة regression يعيد التحميل، ينتقل إلى محادثة أخرى، ثم يعود إلى نفس
+  المحادثة مع lifecycle بالحالة `delivered`.
+
+#### قبول G9
+
+- [x] Given history steer وpending-steer lifecycle لهما نفس `request_id`، when
+  تُحمّل المحادثة، then تظهر فقاعة مستخدم واحدة في موضعها السببي.
+- [x] Given lifecycle وصل إلى `delivered`، when يغادر المستخدم المحادثة ثم
+  يعود، then لا تظهر نسخة مؤقتة في نهاية السجل.
+- [x] Given pending أو delivering بلا رسالة تاريخ دائمة، then يظل projection
+  المؤقت الواحد متاحًا ويتحول بنفس الهوية عبر lifecycle الحي.
+
+**دليل G9:** نجح regression المركز الذي يعيد واقعة hydration والتنقل، ثم نجحت
+مجموعتا أوامر المحادثة وlifecycle (`76 passed`) مع الحفاظ على اختبارات pending
+والإلغاء القائمة. نجح Client analyzer بلا مشكلات ومجموعة Client الكاملة على
+الفرع النهائي المبني من `main` (`1224 passed`, `1 skipped`).
+طُبق hot restart بنجاح على Client المملوك لـWorktree 84، وبقي runtime مطابقًا
+لنفس المصدر والفرع، كما نجح `git diff --check` وتحديث Graphify.
 
 ## معايير القبول
 

--- a/docs/qa_maintenance/conversation_tool_groups_and_compact_window_qa.md
+++ b/docs/qa_maintenance/conversation_tool_groups_and_compact_window_qa.md
@@ -31,6 +31,10 @@ description: "Regression matrix for completed-tool grouping, nested and timeline
 | Diff metrics | Write/edit input and patch output | Added/removed totals match changed lines and animate on update |
 | Ask user | Running and completed states | Running timeline row is absent; completed Q/A has no generic header |
 | History race | Terminal live tool result arrives during stale running history request | Terminal status/output survives and merges with persisted input |
+| History result-first race | Terminal result is retained before hydration returns matching tool-use/result rows | One completed tool keeps the persisted input and renders only the unwrapped terminal output |
+| Older-page tool boundary | Current page starts with a terminal result and the matching tool-use is fetched from the older page | The fragments merge into one completed tool with input and output; neither fragment is discarded as a duplicate |
+| Terminal fallback | A completed `shell_execute` result is temporarily present without input | The terminal renderer unwraps the result envelope; generic `isError`/`output` JSON is never shown |
+| Delivered steer hydration | History contains a durable steer and `pending_steers` contains the same delivered `request_id`; leave the session and reopen it | One user bubble remains at the durable causal position before the post-steer answer; no duplicate is appended at the tail |
 | Group scroll | Open tall group, scroll away, append tools, return to bottom | Offset is preserved while opted out; follow resumes at bottom |
 | Timeline scroll | Send user row, then stream growth and delayed Activity layout; manually scroll away and return | Send restores eligibility; thinking, groups, and post-debounce Activity follow the outer timeline until manual outer-scroll opt-out |
 | Scroll isolation | Scroll inside an expanded tool/group while conversation follow is active | Inner controllers and follow state remain independent and never opt the outer conversation timeline in or out |

--- a/docs/technical/client_conversation_cache_schema.md
+++ b/docs/technical/client_conversation_cache_schema.md
@@ -137,14 +137,18 @@ independent opaque older/newer cursors and exhaustion state. Widgets receive
 only typed load intents and booleans; they never read or construct cursors.
 
 The initial tail replaces a partial timeline atomically. Older pages prepend by
-canonical identity; newer pages apply in chronological order so a terminal tool
-row can enrich its matching running tool even when the pair crosses a page
-boundary. Presentation reprojects the complete loaded slice after either merge;
-hidden reasoning rows do not split a visible tool run, while visible events and
-`system_ask_user` remain grouping boundaries. Each direction coalesces its matching in-flight cursor and advances
-only when the returned cursor differs from the requested one. Session/device
-switches and newer hydration generations reject late results. Failure leaves the
-visible timeline and runtime projections unchanged.
+canonical identity and merge duplicate identities rather than discarding an
+older event fragment. Hydration folds repeated canonical identities before it
+reconciles retained live state. Newer pages apply in chronological order so a
+terminal tool row can enrich its matching running tool even when the pair
+crosses a page boundary. The same rule preserves a tool-use input when its
+terminal result arrived first. Presentation reprojects the complete loaded slice
+after either merge; hidden reasoning rows do not split a visible tool run, while
+visible events and `system_ask_user` remain grouping boundaries. Each direction
+coalesces its matching in-flight cursor and advances only when the returned
+cursor differs from the requested one. Session/device switches and newer
+hydration generations reject late results. Failure leaves the visible timeline
+and runtime projections unchanged.
 
 At most two recently visited timelines that are exhausted in both directions
 may remain in memory. Reopening one reconciles the authoritative tail by event
@@ -220,8 +224,13 @@ that direction, and session activation resets both.
 messages and pending steers. Pending steers are keyed by the daemon's raw
 `request_id` and accept only increasing lifecycle revisions. The timeline
 renders `pending` as one temporary user bubble, transforms that same identity
-to delivered, and removes it only after authoritative cancellation. History,
-live events, navigation, and reconnect must not create duplicate bubbles.
+to delivered, and removes it only after authoritative cancellation. When
+history contains the durable steer with the same raw `request_id`, the store
+removes the temporary display id and enriches the durable event with lifecycle
+metadata without moving it from its causal position. This reconciliation runs
+after initial history replacement and older/newer page merges as well as live
+lifecycle delivery. History, live events, navigation, and reconnect must not
+create duplicate bubbles.
 
 This projection is deliberately separate from `ConversationCacheStore` draft
 ownership. A pending steer is not editable draft text and cannot be copied into


### PR DESCRIPTION
## Problem / Goal

Conversation history could render two incorrect projections after hydration:

- A completed Terminal result could appear as a generic raw JSON envelope or lose its matching command when tool fragments arrived across live/history or pagination boundaries.
- A delivered pending steer could appear twice after reopening a session because the durable history row and lifecycle projection used different display event ids despite sharing one raw request id.

This is a focused follow-up to #127. It does not close #84 because that repository item tracks unrelated work.

## Changes

- Fold canonical tool fragments before retained-history reconciliation and merge matching fragments across older-page boundaries.
- Route completed shell results through the Terminal renderer and unwrap the standard tool-result envelope.
- Reconcile pending-steer lifecycle projections with durable history rows by raw request id while preserving durable event identity and causal position.
- Re-run steer reconciliation after initial, older, and newer history hydration.
- Add regression coverage for result-first hydration, page-boundary tool pairs, Terminal fallback rendering, and delivered-steer navigation/reopen behavior.
- Update the owning task plan, technical cache contract, and QA matrix.

## Verification

- fvm flutter analyze — passed with no issues.
- fvm flutter test — 1224 passed, 1 skipped.
- Focused conversation command and lifecycle tests — 76 passed.
- git diff --check — passed.
- graphify update . — completed.
- Client hot restart on the Work Tree 84 runtime — completed successfully.

## Risk and cross-platform impact

Risk is limited to Flutter conversation timeline reconciliation and tool presentation. The change is platform-neutral and does not alter daemon persistence, transport schemas, authentication, release, or installer paths.

## Documentation

Updated the task plan, client conversation-cache schema, and conversation tool/history QA matrix.

## Rollback

Revert the squash commit. No schema migration or persisted-data rollback is required.
