### PR TITLE
fix(release): keep preparation tests version-agnostic

### DIFF
--- a/agent/test/tool/release_preparation_test.dart
+++ b/agent/test/tool/release_preparation_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
@@ -20,6 +21,10 @@ const _releaseFiles = [
 
 void main() {
   late Directory fixture;
+  late String currentVersion;
+  late String nextVersion;
+  late int currentBuildNumber;
+  late int nextBuildNumber;
 
   setUp(() async {
     fixture = await Directory.systemTemp.createTemp(
@@ -32,6 +37,14 @@ void main() {
       await target.parent.create(recursive: true);
       await source.copy(target.path);
     }
+    final contract = jsonDecode(
+      File('${fixture.path}/release/release-contract.json').readAsStringSync(),
+    ) as Map<String, dynamic>;
+    currentVersion = contract['version'] as String;
+    currentBuildNumber = contract['build_number'] as int;
+    final parts = currentVersion.split('.').map(int.parse).toList();
+    nextVersion = '${parts[0]}.${parts[1]}.${parts[2] + 1}';
+    nextBuildNumber = currentBuildNumber + 1;
   });
 
   tearDown(() async {
@@ -48,25 +61,36 @@ void main() {
   test('updates every mechanical release identity surface', () async {
     final preparation = ReleasePreparation(fixture);
 
-    await preparation.prepare(version: '1.0.7', buildNumber: 8);
+    await preparation.prepare(
+      version: nextVersion,
+      buildNumber: nextBuildNumber,
+    );
 
-    expect(readFixture('agent/pubspec.yaml'), contains('version: 1.0.7'));
-    expect(readFixture('client/pubspec.yaml'), contains('version: 1.0.7+8'));
+    expect(
+      readFixture('agent/pubspec.yaml'),
+      contains('version: $nextVersion'),
+    );
+    expect(
+      readFixture('client/pubspec.yaml'),
+      contains('version: $nextVersion+$nextBuildNumber'),
+    );
     expect(
       readFixture('client/release/windows/sanad_client_installer.iss'),
-      contains('AppVersion=1.0.7'),
+      contains('AppVersion=$nextVersion'),
     );
     expect(
       readFixture('client/windows/runner/Runner.rc'),
-      contains('#define VERSION_AS_NUMBER 1,0,7,8'),
+      contains(
+        '#define VERSION_AS_NUMBER ${nextVersion.replaceAll('.', ',')},$nextBuildNumber',
+      ),
     );
     expect(
       readFixture('release/release-contract.json'),
-      contains('sanad-agent-1.0.7'),
+      contains('sanad-agent-$nextVersion'),
     );
     expect(
       readFixture('release/release-notes.md'),
-      startsWith('# Sanad 1.0.7'),
+      startsWith('# Sanad $nextVersion'),
     );
     expect(readFixture('agent/CHANGELOG.md'), contains('TODO'));
     expect(preparation.check, throwsFormatException);
@@ -86,11 +110,17 @@ void main() {
     final preparation = ReleasePreparation(fixture);
 
     expect(
-      () => preparation.prepare(version: '1.0.6', buildNumber: 8),
+      () => preparation.prepare(
+        version: currentVersion,
+        buildNumber: nextBuildNumber,
+      ),
       throwsFormatException,
     );
     expect(
-      () => preparation.prepare(version: '1.0.7', buildNumber: 7),
+      () => preparation.prepare(
+        version: nextVersion,
+        buildNumber: currentBuildNumber,
+      ),
       throwsFormatException,
     );
 
@@ -103,7 +133,7 @@ void main() {
     writeFixture(
       'client/windows/runner/Runner.rc',
       readFixture('client/windows/runner/Runner.rc').replaceFirst(
-        '#define VERSION_AS_STRING "1.0.6"',
+        '#define VERSION_AS_STRING "$currentVersion"',
         '#define VERSION_AS_STRING "stale"',
       ),
     );
@@ -111,7 +141,8 @@ void main() {
 
     expect(
       () =>
-          ReleasePreparation(fixture).prepare(version: '1.0.7', buildNumber: 8),
+          ReleasePreparation(fixture)
+              .prepare(version: nextVersion, buildNumber: nextBuildNumber),
       throwsFormatException,
     );
 
@@ -126,9 +157,8 @@ void main() {
 
     writeFixture(
       'client/release/windows/sanad_client_installer.iss',
-      readFixture(
-        'client/release/windows/sanad_client_installer.iss',
-      ).replaceFirst('AppVersion=1.0.6', 'AppVersion=0.0.0'),
+      readFixture('client/release/windows/sanad_client_installer.iss')
+          .replaceFirst('AppVersion=$currentVersion', 'AppVersion=0.0.0'),
     );
     expect(preparation.check, throwsFormatException);
   });

--- a/docs/qa_maintenance/release_verification.md
+++ b/docs/qa_maintenance/release_verification.md
@@ -59,8 +59,10 @@ update all package, lockfile, native Windows, release-contract, artifact-name,
 release-note identity, changelog-slot, and current-release documentation
 surfaces. `check-preparation` must then reject any stale surface or unfinished
 `TODO`. Focused tests copy the current 11-file release surface into an isolated
-temporary fixture and prove successful transformation, no mutation after
-prevalidation failure, and stale native/prose rejection.
+temporary fixture, derive the next patch and build from its current contract,
+and prove successful transformation, no mutation after prevalidation failure,
+and stale native/prose rejection. Tests must not pin the release identity that
+they are designed to advance.
 
 The protected-review exception is valid only for an exact metadata release PR.
 `scripts/release/verify_metadata_release_diff.sh` compares the PR merge range


### PR DESCRIPTION
## Problem / Goal

The newly merged release-preparation test pinned `1.0.6 -> 1.0.7`. Preparing v1.0.7 correctly updates the fixture source to 1.0.7, causing the release PR test to fail even though preparation is valid.

## Changes

- derive the current identity from the copied release contract
- derive the next patch and build dynamically
- use those identities in success, no-mutation, and stale-surface assertions
- document that release-advancement tests must not pin the identity they advance

## Verification

- `fvm dart test test/tool/release_preparation_test.dart` — 4 tests passed
- `fvm dart analyze` — no issues
- `git diff --check` — passed
- Graphify updated

## Risk / Rollback

Test-only behavior plus QA documentation. Revert this PR to restore the pinned fixture, although that would block every release after v1.0.6.
