### PR TITLE
revert(conversations): remove streaming markdown milestone keys

### DIFF
--- a/client/lib/features/conversations/presentation/widgets/app_markdown_renderer.dart
+++ b/client/lib/features/conversations/presentation/widgets/app_markdown_renderer.dart
@@ -9,9 +9,6 @@ import 'package:sanad_client/features/conversations/presentation/widgets/markdow
 class AppMarkdownRenderer extends StatelessWidget {
   final String data;
   final bool isFinal;
-  final bool isStreaming;
-  final String? contentId;
-  final Key? markdownKey;
   final void Function(String text, String? href, String title)? onTapLink;
   final Map<String, MarkdownElementBuilder>? builders;
 
@@ -19,28 +16,9 @@ class AppMarkdownRenderer extends StatelessWidget {
     super.key,
     required this.data,
     required this.isFinal,
-    this.isStreaming = false,
-    this.contentId,
-    this.markdownKey,
     this.onTapLink,
     this.builders,
   });
-
-  /// Computes a balanced milestone key for progressive streaming markdown
-  /// to ensure clean AST rendering on structural boundaries (lines, blocks, chunks)
-  /// while avoiding per-character element rebuild thrashing.
-  Key _resolveMarkdownBodyKey() {
-    if (markdownKey != null) {
-      return markdownKey!;
-    }
-    final prefix = contentId != null ? contentId! : 'markdown_body';
-    if (!isStreaming) {
-      return ValueKey('${prefix}_final');
-    }
-    final lineCount = data.split('\n').length;
-    final bucket = data.length ~/ 80;
-    return ValueKey('${prefix}_stream_${lineCount}_$bucket');
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -49,7 +27,6 @@ class AppMarkdownRenderer extends StatelessWidget {
       isFinal: isFinal,
     );
     return MarkdownBody(
-      key: _resolveMarkdownBodyKey(),
       data: data,
       styleSheet: markdownStyle,
       onTapLink: onTapLink,
@@ -57,4 +34,3 @@ class AppMarkdownRenderer extends StatelessWidget {
     );
   }
 }
-

--- a/client/lib/features/conversations/presentation/widgets/event_tile.dart
+++ b/client/lib/features/conversations/presentation/widgets/event_tile.dart
@@ -367,10 +367,8 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
           key: Key('primary_markdown_${widget.event.kind.name}'),
           width: double.infinity,
           child: AppMarkdownRenderer(
-            contentId: widget.event.id,
             data: widget.event.text,
             isFinal: true,
-            isStreaming: widget.event.status == EventStatus.running,
             onTapLink: _onTapLink,
           ),
         ),
@@ -621,10 +619,8 @@ class _EventTileState extends State<EventTile> with TickerProviderStateMixin {
         return Directionality(
           textDirection: TextUtils.getTextDirection(widget.event.text),
           child: AppMarkdownRenderer(
-            contentId: widget.event.id,
             data: widget.event.text,
             isFinal: false,
-            isStreaming: widget.event.status == EventStatus.running,
             onTapLink: _onTapLink,
           ),
         );

--- a/client/test/widget/reasoning_event_tile_test.dart
+++ b/client/test/widget/reasoning_event_tile_test.dart
@@ -77,67 +77,6 @@ void main() {
     },
   );
 
-  testWidgets(
-    'MarkdownBody key uses balanced milestone keys during streaming and stable final key on completion',
-    (tester) async {
-      // 1. Single line short running stream -> stream_1_0
-      await _pumpEvent(
-        tester,
-        _event(
-          kind: EventKind.thinking,
-          status: EventStatus.running,
-          text: 'thinking step 1',
-        ),
-      );
-      expect(
-        find.byKey(const ValueKey('event-1_stream_1_0')),
-        findsOneWidget,
-      );
-
-      // 2. Intra-word addition in same line & bucket does not thrash key
-      await _pumpEvent(
-        tester,
-        _event(
-          kind: EventKind.thinking,
-          status: EventStatus.running,
-          text: 'thinking step 1 with extra words',
-        ),
-      );
-      expect(
-        find.byKey(const ValueKey('event-1_stream_1_0')),
-        findsOneWidget,
-      );
-
-      // 3. Newline milestone advances stream key to rebuild AST cleanly
-      await _pumpEvent(
-        tester,
-        _event(
-          kind: EventKind.thinking,
-          status: EventStatus.running,
-          text: 'thinking step 1\nstep 2',
-        ),
-      );
-      expect(
-        find.byKey(const ValueKey('event-1_stream_2_0')),
-        findsOneWidget,
-      );
-
-      // 4. Completed event uses stable final key
-      await _pumpEvent(
-        tester,
-        _event(
-          kind: EventKind.finalAnswer,
-          status: EventStatus.done,
-          text: 'final answer content',
-        ),
-      );
-      expect(
-        find.byKey(const ValueKey('event-1_final')),
-        findsOneWidget,
-      );
-    },
-  );
-
   testWidgets('streaming thinking renders no header label or icon', (tester) async {
     await _pumpEvent(
       tester,

--- a/docs/technical/reasoning_thoughts_separation.md
+++ b/docs/technical/reasoning_thoughts_separation.md
@@ -138,7 +138,9 @@ reasoning streams are discarded.
 final-answer `MarkdownBody` renderer with the same complete
 `MarkdownStyleSheet`, link handling, and inline-code builder. The former
 progressive Markdown dependency has been removed, so conversation content has
-only one Markdown implementation. There is no content-length threshold and no
+only one Markdown implementation. `AppMarkdownRenderer` does not synthesize
+newline or content-length milestone keys; timeline identity remains owned by
+the surrounding canonical event tile. There is no content-length threshold and no
 separate card, disclosure, measurement probe, bounded viewport, or nested
 scrollbar for streaming text.
 Long content grows naturally inside the conversation timeline. Programming and


### PR DESCRIPTION
## Problem / Goal

Remove the streaming Markdown milestone-key behavior that remained on main after the earlier revert commits stayed on the old Task 84 branch. This is the follow-up recorded in #128 and its post-merge note.

## Changes

- Remove isStreaming, contentId, markdownKey, and the synthesized newline/content-length key from AppMarkdownRenderer.
- Remove the corresponding EventTile arguments.
- Remove the test that required milestone-key churn.
- Clarify in the owning Markdown rendering documentation that canonical timeline identity remains outside AppMarkdownRenderer.

## Verification

- fvm flutter analyze — passed with no issues.
- Focused Markdown and reasoning widget tests — 12 passed.
- fvm flutter test — 1223 passed, 1 skipped.
- git diff --check — passed.
- graphify update . — completed.

## Risk and cross-platform impact

The change is limited to Flutter Markdown widget identity and is platform-neutral. It does not revert the Terminal-result or pending-steer fixes merged in #128.

## Rollback

Revert this pull request to restore milestone-key behavior. No schema or persisted-data migration is involved.
